### PR TITLE
Add "--nosignals" option to nwipe

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,1 +1,1 @@
-man_MANS = nwipe.1
+dist_man_MANS = nwipe.1

--- a/man/nwipe.1
+++ b/man/nwipe.1
@@ -40,6 +40,9 @@ Open devices in sync mode
 \fB\-\-nowait\fR
 Do not wait for a key before exiting (default is to wait).
 .TP
+\fB\-\-nosignals\fR
+Do not allow signals to interrupt a wipe (default is to allow).
+.TP
 \fB\-\-nogui\fR
 Do not show the GUI interface. Can only be used with the autonuke option.
 Nowait option is automatically invoked with the nogui option.

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -147,12 +147,14 @@ int main( int argc, char** argv )
                 nwipe_misc_thread_data.gui_thread = &nwipe_gui_thread;
         nwipe_thread_data_ptr.nwipe_misc_thread_data = &nwipe_misc_thread_data;
 
-        pthread_attr_t pthread_attr;
-        pthread_attr_init(&pthread_attr);
-        pthread_attr_setdetachstate(&pthread_attr, PTHREAD_CREATE_DETACHED);
+	if( !nwipe_options.nosignals )
+	{
+	  pthread_attr_t pthread_attr;
+	  pthread_attr_init(&pthread_attr);
+	  pthread_attr_setdetachstate(&pthread_attr, PTHREAD_CREATE_DETACHED);
 
-        pthread_create( &nwipe_sigint_thread, &pthread_attr, signal_hand, &nwipe_thread_data_ptr);
-
+	  pthread_create( &nwipe_sigint_thread, &pthread_attr, signal_hand, &nwipe_thread_data_ptr);
+	}
 
         /* A context struct for each device has already been created. */
         /* Now set specific nwipe options */

--- a/src/options.c
+++ b/src/options.c
@@ -81,6 +81,9 @@ int nwipe_options_parse( int argc, char** argv )
 		/* Whether to exit after wiping or wait for a keypress. */
 		{ "nowait", no_argument, 0, 0 },
 
+		/* Whether to allow signals to interrupt a wipe. */
+		{ "nosignals", no_argument, 0, 0 },
+
 		/* Whether to exit after wiping or wait for a keypress. */
 		{ "nogui", no_argument, 0, 0 },
 
@@ -114,6 +117,7 @@ int nwipe_options_parse( int argc, char** argv )
 	nwipe_options.rounds   = 1;
 	nwipe_options.noblank  = 0;
 	nwipe_options.nowait   = 0;
+	nwipe_options.nosignals= 0;
 	nwipe_options.nogui    = 0;
 	nwipe_options.sync     = 0;
 	nwipe_options.verify   = NWIPE_VERIFY_LAST;
@@ -148,6 +152,12 @@ int nwipe_options_parse( int argc, char** argv )
 				if( strcmp( nwipe_options_long[i].name, "nowait" ) == 0 )
 				{
 					nwipe_options.nowait = 1;
+					break;
+				}
+
+				if( strcmp( nwipe_options_long[i].name, "nosignals" ) == 0 )
+				{
+					nwipe_options.nosignals = 1;
 					break;
 				}
 
@@ -332,6 +342,11 @@ void nwipe_options_log( void )
 		nwipe_log( NWIPE_LOG_NOTICE, "  do not wait for a key before exiting" );
 	}
 
+	if( nwipe_options.nosignals )
+	{
+		nwipe_log( NWIPE_LOG_NOTICE, "  do not allow signals to interrupt a wipe" );
+	}
+
 	if( nwipe_options.nogui )
 	{
 		nwipe_log( NWIPE_LOG_NOTICE, "  do not show GUI interface" );
@@ -394,6 +409,7 @@ display_help()
   puts("  -r, --rounds=NUM        Number of times to wipe the device using the selected method (default: 1)" );
   puts("      --noblank           Do not blank disk after wipe (default is to complete a final blank pass)" );
   puts("      --nowait            Do not wait for a key before exiting (default is to wait)" );
+  puts("      --nosignals         Do not allow signals to interrupt a wipe (default is to allow)" );
   puts("      --nogui             Do not show the GUI interface. Automatically invokes the nowait option" );
   puts("                          Must be used with --autonuke option. Send SIGUSR1 to log current stats");
   puts("");

--- a/src/options.h
+++ b/src/options.h
@@ -49,6 +49,7 @@ typedef struct /* nwipe_options_t */
 	int            autonuke;  /* Do not prompt the user for confirmation when set.          */
 	int            noblank;   /* Do not perform a final blanking pass.                      */
         int            nowait;    /* Do not wait for a final key before exiting.                */
+        int            nosignals; /* Do not allow signals to interrupt a wipe.                  */
         int            nogui ;    /* Do not show the GUI.                                       */
 	char*          banner;    /* The product banner shown on the top line of the screen.    */
 //	nwipe_method_t method;    /* A function pointer to the wipe method that will be used.   */


### PR DESCRIPTION
Add "--nosignals" option to tell nwipe to ignore signals during a wipe.  Intended for use inside scripts where we don't want users to be able to kill a wipe partway through.