### PR TITLE
Enhancement: Add exclude drive option

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -107,6 +107,18 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
 	/* Populate this struct, then assign it to overall array of structs. */
 	nwipe_context_t* next_device;
 	int fd;
+	int idx;
+
+	/* Check whether this drive is on the excluded drive list ? */
+	idx=0;
+	while ( idx < 10 )
+	{
+		if ( !strcmp( dev->path, nwipe_options.exclude[idx++] ))
+		{
+			nwipe_log( NWIPE_LOG_NOTICE, "Device %s excluded as per command line option -e", dev->path );
+			return 0;
+		}
+	}
 
 	/* Try opening the device to see if it's valid. Close on completion. */
 	if (!ped_device_open(dev))
@@ -149,7 +161,6 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
 	ioctl(fd, HDIO_GET_IDENTITY, &next_device->identity);
 	close( fd );
 
-    int idx;
     for (idx=0; idx<20; idx++) next_device->serial_no[idx]=next_device->identity.serial_no[idx];
     
     next_device->serial_no[20]=0;               /* terminate the string */

--- a/src/options.h
+++ b/src/options.h
@@ -36,6 +36,8 @@
 #define NWIPE_KNOB_SCSI                   "/proc/scsi/scsi"
 #define NWIPE_KNOB_SLEEP                  1
 #define NWIPE_KNOB_STAT                   "/proc/stat"
+#define MAX_NUMBER_EXCLUDED_DRIVES        10
+#define MAX_DRIVE_PATH_LENGTH             200 /* e.g. /dev/sda is only 8 characters long, so 200 should be plenty*/
 
 /* Function prototypes for loading options from the environment and command line. */
 int nwipe_options_parse( int argc, char** argv );
@@ -55,6 +57,7 @@ typedef struct /* nwipe_options_t */
 //	nwipe_method_t method;    /* A function pointer to the wipe method that will be used.   */
 	void*          method;    /* A function pointer to the wipe method that will be used.   */
 	char           logfile[FILENAME_MAX];   /* The filename to log the output to            */
+	char           exclude[MAX_NUMBER_EXCLUDED_DRIVES][MAX_DRIVE_PATH_LENGTH]; /* Drives excluded from the search */
 	nwipe_prng_t*  prng;      /* The pseudo random number generator implementation.         */
 	int            rounds;    /* The number of times that the wipe method should be called. */
 	int            sync;      /* A flag to indicate whether writes should be sync'd.        */


### PR DESCRIPTION
Closes #56

This patch adds a new command line option called '--exclude' or '-e'.

It's purpose is to allow a user to specifiy drives to be ignored by nwipe. By ignore, this means the drive will not be displayed in the GUI or if the autonuke option is specified, autonuke will not wipe the excluded drive/s.

For instance. If your main drive is /dev/sda you can specify on the command line
```
nwipe --exclude=/dev/sda
```
nwipe will not display /dev/sda in the GUI and therefore a user can not inadvertently select the wrong drive for wiping. This feature could be used in an environment where staff are wiping many drives on a system but you don't want the bootable drive wiped. In such a case nwipe could be called from a script such as
```
#!/bin/bash
nwipe --exclude=/dev/sda
```
Up to ten drives can be excluded, separated by commas, the syntax shown in the example below ..
```
nwipe --exclude=/dev/sda,/dev/sde,/dev/sdf
```

etc.