### PR TITLE
Fix segfault on Control-C, after a successful wipe

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -114,6 +114,7 @@ typedef struct nwipe_context_t_
 	pthread_t         thread;           /* The ID of the thread.                                          */
 	u64               throughput;       /* Average throughput in bytes per second.                        */
 	u64               verify_errors;    /* The number of verification errors across all passes.           */
+	int               wipe_status;      /* Wipe finished = 0, wipe in progress = 1, wipe yet to start = -1*/
     char              serial_no[21];    /* Serial number(processed), 20 characters, plus null termination */
 	struct hd_driveid  identity;	    /* Identity contains the raw serial number of the drive           */
                                         /* (where applicable), however, for use within nwipe use the      */

--- a/src/gui.c
+++ b/src/gui.c
@@ -1829,7 +1829,8 @@ void *nwipe_gui_status( void *ptr )
 				}
 
 				/* Check whether the child process is still running the wipe. */
-				if( c[i]->thread > 0 )
+				//if( c[i]->thread > 0 )
+				if( c[i]->wipe_status == 1 )
 				{
 					/* Print percentage and pass information. */
 					mvwprintw( main_window, yy++, 4, "[%05.2f%%, round %i of %i, pass %i of %i] ", \
@@ -2050,7 +2051,8 @@ int compute_stats(void *ptr)
 	for( i = 0 ; i < count ; i++ )
 	{
 		/* Check whether the child process is still running the wipe. */
-		if( c[i]->thread > 0 )
+//		if( c[i]->thread > 0 )
+		if( c[i]->wipe_status == 1 )
 		{
 			/* Increment the child counter. */
 			nwipe_active += 1;

--- a/src/method.c
+++ b/src/method.c
@@ -97,6 +97,9 @@ void *nwipe_zero( void *ptr )
 
  	nwipe_context_t *c;
  	c = (nwipe_context_t *) ptr;
+   
+	/* set wipe in progress flag for GUI */
+	c->wipe_status = 1;
 
 	/* Do nothing because nwipe_runmethod appends a zero-fill. */
 	nwipe_pattern_t patterns [] =
@@ -107,8 +110,8 @@ void *nwipe_zero( void *ptr )
 	/* Run the method. */
 	c->result = nwipe_runmethod( c, patterns );
 
-	/* Finished. Set the thread ID to 0 so that the GUI knows */
-	c->thread = 0;
+	/* Finished. Set the wipe_status flag so that the GUI knows */
+	c->wipe_status = 0;
 
     return NULL;
 } /* nwipe_zero */
@@ -124,6 +127,9 @@ void *nwipe_dod522022m( void *ptr )
 
         nwipe_context_t *c;
         c = (nwipe_context_t *) ptr;
+        
+	/* set wipe in progress flag for GUI */
+	c->wipe_status = 1;
 
 	/* A result holder. */
 	int r;
@@ -170,8 +176,8 @@ void *nwipe_dod522022m( void *ptr )
 	/* Run the DoD 5220.22-M method. */
 	c->result = nwipe_runmethod( c, patterns );
 
-	/* Finished. Set the thread ID to 0 so that the GUI knows */
-	c->thread = 0;
+	/* Finished. Set the wipe_status flag so that the GUI knows */
+	c->wipe_status = 0;
 
     return NULL;
 } /* nwipe_dod522022m */
@@ -188,6 +194,9 @@ void *nwipe_dodshort( void *ptr )
 
         nwipe_context_t *c;
 	c = (nwipe_context_t *) ptr;
+   
+	/* set wipe in progress flag for GUI */
+	c->wipe_status = 1;
                 
 	/* A result holder. */
 	int r;
@@ -227,8 +236,8 @@ void *nwipe_dodshort( void *ptr )
 	/* Run the DoD 5220.022-M short method. */
 	c->result = nwipe_runmethod( c, patterns );
 
-	/* Finished. Set the thread ID to 0 so that the GUI knows */
-	c->thread = 0;
+	/* Finished. Set the wipe_status flag so that the GUI knows */
+	c->wipe_status = 0;
 
     return NULL;
 } /* nwipe_dodshort */
@@ -244,6 +253,9 @@ void *nwipe_gutmann( void *ptr )
 
         nwipe_context_t *c;
 	c = (nwipe_context_t *) ptr;
+
+	/* set wipe in progress flag for GUI */
+	c->wipe_status = 1;
                 
 	/* A result buffer. */
 	int r;
@@ -353,9 +365,8 @@ void *nwipe_gutmann( void *ptr )
 	/* Run the Gutmann method. */
 	c->result = nwipe_runmethod( c, patterns );
 
-
-	/* Finished. Set the thread ID to 0 so that the GUI knows */
-	c->thread = 0;
+	/* Finished. Set the wipe_status flag so that the GUI knows */
+	c->wipe_status = 0;
 
     return NULL;
 } /* nwipe_gutmann */
@@ -375,6 +386,9 @@ void *nwipe_ops2( void *ptr )
 
         nwipe_context_t *c;
         c = (nwipe_context_t *) ptr;
+        
+	/* set wipe in progress flag for GUI */
+	c->wipe_status = 1;
 
 	/* A generic array index. */
 	int i;
@@ -522,9 +536,8 @@ void *nwipe_ops2( void *ptr )
 	/* We're done. */
 	c->result = nwipe_runmethod( c, patterns );
 
-
-	/* Finished. Set the thread ID to 0 so that the GUI knows */
-	c->thread = 0;
+	/* Finished. Set the wipe_status flag so that the GUI knows */
+	c->wipe_status = 0;
 
     return NULL;
 } /* nwipe_ops2 */
@@ -540,6 +553,9 @@ void *nwipe_random( void *ptr )
 
         nwipe_context_t *c;
 	c = (nwipe_context_t *) ptr;
+
+	/* set wipe in progress flag for GUI */
+	c->wipe_status = 1;
 	
 	/* Define the random method. */
 	nwipe_pattern_t patterns [] =
@@ -551,9 +567,8 @@ void *nwipe_random( void *ptr )
 	/* Run the method. */
 	c->result = nwipe_runmethod( c, patterns );
 
-
-	/* Finished. Set the thread ID to 0 so that the GUI knows */
-	c->thread = 0;
+	/* Finished. Set the wipe_status flag so that the GUI knows */
+	c->wipe_status = 0;
 
     return NULL;
 } /* nwipe_random */

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -254,6 +254,9 @@ int main( int argc, char** argv )
 
                 /* A result buffer for the BLKGETSIZE64 ioctl. */
                 u64 size64;
+                
+                /* Initialise the wipe_status flag, -1 = wipe not yet started */
+                c2[i]->wipe_status = -1;
 
                 /* Open the file for reads and writes. */
                 c2[i]->device_fd = open( c2[i]->device_name, O_RDWR );
@@ -417,14 +420,44 @@ int main( int argc, char** argv )
                 errno = pthread_create( &nwipe_gui_thread, NULL, nwipe_gui_status, &nwipe_gui_data);
         }
 
+        /* Wait for all the wiping threads to finish. */
+        i = 0;
+        while( i < nwipe_selected )
+        {
+            if( i == nwipe_selected )
+            {
+               break;
+            }
 
-        /* Wait for all the wiping threads to finish. */        
+            if ( c2[i]->wipe_status != 0 )
+            {
+               i = 0;
+            }
+            else
+            {
+               i++;
+               continue;
+            }
+            sleep( 2 ); /* DO NOT REMOVE ! Stops the routine hogging CPU cycles */
+        }
+           
+        /* Now cancel the wipe threads */
         for( i = 0 ; i < nwipe_selected ; i++ )
         {
 
                 if ( c2[i]->thread )
                 {
-                        pthread_join( c2[i]->thread, NULL);
+                        nwipe_log( NWIPE_LOG_INFO, "main():Cancelling wipe thread for %s", c2[i]->device_name );
+                        nwipe_log( NWIPE_LOG_INFO, "main():Please wait.. disk cache is being flushed" );
+                        pthread_cancel( c2[i]->thread );
+
+                        /* Joins the thread and waits for completion before continuing */
+                        r = pthread_join( c2[i]->thread, NULL);
+                        if( r != 0 )
+                        {
+                           nwipe_log( NWIPE_LOG_WARNING, "main()>pthread_join():Error when waiting for wipe thread to cancel." );
+                        }
+                        c2[i]->thread = 0; /* Zero the thread so we know it's been cancelled */
 
                         /* Close the device file descriptor. */
                         close( c2[i]->device_fd );
@@ -450,7 +483,7 @@ int main( int argc, char** argv )
                 nwipe_gui_free();
                 
         }
-        
+
         nwipe_log( NWIPE_LOG_NOTICE, "Nwipe exited." );
 
         for( i = 0 ; i < nwipe_selected ; i++ )
@@ -495,7 +528,8 @@ void *signal_hand(void *ptr)
         sigaddset(&sigset, SIGINT);
         sigaddset(&sigset, SIGUSR1);
 
-        int i;        
+        int i;
+        int r; /* Generic result buffer */
 
         /* Set up the structs we will use for the data required. */
         nwipe_thread_data_ptr_t *nwipe_thread_data_ptr;
@@ -571,12 +605,17 @@ void *signal_hand(void *ptr)
 
                                 for( i = 0; i < nwipe_misc_thread_data->nwipe_selected; i++ )
                                 {
-
                                         if ( c[i]->thread )
                                         {
                                                 nwipe_log( NWIPE_LOG_INFO, "Cancelling thread for %s", c[i]->device_name );
                                                 nwipe_log( NWIPE_LOG_INFO, "Please be patient.. disk cache is being flushed" );
                                                 pthread_cancel( c[i]->thread );
+                                                
+                                                r = pthread_join( c[i]->thread, NULL);
+                                                if( r != 0 )
+                                                {
+                                                   nwipe_log( NWIPE_LOG_WARNING, "signal_hand()>pthread_join():Error when waiting for wipe thread to cancel." );
+                                                }
                                         }
                                 }
 
@@ -586,6 +625,13 @@ void *signal_hand(void *ptr)
                                         if ( *nwipe_misc_thread_data->gui_thread )
                                         {
                                                 pthread_cancel( *nwipe_misc_thread_data->gui_thread );
+                                                
+                                                r = pthread_join( *nwipe_misc_thread_data->gui_thread, NULL);
+                                                if( r != 0 )
+                                                {
+                                                   nwipe_log( NWIPE_LOG_WARNING, "signal_hand()>pthread_join():Error when waiting for GUI thread to cancel." );
+                                                }
+                                                
                                                 *nwipe_misc_thread_data->gui_thread = 0;
                                         }
                                 }

--- a/src/pass.c
+++ b/src/pass.c
@@ -703,7 +703,6 @@ int nwipe_static_pass( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* pattern )
 		return -1;
 	}
 
-
 	while( z > 0 )
 	{
 		if( c->device_stat.st_blksize <= z )


### PR DESCRIPTION
Closes #95, closes #117 

Symptoms: If you control-C to exit nwipe at the end of a successful
wipe you would get a segmentation fault. If nwipe log data was being
sent to stdout rather than to a log file, then you would not see the
log in the terminal windows after nwipe had exited. This patch fixes
those problems by creating a tri-state wipe flag for each wipe
thread. The main thread after having launched the wipe threads
will wait for ALL wipe flags to report that the wipe routine has
completed and the thread has exited. Only at that time does the
main() routine then proceed with joining the threads and waiting
for the join to confirm the thread has indeed exited. This join
is important as the thread will not actually exit until the OS
has flushed the disk buffers. Currently nwipe does not use O_SYNC
where data is sent straight to disk. Therefore it's important
to wait for data to be flushed before exiting nwipe. Part of this
patch is introducing a "please wait .. disks are being flushed"
prior to exiting nwipe otherwise it might look like nwipe had
hung. A disk flush in terms of how long it takes, can be from
instantly to 30 seconds or more, depending on how much system
memory you have, when the last sync occurred and if you have
changed the sync option from it's default. Something else to
note is that when all wipes have finished nwipe displays "Enter
To Exit" on the status line at the bottom of the screen. I
believe typing 'enter' rather than control-c did not produce a
segmentation fault. Irrespective, both methods of exiting nwipe
have been tested and confirmed to now work correctly. Tested
overnight with two drives using multiple wipe methods,
verification and blanking.

The log below shows a successful DOD Short wipe with verification
and blanking,  with the addition of the disk flush messages prior
to exit.

 sudo ./nwipe --exclude=/dev/sda,/dev/sdb,/dev/mapper/cryptswap1
[2019/11/10 23:42:35] nwipe: notice: Device /dev/sda excluded as per command line option -e
[2019/11/10 23:42:35] nwipe: notice: Device /dev/sdb excluded as per command line option -e
[2019/11/10 23:42:35] nwipe: info: Found drive model="ATA WDC WD5000BEVT-0", device path="/dev/sdc", size="500GB", serial number="WD-WXN409SR3695"
[2019/11/10 23:42:35] nwipe: info: Found drive model="Maxtor 6 Y080P0", device path="/dev/sdd", size="82.0GB", serial number=""
[2019/11/10 23:42:35] nwipe: notice: Device /dev/mapper/cryptswap1 excluded as per command line option -e
[2019/11/10 23:42:35] nwipe: info: Automatically enumerated 2 devices.
[2019/11/10 23:42:35] nwipe: info: bios-version = E16F2IM7 V5.0E
[2019/11/10 23:42:35] nwipe: info: bios-release-date = 01/10/2012
[2019/11/10 23:42:35] nwipe: info: system-manufacturer = MEDION
[2019/11/10 23:42:35] nwipe: info: system-product-name = X681X
[2019/11/10 23:42:35] nwipe: info: system-version = To be filled by O.E.M.
[2019/11/10 23:42:35] nwipe: info: system-serial-number = To be filled by O.E.M.
[2019/11/10 23:42:35] nwipe: info: system-uuid = 03000200-0400-0500-0006-000700080009
[2019/11/10 23:42:35] nwipe: info: baseboard-manufacturer = MEDION
[2019/11/10 23:42:35] nwipe: info: baseboard-product-name = X681X
[2019/11/10 23:42:35] nwipe: info: baseboard-version = To be filled by O.E.M.
[2019/11/10 23:42:35] nwipe: info: baseboard-serial-number = To be filled by O.E.M.
[2019/11/10 23:42:35] nwipe: info: baseboard-asset-tag = To be filled by O.E.M.
[2019/11/10 23:42:35] nwipe: info: chassis-manufacturer = To Be Filled By O.E.M.
[2019/11/10 23:42:35] nwipe: info: chassis-type = Notebook
[2019/11/10 23:42:35] nwipe: info: chassis-version = To be filled by O.E.M.
[2019/11/10 23:42:35] nwipe: info: chassis-serial-number = To Be Filled By O.E.M.
[2019/11/10 23:42:35] nwipe: info: chassis-asset-tag = To Be Filled By O.E.M.
[2019/11/10 23:42:35] nwipe: info: processor-family = Core i7
[2019/11/10 23:42:35] nwipe: info: processor-manufacturer = Intel
[2019/11/10 23:42:35] nwipe: info: processor-version = Intel(R) Core(TM) i7-2670QM CPU @ 2.20GHz
[2019/11/10 23:42:35] nwipe: info: processor-frequency = 800 MHz
[2019/11/10 23:42:35] nwipe: notice: Opened entropy source '/dev/urandom'.
[2019/11/10 23:42:49] nwipe: info: Device /dev/sdc has serial number WD-WXN409SR3695
[2019/11/10 23:42:49] nwipe: info: Device '/dev/sdc' has sector size 512.
[2019/11/10 23:42:49] nwipe: info: Device '/dev/sdc' has block size 4096.
[2019/11/10 23:42:49] nwipe: info: Device '/dev/sdc' is size 500107862016.
[2019/11/10 23:42:49] nwipe: info: Device '/dev/sdd' has sector size 512.
[2019/11/10 23:42:49] nwipe: info: Device '/dev/sdd' has block size 4096.
[2019/11/10 23:42:49] nwipe: info: Device '/dev/sdd' is size 81964302336.
[2019/11/10 23:42:49] nwipe: notice: Invoking method 'DoD Short' on device '/dev/sdc'.
[2019/11/10 23:42:49] nwipe: notice: Starting round 1 of 1 on device '/dev/sdc'.
[2019/11/10 23:42:49] nwipe: notice: Starting pass 1 of 3, round 1 of 1, on device '/dev/sdc'.
[2019/11/10 23:42:49] nwipe: notice: Invoking method 'DoD Short' on device '/dev/sdd'.
[2019/11/10 23:42:49] nwipe: notice: Starting round 1 of 1 on device '/dev/sdd'.
[2019/11/10 23:42:49] nwipe: notice: Starting pass 1 of 3, round 1 of 1, on device '/dev/sdd'.
[2019/11/11 00:20:48] nwipe: notice: 81964302336 bytes written to device '/dev/sdd'.
[2019/11/11 00:20:48] nwipe: notice: Finished pass 1 of 3, round 1 of 1, on device '/dev/sdd'.
[2019/11/11 00:20:48] nwipe: notice: Starting pass 2 of 3, round 1 of 1, on device '/dev/sdd'.
[2019/11/11 01:02:11] nwipe: notice: 81964302336 bytes written to device '/dev/sdd'.
[2019/11/11 01:02:11] nwipe: notice: Finished pass 2 of 3, round 1 of 1, on device '/dev/sdd'.
[2019/11/11 01:02:11] nwipe: notice: Starting pass 3 of 3, round 1 of 1, on device '/dev/sdd'.
[2019/11/11 01:43:47] nwipe: notice: 81964302336 bytes written to device '/dev/sdd'.
[2019/11/11 01:43:47] nwipe: notice: Finished pass 3 of 3, round 1 of 1, on device '/dev/sdd'.
[2019/11/11 01:43:47] nwipe: notice: Finished round 1 of 1 on device '/dev/sdd'.
[2019/11/11 01:43:47] nwipe: notice: Blanking device '/dev/sdd'.
[2019/11/11 02:03:12] nwipe: notice: 500107862016 bytes written to device '/dev/sdc'.
[2019/11/11 02:03:12] nwipe: notice: Finished pass 1 of 3, round 1 of 1, on device '/dev/sdc'.
[2019/11/11 02:03:12] nwipe: notice: Starting pass 2 of 3, round 1 of 1, on device '/dev/sdc'.
[2019/11/11 02:22:44] nwipe: notice: Verifying that '/dev/sdd' is empty.
[2019/11/11 03:01:40] nwipe: notice: Verified that '/dev/sdd' is empty.
[2019/11/11 03:01:40] nwipe: notice: Blanked device '/dev/sdd'.
[2019/11/11 04:23:22] nwipe: notice: 500107862016 bytes written to device '/dev/sdc'.
[2019/11/11 04:23:22] nwipe: notice: Finished pass 2 of 3, round 1 of 1, on device '/dev/sdc'.
[2019/11/11 04:23:22] nwipe: notice: Starting pass 3 of 3, round 1 of 1, on device '/dev/sdc'.
[2019/11/11 07:00:43] nwipe: notice: 500107862016 bytes written to device '/dev/sdc'.
[2019/11/11 07:00:43] nwipe: notice: Finished pass 3 of 3, round 1 of 1, on device '/dev/sdc'.
[2019/11/11 07:00:43] nwipe: notice: Finished round 1 of 1 on device '/dev/sdc'.
[2019/11/11 07:00:43] nwipe: notice: Blanking device '/dev/sdc'.
[2019/11/11 09:20:50] nwipe: notice: Verifying that '/dev/sdc' is empty.
[2019/11/11 11:35:00] nwipe: notice: Verified that '/dev/sdc' is empty.
[2019/11/11 11:35:00] nwipe: notice: Blanked device '/dev/sdc'.
[2019/11/11 11:35:02] nwipe: info: main():Cancelling wipe thread for /dev/sdc
[2019/11/11 11:35:02] nwipe: info: main():Please wait.. disk cache is being flushed
[2019/11/11 11:35:05] nwipe: info: main():Cancelling wipe thread for /dev/sdd
[2019/11/11 11:35:05] nwipe: info: main():Please wait.. disk cache is being flushed
[2019/11/11 11:57:01] nwipe: notice: Nwipe exited.