### PR TITLE
(void) unused variables in func.nwipe_isaac_read()

### DIFF
--- a/src/prng.c
+++ b/src/prng.c
@@ -149,6 +149,19 @@ int nwipe_isaac_init( NWIPE_PRNG_INIT_SIGNATURE )
 
 int nwipe_isaac_read( NWIPE_PRNG_READ_SIGNATURE )
 {
+	/* The purpose of this function is unclear, as it does not do anything except immediately return !
+	 * Because the variables in the macro NWIPE_PRNG_READ_SIGNATURE were then unused this throws
+	 * up a handful of compiler warnings, related to variables being unused. To stop the compiler warnings
+	 * I've simply put in a (void) var so that compiler sees the variable are supposed to be unused.
+	 * 
+	 * As this code works, I thought it best not to remove this function, just in case it servers
+	 * some purpose or is there for future use.
+	 */
+
+	(void) state;
+	(void) buffer;
+	(void) count;
+
 	return 0;
 }
 


### PR DESCRIPTION
The function nwipe_issac_read() has no content, just a return, hence the variables passed via the function call, specifically state, buffer and count are unused. The compiler generates a warning about unused variables in this function.

As I did not want to remove the function as there might be some reason it's there, maybe for some future code, or some other bit of code calls it even though it does nothing, I decided the safest thing to do is (void) the variables in the function to let the compiler know that it's ok. We're aware that they are unused.

This clears 5 warnings, 19 warnings remain out of 24.