### PR TITLE
Fix order of include files in options.c

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -20,12 +20,12 @@
  *
  */
 
-#include "options.h"
-#include "context.h"
-#include "logging.h"
-#include "method.h"
 #include "nwipe.h"
+#include "context.h"
+#include "method.h"
 #include "prng.h"
+#include "options.h"
+#include "logging.h"
 #include "version.h"
 
 /* The global options struct. */


### PR DESCRIPTION
After running clang on options.c the includes were reordered. This caused the compilation to fail with multiple errors.