### PR TITLE
Malloc return status not checked in nwipe_log()

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -43,6 +43,7 @@ void nwipe_log( nwipe_log_t level, const char* format, ... )
  */
 
 	char **result;
+	char *malloc_result;
 
 	/* A time buffer. */
 	time_t t;
@@ -62,11 +63,20 @@ void nwipe_log( nwipe_log_t level, const char* format, ... )
 		result = realloc (log_lines, (log_elements_allocated) * sizeof(char *));
 		if ( result == NULL )
 		{
-			fprintf( stderr, "nwipe_log: realloc failed when adding a line.\n" );
+			fprintf( stderr, "nwipe_log: realloc failed when adding a log line.\n" );
+			pthread_mutex_unlock( &mutex1 );
 			return;
 		}
 		log_lines = result;
-		log_lines[log_current_element] = malloc(MAX_LOG_LINE_CHARS * sizeof(char));
+
+		malloc_result = malloc(MAX_LOG_LINE_CHARS * sizeof(char));
+		if (malloc_result == NULL)
+		{
+			fprintf( stderr, "nwipe_log: malloc failed when adding a log line.\n" );
+			pthread_mutex_unlock( &mutex1 );
+			return;
+		}
+		log_lines[log_current_element] = malloc_result;
 	}
 
 	/* Position of writing to current log string */


### PR DESCRIPTION
Malloc is used to allocate some memory for storing a log line, however it's return status is not checked prior to use. A consequence of this is that if malloc failed and returned a NULL pointer, the code would not recognise there was a problem and would attempt to write the log text to a NULL pointer resulting in a segmentation fault.

This patch fixes the problem by checking the malloc return status prior to use and if malloc should fail a error message is printed to stderr and the function returns.