### PR TITLE
Common realloc mistake: nulled but not freed

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -42,6 +42,7 @@ void nwipe_log( nwipe_log_t level, const char* format, ... )
  *
  */
 
+	char **result;
 
 	/* A time buffer. */
 	time_t t;
@@ -58,7 +59,13 @@ void nwipe_log( nwipe_log_t level, const char* format, ... )
 	/* Increase the current log element pointer - we will write here */
 	if (log_current_element == log_elements_allocated) {
 		log_elements_allocated++;
-		log_lines = (char **) realloc (log_lines, (log_elements_allocated) * sizeof(char *));
+		result = realloc (log_lines, (log_elements_allocated) * sizeof(char *));
+		if ( result == NULL )
+		{
+			fprintf( stderr, "nwipe_log: realloc failed when adding a line.\n" );
+			return;
+		}
+		log_lines = result;
 		log_lines[log_current_element] = malloc(MAX_LOG_LINE_CHARS * sizeof(char));
 	}
 


### PR DESCRIPTION
In the function nwipe_log(), realloc is called each time a new log line is added. The problem being that a check is not performed on the realloc for NULL to determine whether the realloc actually worked. In the event realloc failed the original pointer would be lost, causing a memory leak. This patch fixes that problem by checking that realloc worked, before assigning the new pointer to log_lines. In the event realloc failed a error is printed to stderr and the function returns.

It also looks like, along with c1 & c2 not being freed, loglines and each malloc log line is also not freed on exit, I need to look further into those cases, however that will be for another pull request...