### PR TITLE
Add notification of cache flush on CNTRL-C exit

### DIFF
--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -575,6 +575,7 @@ void *signal_hand(void *ptr)
                                         if ( c[i]->thread )
                                         {
                                                 nwipe_log( NWIPE_LOG_INFO, "Cancelling thread for %s", c[i]->device_name );
+                                                nwipe_log( NWIPE_LOG_INFO, "Please be patient.. disk cache is being flushed" );
                                                 pthread_cancel( c[i]->thread );
                                         }
                                 }


### PR DESCRIPTION
When aborting a wipe with CNTRL-C, wipe thread cancellation is requested, however the threads won't cancel until the disk cache has been flushed. This p.r. notifies the user via a command line message to please wait as the disk cache is being flushed. How long this takes depends on how long it has been since the last flush, how large the cache is, which is dependant upon how much memory is in the system. In practise this may be from a few seconds to in excess of 30 seconds.