### PR TITLE
Fix build when panel header is not in /usr/include

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,14 @@ PKG_CHECK_MODULES(
 		CFLAGS="${CFLAGS} ${PANEL_CFLAGS}"
 		LIBS="${LIBS} ${PANEL_LIBS}"
 	],
-	[AC_CHECK_LIB([panel], [main], ,[AC_MSG_ERROR([ncurses panel library not found])])]
+	[AC_CHECK_LIB([panel], [main], [
+		LIBS="-lpanel $LIBS"
+		AC_CHECK_HEADERS(panel.h,, [
+		    AC_CHECK_HEADERS(ncurses/panel.h, [
+			AC_DEFINE([PANEL_IN_SUBDIR], [ncurses/], [Look for ncurses headers in subdir])
+			], [AC_MSG_ERROR([ncurses panel headers not found])])
+		])
+	    ], [AC_MSG_ERROR([ncurses panel library not found])])]
 )
 
 PKG_CHECK_MODULES(

--- a/src/nwipe.h
+++ b/src/nwipe.h
@@ -65,12 +65,15 @@ extern int log_current_element;
 extern int log_elements_allocated;
 extern pthread_mutex_t mutex1;
 
-/* Ncurses headers. Assume panel.h is in same place.*/
+/* Ncurses headers. */
 #ifdef NCURSES_IN_SUBDIR
     #include <ncurses/ncurses.h>
-    #include <ncurses/panel.h>
 #else
     #include <ncurses.h>
+#endif
+#ifdef PANEL_IN_SUBDIR
+    #include <ncurses/panel.h>
+#else
     #include <panel.h>
 #endif
 


### PR DESCRIPTION
When there's no pkg-config file for the panel library, the build breaks
if the header is not in /usr/include.

At least in openSUSE, we have /usr/include/ncurses.h and
/usr/include/ncurses/panel.h.