### PR TITLE
Update ci_update-16.04.yml

### DIFF
--- a/.github/workflows/ci_ubuntu-16.04.yml
+++ b/.github/workflows/ci_ubuntu-16.04.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: update repo
+      run: sudo apt-get update
     - name: installing system dependencies
       run: sudo apt-get install -y build-essential pkg-config automake libncurses5-dev autotools-dev libparted-dev dmidecode
     - name: creating autoconf files


### PR DESCRIPTION
As I did with ci.yml (ubuntu-latest) use apt-get update prior to installing system dependencies else CI will fail with missing dependencies when upstream versions change.