### PR TITLE
Fix drive parsing and success status

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -151,6 +151,7 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
 	next_device->device_name = dev->path;
 	next_device->device_size = dev->length * dev->sector_size;
 	next_device->device_size_text = ped_unit_format_byte(dev, dev->length * dev->sector_size);
+   next_device->result = -2;
 	/* Attempt to get serial number of device. */
 	if ( (fd = open ( next_device->device_name = dev->path, O_RDONLY)) == ERR )
 	{

--- a/src/device.c
+++ b/src/device.c
@@ -90,7 +90,10 @@ int nwipe_device_get( nwipe_context_t*** c, char **devnamelist, int ndevnames )
 
 		dev = ped_device_get(devnamelist[i]);
 		if (!dev)
-			break;
+      {
+         nwipe_log( NWIPE_LOG_WARNING, "Device %s not found", devnamelist[i] );
+			continue;
+      }
 
 		if (check_device(c, dev, dcount))
 			dcount++;

--- a/src/gui.c
+++ b/src/gui.c
@@ -1839,9 +1839,9 @@ void *nwipe_gui_status( void *ptr )
 
 				else
 				{
-					if( c[i]->result == 0 ) { mvwprintw( main_window, yy++, 4, "(success) " );                         }
-					else if( c[i]->signal ) { mvwprintw( main_window, yy++, 4, "(failure, signal %i) ", c[i]->signal ); }
-					else                   { mvwprintw( main_window, yy++, 4, "(failure, code %i) ", c[i]->result );   }
+					if( c[i]->result == 0 ) { mvwprintw( main_window, yy++, 4, "(SUCCESS!) " );                         }
+					else if( c[i]->signal ) { mvwprintw( main_window, yy++, 4, "(>>> FAILURE! <<<, signal %i) ", c[i]->signal ); }
+					else                   { mvwprintw( main_window, yy++, 4, "(>>>FAILURE!<<<, code %i) ", c[i]->result );   }
 
 				} /* child returned */
 

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -565,8 +565,8 @@ void *signal_hand(void *ptr)
                                         else
                                         {
                                                 if( c[i]->result == 0 ) { nwipe_log( NWIPE_LOG_INFO, "%s: Success", c[i]->device_name ); }
-                                                else if( c[i]->signal ) { nwipe_log( NWIPE_LOG_INFO, "%s: Failure: signal %i", c[i]->device_name, c[i]->signal ); }
-                                                else                    { nwipe_log( NWIPE_LOG_INFO, "%s: Failure: code %i", c[i]->device_name, c[i]->result ); }
+                                                else if( c[i]->signal ) { nwipe_log( NWIPE_LOG_INFO, "%s: >>> FAILURE! <<<: signal %i", c[i]->device_name, c[i]->signal ); }
+                                                else                    { nwipe_log( NWIPE_LOG_INFO, "%s: >>> FAILURE! <<<: code %i", c[i]->device_name, c[i]->result ); }
                                         }
                                 }
 


### PR DESCRIPTION
Commit "Have nwipe continue with following devices even if one fails:
When using a command such as
>nwipe --verify=last -m zero -r 1 --autonuke --nowait /dev/sda /dev/sdb /dev/sdx /dev/sde /dev/sdf
If one of the drives is not accessible all the remaining drives don't get wiped. Fixed by this commit.

Commit "Fix wip status saying Success when it never even started"
If a drive is enumerated but then fails before the wipe has started, prior to this fix the status in the GUI would say Success. This patch corrects this status message to >>>FAILURE!<<< code -2 under such conditions.