### PR TITLE
Put Function prototypes inside #ifndef/#define/#endif macro guard

### DIFF
--- a/src/nwipe.h
+++ b/src/nwipe.h
@@ -20,11 +20,12 @@
  *
  */
 
-/* Function prototypes */
-int cleanup();
 
 #ifndef NWIPE_H_
 #define NWIPE_H_
+
+/* Function prototypes */
+int cleanup();
 
 #ifndef _LARGEFILE64_SOURCE
 #define _LARGEFILE64_SOURCE


### PR DESCRIPTION
Put the function prototype inside the #ifndef/#define/#endif macro to guard against multiple header file inclusion. (and to get rid of the preprocessor warning).

My mistake, this didn't cause an issue, just flags a preprocessor warning.. so now one less warning with the prototype inside the nwipe.h multiple inclusion guard.