### PR TITLE
Fix uninitialized variable 'keystroke' in nwipe_gui_verify()

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -1124,7 +1124,7 @@ void nwipe_gui_verify( void )
 	nwipe_gui_title( footer_window, nwipe_buttons2 );
 	wrefresh( footer_window );
 
-	while( keystroke != ERR )
+	do
 	{
 		/* Clear the main window. */
 		werase( main_window );
@@ -1219,7 +1219,8 @@ void nwipe_gui_verify( void )
 
 		} /* switch */
 		
-	} /* while */
+	}
+	while( keystroke != ERR );
 
 } /* nwipe_gui_verify */
 


### PR DESCRIPTION
Fixes #58 - Issue was closed but patch hadn't been applied.