### PR TITLE
De-allocate memory used by the log functions

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -188,7 +188,7 @@ void nwipe_log( nwipe_log_t level, const char* format, ... )
 		}
 	}
 
-	/* Increase the current log element pointer - we will write here */
+	/* Increase the current log element pointer - we will write here, deallocation is done in cleanup() in nwipe.c */
 	if (log_current_element == log_elements_allocated) {
 		log_elements_allocated++;
 		result = realloc (log_lines, (log_elements_allocated) * sizeof(char *));
@@ -200,6 +200,7 @@ void nwipe_log( nwipe_log_t level, const char* format, ... )
 		}
 		log_lines = result;
 
+		/* Allocate memory for storing a single log message, deallocation is done in cleanup() in nwipe.c */
 		message_buffer_length = strlen( message_buffer ) * sizeof(char);
 		malloc_result = malloc((message_buffer_length + 1) * sizeof(char));
 		if (malloc_result == NULL)

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -102,6 +102,7 @@ int main( int argc, char** argv )
                 nwipe_enumerated = nwipe_device_get( &c1, argv, argc );
                 if ( nwipe_enumerated == 0 )
                 {
+                    cleanup();
                     exit(1);
                 }
 
@@ -210,6 +211,7 @@ int main( int argc, char** argv )
                 if( nwipe_options.nogui )
                 {
                         printf("--nogui option must be used with autonuke option\n"); 
+                        cleanup();
                         exit(1);
                 }
                 else
@@ -481,6 +483,8 @@ int main( int argc, char** argv )
                 printf("%s\n", log_lines[i]);
         }
 
+        cleanup();
+
         /* Success. */
         return 0;
 
@@ -604,8 +608,7 @@ void *signal_hand(void *ptr)
 
                                 printf("Program interrupted (caught signal %d)\n", sig); 
 
-                                // Cleanup
-                                // TODO: All other cleanup required
+                                cleanup();
 
                                 exit(0);
 
@@ -619,5 +622,20 @@ void *signal_hand(void *ptr)
 
 } /* end of signal_hand */
 
+int cleanup()
+{
+	/* Deallocate memory used by logging */
+	int idx;
+	for ( idx=0; idx < log_elements_allocated; idx++ )
+	{
+		free ( log_lines[idx] );
+	}
+	log_elements_allocated=0; /* zeroed just in case cleanup is called twice */
+	free ( log_lines );
+	
+	/* TODO: All other cleanup required */
+	
+	return 0;
+}
  
 /* eof */

--- a/src/nwipe.h
+++ b/src/nwipe.h
@@ -20,6 +20,9 @@
  *
  */
 
+/* Function prototypes */
+int cleanup();
+
 #ifndef NWIPE_H_
 #define NWIPE_H_
 


### PR DESCRIPTION
This patch deallocates both the multiple mallocs used for each log message and also the realloc memory that holds the pointers to those multiple log messages.

Confirmed as successfully deallocating the expected number of allocations using valgrind.

This leaves about 400 allocates that are not being deallocated, some of those being c1, c2 allocations. Those will be dealt with in a separate patch.