### PR TITLE
Adding GitHub CI build process.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI on Ubuntu 18.04
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: installing system dependencies
+      run: sudo apt-get install -y build-essential pkg-config automake libncurses5-dev autotools-dev libparted-dev dmidecode
+    - name: creating autoconf files
+      run: ./init.sh
+    - name: configure
+      run: ./configure CFLAGS='-O0 -g -Wall -Wextra'
+    - name: make
+      run: make

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # nwipe
+![GitHub CI badge](https://github.com/martijnvanbrummelen/nwipe/workflows/CI%20on%20Ubuntu%2018.04/badge.svg)
 
 nwipe is a command that will securely erase disks using a variety of
 recognised methods.  It is a fork of the dwipe command used by


### PR DESCRIPTION
For now the build does not fail with the `gcc` warnings, but that could be changed in the future. Code formatting could also be added at some point.