### PR TITLE
Add documentation for verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 RELEASE NOTES
 =============
 
+v0.27
+-----
+- Add `verify` method to verify a disk is zero filled [#128](https://github.com/martijnvanbrummelen/nwipe/pull/128)
+
 v0.26
 -----
 - Add exclude drive option (Thanks PartialVolume)

--- a/man/nwipe.1
+++ b/man/nwipe.1
@@ -68,6 +68,8 @@ ops2                   \- RCMP TSSIT OPS\-II
 random / prng / stream \- PRNG Stream
 .IP
 zero / quick           \- Overwrite with zeros
+.IP
+verify                 \- Verifies disk is zero filled
 .TP
 \fB\-l\fR, \fB\-\-logfile\fR=\fIFILE\fR
 Filename to log to. Default is STDOUT

--- a/src/options.c
+++ b/src/options.c
@@ -452,8 +452,8 @@ void display_help()
   puts("                          gutmann                - Peter Gutmann's Algorithm");
   puts("                          ops2                   - RCMP TSSIT OPS-II");
   puts("                          random / prng / stream - PRNG Stream");
-  puts("                          zero / quick           - Overwrite with zeros\n");
-  puts("                          verify                 - Verifies disk is zero filled");
+  puts("                          zero / quick           - Overwrite with zeros");
+  puts("                          verify                 - Verifies disk is zero filled\n");
   puts("  -l, --logfile=FILE      Filename to log to. Default is STDOUT\n");
   puts("  -p, --prng=METHOD       PRNG option (mersenne|twister|isaac)\n");
   puts("  -r, --rounds=NUM        Number of times to wipe the device using the selected");


### PR DESCRIPTION
Adds documentation to the `verify` method and fix the help message display (verify option was not in the same block as the other options).

I tried the feature, and it feels weird that all the fields are filled with non-relevant values when using this method:
![options](https://user-images.githubusercontent.com/3301383/68813836-1f8bff00-0645-11ea-8d65-8a15cbc48c45.png) 
It could make sense to at least blank these fields when they are not relevant to the current method. @Legogizmo what do you think?
