### PR TITLE
Add details of exclude drive option to man page

### DIFF
--- a/man/nwipe.1
+++ b/man/nwipe.1
@@ -77,6 +77,11 @@ PRNG option (mersenne|twister|isaac)
 .TP
 \fB\-r\fR, \fB\-\-rounds\fR=\fINUM\fR
 Number of times to wipe the device using the selected method (default: 1)
+.TP
+\fB\-e\fR, \fB\-\-exclude\fR=\fIDEVICES\fR
+Up to ten comma separated devices to be excluded, examples:
+ --exclude=/dev/sdc
+ --exclude=/dev/sdc,/dev/sdd
 .SH BUGS
 Please see the GitHub site for the latest list
 (https://github.com/martijnvanbrummelen/nwipe/issues)


### PR DESCRIPTION
Adds the details of the exclude drive option to the man page:

![Screenshot_20190910_224915](https://user-images.githubusercontent.com/22084881/64653102-709d2e00-d41d-11e9-8604-fe2a77f83a4d.png)
