### PR TITLE
Fixes implicit declaration of function fileno()

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -18,6 +18,7 @@
  *
  */
 
+#define _POSIX_SOURCE
 
 #include "nwipe.h"
 #include "context.h"


### PR DESCRIPTION
Closes #60 
More tidying up of the code to clear up warnings, parser errors & cppcheck fails.

This patch fixes the following parser error
```
Implicit declaration of function 'fileno' is invalid in C99 [-Wimplicit-function-declaration]
```