### PR TITLE
Use stdint.h, ncurses.h and panel.h instead of netinet/in.h

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -20,8 +20,7 @@
  *
  */
 
-/* Why is this needed? Segfaults without it */
-#include <netinet/in.h>
+#include <stdint.h>
 
 #include "nwipe.h"
 #include "context.h"

--- a/src/gui.c
+++ b/src/gui.c
@@ -29,8 +29,9 @@
  *   and things like ncurses libmenu are not worth the storage overhead.
  *
  */
-/* Why is this needed? Segfaults without it */
-#include <netinet/in.h>
+#include <ncurses.h>
+#include <panel.h>
+#include <stdint.h>
 
 #include "nwipe.h"
 #include "context.h"

--- a/src/method.c
+++ b/src/method.c
@@ -38,8 +38,7 @@
  *
  */
 
-/* Why is this needed? Segfaults without it */
-#include <netinet/in.h>
+#include <stdint.h>
 
 #include "nwipe.h"
 #include "context.h"

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -22,7 +22,7 @@
  */
 #define _POSIX_SOURCE
 
-#include <netinet/in.h>
+#include <stdint.h>
 #include <time.h>
 #include <signal.h>
 #include <pthread.h>

--- a/src/pass.c
+++ b/src/pass.c
@@ -20,9 +20,8 @@
  *
  */
 
-/* Why is this needed? Segfaults without it */
-#include <netinet/in.h>
 
+#include <stdint.h>
 #include "nwipe.h"
 #include "context.h"
 #include "method.h"


### PR DESCRIPTION
Removal of the `#include "netinet/in.h"` statements from a number of the source files, did not appear to cause any problems on ubuntu 64 bit, however on ubuntu 32 bit it would cause issues with missing device name, missing drive information related to the GUI display.

This was because the gui.c source should have included ncurses.h, panel.h and most importantly stdint.h Including those headers in gui.c and removing netinet/in.h fixed all the display problems. (netinet/in.h includes stdint.h, hence why netinet/in.h appeared to work).

For other files that included netinet/in.h it was only necessary to replace with stdint.h

Tested on both 32 bit & 64 bit systems.

 