### PR TITLE
Do not sort includes on clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -62,7 +62,7 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
 ReflowComments:  true
-SortIncludes:    true
+SortIncludes:    false
 SpaceAfterCStyleCast: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: Never


### PR DESCRIPTION
@PartialVolume that will disable the includes reordering.