### PR TITLE
warning: logical 'or' of collectively exhaustive tests is always true

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -296,7 +296,7 @@ int nwipe_options_parse( int argc, char** argv )
 						{ /* This section deals with file names that exceed
 						     MAX_DRIVE_PATH_LENGTH */
 							nwipe_options.exclude[idx_drive][idx_drive_chr] = 0;
-							while( optarg[idx_optarg] != 0 || optarg[idx_optarg] != ',' )
+							while( optarg[idx_optarg] != 0 && optarg[idx_optarg] != ',' )
 							{
 								idx_optarg++;
 							}


### PR DESCRIPTION
If using || in the while statement and if 'MAX_DRIVE_PATH_LENGTH' was exceeded the while loop would loop indefinitely.