### PR TITLE
Update Readme with package requirements

### DIFF
--- a/README
+++ b/README
@@ -1,12 +1,59 @@
-Installation
-============
-First bootstrap the source tree:
+Compiling & Installing
+======================
+
+Nwipe requires the following libraries to be installed.
+
+ncurses
+pthreads
+parted
+
+Debian & Ubuntu prerequisite
+============================
+
+If you compiling nwipe from source the following will need to be installed first
+
+sudo apt install build-essential
+sudo apt install pkg-config
+sudo apt install automake
+sudo apt install libncurses5-dev
+sudo apt install autotools-dev
+sudo apt install libparted-dev
+
+Compilation
+===========
+
+then create all the autoconf files:
+
 ./init.sh
 
-The install using the standard:
+Then compile & install using the standard: (Devs see below)
+
 ./configure
 make
 make install
+
+Developers !
+==========
+
+If you wish to submit pull requests to this code we would prefer you enable all warnings,
+this can be done using the alternate compile commands
+
+./configure --prefix=/usr CFLAGS='-O0 -g -Wall -Wextra'
+make
+make install
+
+The '-O0 -g' flags disable optimisations, this is required if your debugging with
+gdb in an IDE such as Kdevelop. Without these optimisations disabled you won't be
+able to see the values of many variables in nwipe, not to mention the IDE won't step
+through the code properly.
+
+The -Wall & -Wextra flags enable all compiler warnings. Please submit code with zero warnings.
+
+Once done with your coding then the released/patch/fixed code can be compiled with
+
+./configure --prefix=/usr && make && make install
+
+complete with all it's optimisations.
 
 The ncurses, pthreads and parted libraries are required for compiling.
 For any problems, please use the Github page:

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ To use from the git repository, first create all the autoconf files with
 
 Then do the standard ./configure --prefix=/usr && make && make install
 
-For release notes please see the [README file](README)
+For developer & release notes please see the [README file](README)
 


### PR DESCRIPTION
This patch adds details of the packages that need to be installed prior to compiling nwipe.

These are basically the things I had to figure out when I first started coding on nwipe on the ubuntu platform. Hopefully it will make things easier for those that want to compile from source. Different distros could be added in the future. For instance I wasn't familiar with the Fedora way of doing things so had to figure that out too.

It also adds some info for developers about how to compile with warnings enabled and switches required if debugging with gdb.