### PR TITLE
Exit on invalid long option.

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -206,6 +206,9 @@ int nwipe_options_parse( int argc, char** argv )
 					exit( EINVAL );
 				}
 
+				/* getopt_long should raise on invalid option, so we should never get here. */
+				exit( EINVAL );
+
 			case 'm': /* Method option. */
 
 				if( strcmp( optarg, "dod522022m" ) == 0 || strcmp( optarg, "dod" ) == 0 )


### PR DESCRIPTION
@PartialVolume as mentioned in the comment, this should never happen, but otherwise we get compiler warnings:
```
options.c:183:7: warning: this statement may fall through [-Wimplicit-fallthrough=]
```