### PR TITLE
Update Fedora workaround

### DIFF
--- a/src/nwipe.h
+++ b/src/nwipe.h
@@ -37,7 +37,11 @@ int cleanup();
 
 /* workaround for Fedora */
 #ifndef off64_t
-# define off64_t off_t
+#ifndef off_t
+#define off64_t int64_t
+#else
+#define off64_t off_t
+#endif
 #endif
 
 /* Busybox headers. */


### PR DESCRIPTION
Originally this Fedora workaround was stopping ubuntu 32 bit (16.04LTS) from compiling. Removing the workaround got ubuntu compiling ok, but then without the workaround Fedora 32bit wouldn't compile.

The update to the Fedora workaround fixes this in the define (without changing any other code). So now Fedora 32bit, Ubuntu 32bit and Ubuntu 64bit now all compile without any issues.