### PR TITLE
Fix missing log lines

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2109,17 +2109,6 @@ void *nwipe_gui_status( void *ptr )
 			/* Flush stdout and disable buffering, otherwise output missed new lines. */
 			fflush(stdout);
 			setbuf(stdout, NULL);
-			
-			pthread_mutex_lock( &mutex1 );
-			
-			for (i=0; i < log_current_element; i++)
-			{
-				printf("%s\n", log_lines[i]);
-			}
-			log_current_element = 0;
-
-			pthread_mutex_unlock( &mutex1 );
-			
 			reset_prog_mode();              /* Return to the previous tty mode*/
 							/* stored by def_prog_mode()      */
 			refresh();                      /* Do refresh() to restore the    */

--- a/src/logging.c
+++ b/src/logging.c
@@ -40,7 +40,9 @@
 char **log_lines;
 int log_current_element = 0;
 int log_elements_allocated = 0;
+int log_elements_displayed = 0;
 pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+
 
 void nwipe_log( nwipe_log_t level, const char* format, ... )
 {
@@ -215,6 +217,7 @@ void nwipe_log( nwipe_log_t level, const char* format, ... )
 		}
 	}
 
+   fflush(stdout);
 	/* Increase the current log element pointer - we will write here, deallocation is done in cleanup() in nwipe.c */
 	if (log_current_element == log_elements_allocated) {
 		log_elements_allocated++;
@@ -279,7 +282,8 @@ void nwipe_log( nwipe_log_t level, const char* format, ... )
 		if (nwipe_options.nogui)
 		{
 			printf( "%s\n", log_lines[log_current_element] );
-		}
+         log_elements_displayed++;
+		}  
 	} else
 	{
 		/* Open the log file for appending. */

--- a/src/nwipe.h
+++ b/src/nwipe.h
@@ -74,10 +74,11 @@ int cleanup();
 extern int errno;
 
 /* Global array to hold log values to print when logging to STDOUT */
-extern char **log_lines;
-extern int log_current_element;
-extern int log_elements_allocated;
-extern pthread_mutex_t mutex1;
+/* char **log_lines;
+int log_current_element = 0;
+int log_elements_allocated = 0;
+int log_elements_displayed = 0;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER; */
 
 /* Ncurses headers. */
 #ifdef NCURSES_IN_SUBDIR


### PR DESCRIPTION
Change code so that there is only one place where the log is flushed on
exit from the ncurses gui. Prior to this patch the flush was done twice
which resulted in duplicated lines and missing lines. The
log_current_element variable was being initialised after the first flush.
This caused subsequent writes to nwipe to write log_lines pointers passed
the end of the pointer array causing memory corruption and resulting in the
occassional segfault on attempts to print the log array.