### PR TITLE
Sync changes

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -111,7 +111,6 @@ typedef struct nwipe_context_t_
 	int               signal;           /* Set when the child is killed by a signal.                      */
 	nwipe_speedring_t speedring;        /* Ring buffer for computing the rolling throughput average.      */
 	short             sync_status;      /* A flag to indicate when the method is syncing.                 */
-	int               sync_rate;        
 	pthread_t         thread;           /* The ID of the thread.                                          */
 	u64               throughput;       /* Average throughput in bytes per second.                        */
 	u64               verify_errors;    /* The number of verification errors across all passes.           */

--- a/src/context.h
+++ b/src/context.h
@@ -111,6 +111,7 @@ typedef struct nwipe_context_t_
 	int               signal;           /* Set when the child is killed by a signal.                      */
 	nwipe_speedring_t speedring;        /* Ring buffer for computing the rolling throughput average.      */
 	short             sync_status;      /* A flag to indicate when the method is syncing.                 */
+	int               sync_rate;        
 	pthread_t         thread;           /* The ID of the thread.                                          */
 	u64               throughput;       /* Average throughput in bytes per second.                        */
 	u64               verify_errors;    /* The number of verification errors across all passes.           */

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -309,19 +309,8 @@ int main( int argc, char** argv )
 
                         if( ioctl( c2[i]->device_fd, BLKBSZGET, &c2[i]->block_size ) == 0 )
                         {
-                                if( c2[i]->block_size != c2[i]->sector_size )
-                                {
-                                        nwipe_log( NWIPE_LOG_WARNING, "Changing '%s' block size from %i to %i.", c2[i]->device_name, c2[i]->block_size, c2[i]->sector_size );
-                                        if( ioctl( c2[i]->device_fd, BLKBSZSET, &c2[i]->sector_size ) == 0 )
-                                        {
-                                                c2[i]->block_size = c2[i]->sector_size;
-                                        }
-
-                                        else
-                                        {
-                                                nwipe_log( NWIPE_LOG_WARNING, "Device '%s' failed BLKBSZSET ioctl.", c2[i]->device_name );
-                                        }
-                                }
+                                nwipe_log( NWIPE_LOG_INFO, "Device '%s' has block size %i.", c2[i]->device_name,  c2[i]->block_size );
+                                
                         }
                         else
                         {

--- a/src/options.c
+++ b/src/options.c
@@ -111,7 +111,7 @@ int nwipe_options_parse( int argc, char** argv )
 	nwipe_options.nowait    = 0;
 	nwipe_options.nosignals = 0;
 	nwipe_options.nogui     = 0;
-	nwipe_options.sync      = 0;
+	nwipe_options.sync      = 100000;
 	nwipe_options.verify    = NWIPE_VERIFY_LAST;
 	memset( nwipe_options.logfile, '\0', sizeof( nwipe_options.logfile ) );
 

--- a/src/options.c
+++ b/src/options.c
@@ -93,7 +93,7 @@ int nwipe_options_parse( int argc, char** argv )
 		{ "nogui", no_argument, 0, 0 },
 
 		/* A flag to indicate whether the devices whould be opened in sync mode. */
-		{ "sync", no_argument, 0, 0 },
+		{ "sync", required_argument, 0, 0 },
 
 		/* Verify that wipe patterns are being written to the device. */
 		{ "verify", required_argument, 0, 0 },
@@ -171,7 +171,13 @@ int nwipe_options_parse( int argc, char** argv )
 
 				if( strcmp( nwipe_options_long[i].name, "sync" ) == 0 )
 				{
-					nwipe_options.sync = 1;
+					if( sscanf( optarg, " %i", &nwipe_options.sync ) != 1 \
+				      || nwipe_options.sync < 1
+				    )
+					{
+				  	fprintf( stderr, "Error: The sync argument must be a positive integer.\n" );
+				  	exit( EINVAL );
+					}
 					break;
 				}
 
@@ -433,7 +439,10 @@ display_help()
   puts("      --autonuke          If no devices have been specified on the command line, starts wiping all");
   puts("                          devices immediately. If devices have been specified, starts wiping only");
   puts("                          those specified devices immediately.");
-  puts("      --sync              Open devices in sync mode");
+  puts("      --sync=NUM          Will preform a sync after NUM writes (default: 0)");
+  puts("                          0 - fdatasync after the disk is completely written");
+  puts("                          1 - fdatasync after every write");
+  puts("                          1000000 - fdatasync after 1000000 writes ect.");
   puts("      --verify=TYPE       Whether to perform verification of erasure (default: last)");
   puts("                          off   - Do not verify");
   puts("                          last  - Verify after the last pass");

--- a/src/options.h
+++ b/src/options.h
@@ -60,7 +60,7 @@ typedef struct /* nwipe_options_t */
 	char           exclude[MAX_NUMBER_EXCLUDED_DRIVES][MAX_DRIVE_PATH_LENGTH]; /* Drives excluded from the search */
 	nwipe_prng_t*  prng;      /* The pseudo random number generator implementation.         */
 	int            rounds;    /* The number of times that the wipe method should be called. */
-	int            sync;      /* A flag to indicate whether writes should be sync'd.        */
+	int            sync;      /* A flag to indicate whether and how often writes should be sync'd. */
 	nwipe_verify_t verify;    /* A flag to indicate whether writes should be verified.      */
 } nwipe_options_t;
 


### PR DESCRIPTION
This fixes [issue 104](https://github.com/martijnvanbrummelen/nwipe/issues/104), [issue 103](https://github.com/martijnvanbrummelen/nwipe/issues/103), and [issue 96](https://github.com/martijnvanbrummelen/nwipe/issues/96).

I changed the unused sync option to enable periodic fdatasyncs during the writes in pass.c.
I stopped nwipe from changing the blocksize, not sure if this should be an option or not.