### PR TITLE
Remove a Fedora workaround in nwipe.h

### DIFF
--- a/src/nwipe.h
+++ b/src/nwipe.h
@@ -35,11 +35,6 @@ int cleanup();
 #define _FILE_OFFSET_BITS 64
 #endif
 
-/* workaround for Fedora */
-#ifndef off64_t
-# define off64_t off_t
-#endif
-
 /* Busybox headers. */
 #ifdef BB_VER
 #include "busybox.h"


### PR DESCRIPTION
As discussed in #85 this causes a compiler error on 32 bit ubuntu systems only, basically because it is no longer required. The system headers handle this.

closes #85 