### PR TITLE
Fix segfault on immediate CNTRL-C exit, shows in Fedora32 bit

### DIFF
--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -590,7 +590,7 @@ void *signal_hand(void *ptr)
                                 // Kill the GUI thread
                                 if( !nwipe_options.nogui )
                                 {
-                                        if ( nwipe_misc_thread_data->gui_thread )
+                                        if ( *nwipe_misc_thread_data->gui_thread )
                                         {
                                                 pthread_cancel( *nwipe_misc_thread_data->gui_thread );
                                                 *nwipe_misc_thread_data->gui_thread = 0;


### PR DESCRIPTION
This fixes another segfault. The segfault was caused because instead of checking whether the GUI thread was '0' and therefore NOT calling the pthread_cancel function, (because the thread was already cancelled) the if statement was actually checking the pointer to the thread pointer, so trying to cancel with a NULL pointer which causes a segfault.

If the GUI thread was still running, then the segfault wouldn't occur. As there is more than one way the GUI thread terminates in nwipe, I guess that's why this segfault didn't show on some systems and not others, perhaps because of a race condition.

Anyway, now fixed.
Fixes #88