### PR TITLE
Fixes warning "Implicit declaration of function 'fdatasync' is invalid in C99"

### DIFF
--- a/src/pass.c
+++ b/src/pass.c
@@ -20,6 +20,7 @@
  *
  */
 
+#define _POSIX_C_SOURCE 200809L
 
 #include <stdint.h>
 #include "nwipe.h"


### PR DESCRIPTION
#define _POSIX_C_SOURCE 200809L