### PR TITLE
Fix typos in README and comments.

### DIFF
--- a/README
+++ b/README
@@ -10,7 +10,7 @@ parted
 Debian & Ubuntu prerequisites
 ============================
 
-If you compiling nwipe from source the following will need to be installed first
+If you are compiling nwipe from source the following will need to be installed first
 
 sudo apt install build-essential
 sudo apt install pkg-config
@@ -52,7 +52,7 @@ this can be done using the alternate compile commands
 make
 make install
 
-The '-O0 -g' flags disable optimisations, this is required if your debugging with
+The '-O0 -g' flags disable optimisations, this is required if you're debugging with
 gdb in an IDE such as Kdevelop. Without these optimisations disabled you won't be
 able to see the values of many variables in nwipe, not to mention the IDE won't step
 through the code properly.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@ allow its use with any host distribution, thus giving better hardware
 support.
 
 To use from the git repository, first create all the autoconf files with
-./init.sh
+`./init.sh`
 
-Then do the standard ./configure --prefix=/usr && make && make install
+Then do the standard `./configure --prefix=/usr && make && make install`
 
-For developer & release notes please see the [README file](README)
-
+For developers & release notes please see the [README file](README)

--- a/src/device.c
+++ b/src/device.c
@@ -44,7 +44,7 @@ char *trim(char *str);
 int nwipe_device_scan( nwipe_context_t*** c )
 {
 	/**
-	 * Scans the the filesystem for storage device names.
+	 * Scans the filesystem for storage device names.
 	 *
 	 * @parameter device_names  A reference to a null array pointer.
 	 * @modifies  device_names  Populates device_names with an array of nwipe_contect_t

--- a/src/options.c
+++ b/src/options.c
@@ -280,7 +280,7 @@ int nwipe_options_parse( int argc, char** argv )
 
 				break;
 
-			case 'V':  /* Rounds option. */
+			case 'V':  /* Version option. */
 
 				printf ( "%s version %s\n", program_name, version_string );
 				exit( EXIT_SUCCESS );


### PR DESCRIPTION
Also added some formatting on the code found in the `README.md` file.
@martijnvanbrummelen can you :eyes: please :smiley: 

Also, is there a reason why there's 2 README files?