### PR TITLE
Runtime statistics uses too much CPU

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -32,6 +32,7 @@
 #include <ncurses.h>
 #include <panel.h>
 #include <stdint.h>
+#include <time.h>
 
 #include "nwipe.h"
 #include "context.h"
@@ -1796,6 +1797,10 @@ void *nwipe_gui_status( void *ptr )
 	int nwipe_hh;
 	int nwipe_mm;
 	int nwipe_ss;
+   
+   struct timespec tim, tim2;
+   tim.tv_sec = 0;
+   tim.tv_nsec = 100000000L; /* sleep for 0.1 seconds */
 
 	/* The number of active wipe processes. */
 	/* Set to 1 initially to start loop.    */
@@ -2120,6 +2125,12 @@ void *nwipe_gui_status( void *ptr )
 			refresh();                      /* Do refresh() to restore the    */
 							/* Screen contents                */
 		}
+		
+		/* Stop this function unnecessarily running the CPU or a CPU core at 100% */
+		if(nanosleep(&tim , &tim2) < 0 )   
+      {
+         printf("Nano sleep system call failed \n");
+      }
 
 		/* Test for a thread cancellation request */
 		pthread_testcancel();


### PR DESCRIPTION
During testing a single drive two cores consistently run at close to 100%,
one core at 100% and the other varying between 80-100%. This shouldn't be
the case. Although there would be two threads running, i.e. the gui status
thread and the disk drives wipe thread I would have expected the amount of
CPU required to calculate the on screen stats to be insignificant as they
are only updated once a second.

To reduce the gui stats thread to near zero% while still maintaining the
stats update at one second I inserted an nanosleep interval of 100ms. This
now means that only the one core now shows at 80-100% while all other cores
are close to zero.