### PR TITLE
Show percentage completed, on completion of wipe.

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -1983,7 +1983,7 @@ void *nwipe_gui_status( void *ptr )
 
 				else
 				{
-					if( c[i]->result == 0 ) { mvwprintw( main_window, yy++, 4, "(SUCCESS!) " );                         }
+					if( c[i]->result == 0 ) { mvwprintw( main_window, yy++, 4, "[%05.2f%% complete, SUCCESS! ", c[i]->round_percent); }
 					else if( c[i]->signal ) { mvwprintw( main_window, yy++, 4, "(>>> FAILURE! <<<, signal %i) ", c[i]->signal ); }
 					else                   { mvwprintw( main_window, yy++, 4, "(>>>FAILURE!<<<, code %i) ", c[i]->result );   }
 


### PR DESCRIPTION
Rather than delete percentage complete, show it. Because we were hiding
percentage complete we were not aware of inaccuracies in the percentage
calculation that are introduced when you toggle blanking and
verification on various methods.