### PR TITLE
Fix segfault & missing log lines

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -280,10 +280,6 @@ void nwipe_log( nwipe_log_t level, const char* format, ... )
 		{
 			printf( "%s\n", log_lines[log_current_element] );
 		}
-		else
-		{
-			log_current_element++;
-		}
 	} else
 	{
 		/* Open the log file for appending. */
@@ -342,6 +338,8 @@ void nwipe_log( nwipe_log_t level, const char* format, ... )
 			fprintf( stderr, "Error: Unable to close '%s' after logging.\n", nwipe_options.logfile );
 		}
 	}
+	
+	log_current_element++;
 	
 	r = pthread_mutex_unlock( &mutex1 );
    if ( r !=0 )


### PR DESCRIPTION
This patch fixes a segfault that occurs when a logfile is specified.
The segfault occurred on exit of nwipe. It did not affect the wipe
process.

This patch also fixes a related issue, at the end of a wipe some
of the log lines were missing on stdout, this occurred when a log
file was not specified as an option.

closes #134 
