### PR TITLE
Fix AutoConf deprecated warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,8 +2,8 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.64])
-AC_INIT(nwipe, 0.26, git@brumit.nl)
-AM_INIT_AUTOMAKE(nwipe, 0.26)
+AC_INIT([nwipe], [0.26], [git@brumit.nl])
+AM_INIT_AUTOMAKE
 AC_OUTPUT(Makefile src/Makefile man/Makefile)
 AC_CONFIG_SRCDIR([src/nwipe.c])
 AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
This fixes the following AC warning:
```
configure.ac:6: warning: AM_INIT_AUTOMAKE: two- and three-arguments forms are deprecated.  For more info, see:
configure.ac:6: https://www.gnu.org/software/automake/manual/automake.html#Modernize-AM_005fINIT_005fAUTOMAKE-invocation
```

As per the deprecation notice, using `AM_INIT_AUTOMAKE` for setting the
version is mostly obsolete because the package and version can be obtained
from Autoconf’s `AC_INIT` macro.