### PR TITLE
(void) unused wy, to silence compiler warning

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -139,6 +139,7 @@ void nwipe_gui_title( WINDOW* w, const char* s )
 
 	/* The number of lines in the window. (Not used.) */
 	int wy;
+	(void) wy; /* flag wy not used to the compiler, to silence warning */
 
 	/* The number of columns in the window. */
 	int wx;


### PR DESCRIPTION
Unused variable 'wy' was causing a 'set but not used' compiler warning.

This patch applies the statement (void) wy; to let the compiler know that 'wy' is purposely unused and to silence the warning.