### PR TITLE
Suppress warnings from glibc macros.

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -18,8 +18,13 @@
  *
  */
 
-#define _POSIX_SOURCE
+#ifndef _DEFAULT_SOURCE
 #define _DEFAULT_SOURCE
+#endif
+
+#ifndef _POSIX_SOURCE
+#define _POSIX_SOURCE
+#endif
 
 #include "stdio.h"
 #include "stdlib.h"

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -20,7 +20,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. 
  *
  */
+#ifndef _POSIX_SOURCE
 #define _POSIX_SOURCE
+#endif
 
 #include <stdint.h>
 #include <time.h>


### PR DESCRIPTION
These warnings pop up when first compiling the project (even when not in dev mode):
```
 warning: "_DEFAULT_SOURCE" redefined
```
This makes sure we're only defining those glibc macros if needed.