### PR TITLE
Pointer d undeclared

### DIFF
--- a/src/pass.c
+++ b/src/pass.c
@@ -285,7 +285,6 @@ int nwipe_random_pass( NWIPE_METHOD_SIGNATURE )
 		/* This is system insanity. */
 		nwipe_log( NWIPE_LOG_SANITY, "__FUNCTION__: lseek() returned a bogus offset on '%s'.", c->device_name );
 		free(b);
-		free(d);
 		return -1;
 	}
 


### PR DESCRIPTION
The statment free(d), should not be in nwipe_random_pass().