### PR TITLE
Fix log message buffer overflow & reduce log memory requirements.

### DIFF
--- a/src/logging.h
+++ b/src/logging.h
@@ -22,6 +22,9 @@
 #ifndef LOGGING_H_
 #define LOGGING_H_
 
+/* Maximum size a log message can be */
+#define MAX_LOG_LINE_CHARS 512
+
 typedef enum nwipe_log_t_
 {
 	NWIPE_LOG_NONE = 0,


### PR DESCRIPTION
This patch fixes several issues with the message logging:

1. snprintf() and vsnprintf() functions are not checked for failure (< 0)

2. The return values of snprintf & vsnprintf were assumed to always return the actual number of chars written, which is not the case if the end of the buffer is reached. The return value will exceed the end of the buffer, e.g it returns the number of characters that would have been written if the end of the buffer had not been reached, not the actual number of characters written. Unfortunately the existing code was ignoring that and simply incrementing the pointer into the buffer pushing it past the end of the buffer. This results in a segmentation fault for log messages that are greater than the define MAX_LOG_LINE_CHARS 512.

3. The memory allocation for each log line was 512 bytes, irrespective of how long the log line actually was. Most are between 60-100 characters. This is a waste of memory and is particularly important for when nwipe will get its hot swap enhancement becauses the nwipe program may be running for weeks if not months when memory usage would be more important as the log grows ever larger.

All the above issues have been corrected by this patch. I have tested it by varying the actual buffer define to cause the log messages to reach the buffer limits and found that nwipe handles these potential overflows by trapping them, issuing a warning about the log message being truncated and then continuing on without any further issues. Much better than a random segfault that would have occured before.

Closes #75 