### PR TITLE
Prefixing device fields with `_device`.

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -65,9 +65,15 @@ typedef struct nwipe_speedring_t_
     u32 position;
 } nwipe_speedring_t;
 
+#define NWIPE_DEVICE_LABEL_LENGTH 200
+
 typedef struct nwipe_context_t_
 {
-    int block_size;  // The soft block size reported the device.
+    /*
+     * Device fields
+     */
+    int device_block_size;  // The soft block size reported by the device.
+    int device_sector_size;  // The hard sector size reported by the device.
     int device_bus;  // The device bus number.
     int device_fd;  // The file descriptor of the device file being wiped.
     int device_host;  // The host number.
@@ -79,12 +85,15 @@ typedef struct nwipe_context_t_
     char* device_name;  // The device file name.
     long long device_size;  // The device size in bytes.
     char* device_size_text;  // The device size in a more (human)readable format.
+    char* device_model;  // The model of the device.
+    char device_label[NWIPE_DEVICE_LABEL_LENGTH];  // The label (name, model, size and serial) of the device.
     struct stat device_stat;  // The device file state from fstat().
     nwipe_device_t device_type;  // Indicates an IDE, SCSI, or Compaq SMART device.
+    char device_serial_no[21];  // Serial number(processed, 20 characters plus null termination) of the device.
     int device_target;  // The device target.
+
     u64 eta;  // The estimated number of seconds until method completion.
     int entropy_fd;  // The entropy source. Usually /dev/urandom.
-    char* label;  // The string that we will show the user.
     int pass_count;  // The number of passes performed by the working wipe method.
     u64 pass_done;  // The number of bytes that have already been i/o'd in this pass.
     u64 pass_errors;  // The number of errors across all passes.
@@ -101,7 +110,6 @@ typedef struct nwipe_context_t_
     u64 round_size;  // The total number of i/o bytes across all rounds.
     double round_percent;  // The percentage complete across all rounds.
     int round_working;  // The current working round.
-    int sector_size;  // The hard sector size reported by the device.
     nwipe_select_t select;  // Indicates whether this device should be wiped.
     int signal;  // Set when the child is killed by a signal.
     nwipe_speedring_t speedring;  // Ring buffer for computing the rolling throughput average.
@@ -110,7 +118,6 @@ typedef struct nwipe_context_t_
     u64 throughput;  // Average throughput in bytes per second.
     u64 verify_errors;  // The number of verification errors across all passes.
     int wipe_status;  // Wipe finished = 0, wipe in progress = 1, wipe yet to start = -1.
-    char serial_no[21];  // Serial number(processed), 20 characters, plus null termination.
     /*
      * Identity contains the raw serial number of the drive
      * (where applicable), however, for use within nwipe use the

--- a/src/gui.c
+++ b/src/gui.c
@@ -475,48 +475,24 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
             {
                 case NWIPE_SELECT_TRUE:
 
-                    wprintw( main_window,
-                             " [wipe] %i. %s - %s, S/N:%s, (%s)",
-                             ( i + offset + 1 ),
-                             c[i + offset]->device_name + SKIP_DEV_PREFIX,
-                             c[i + offset]->label,
-                             c[i + offset]->serial_no,
-                             c[i + offset]->device_size_text );
+                    wprintw( main_window, " [wipe] %i. %s", ( i + offset + 1 ), c[i + offset]->device_label );
                     break;
 
                 case NWIPE_SELECT_FALSE:
                     /* Print an element that is not selected. */
-                    wprintw( main_window,
-                             " [    ] %i. %s - %s, S/N:%s, (%s)",
-                             ( i + offset + 1 ),
-                             c[i + offset]->device_name + SKIP_DEV_PREFIX,
-                             c[i + offset]->label,
-                             c[i + offset]->serial_no,
-                             c[i + offset]->device_size_text );
+                    wprintw( main_window, " [    ] %i. %s", ( i + offset + 1 ), c[i + offset]->device_label );
                     break;
 
                 case NWIPE_SELECT_TRUE_PARENT:
 
                     /* This element will be wiped when its parent is wiped. */
-                    wprintw( main_window,
-                             " [****] %i. %s - %s, S/N:%s, (%s)",
-                             ( i + offset + 1 ),
-                             c[i + offset]->device_name + SKIP_DEV_PREFIX,
-                             c[i + offset]->label,
-                             c[i + offset]->serial_no,
-                             c[i + offset]->device_size_text );
+                    wprintw( main_window, " [****] %i. %s", ( i + offset + 1 ), c[i + offset]->device_label );
                     break;
 
                 case NWIPE_SELECT_FALSE_CHILD:
 
                     /* We can't wipe this element because it has a child that is being wiped. */
-                    wprintw( main_window,
-                             " [----] %i. %s - %s, S/N:%s, (%s)",
-                             ( i + offset + 1 ),
-                             c[i + offset]->device_name + SKIP_DEV_PREFIX,
-                             c[i + offset]->label,
-                             c[i + offset]->serial_no,
-                             c[i + offset]->device_size_text );
+                    wprintw( main_window, " [----] %i. %s", ( i + offset + 1 ), c[i + offset]->device_label );
                     break;
 
                 case NWIPE_SELECT_DISABLED:
@@ -2131,21 +2107,8 @@ void* nwipe_gui_status( void* ptr )
             /* Print information for the user. */
             for( i = offset; i < offset + slots && i < count; i++ )
             {
-                /* Print the context label. */
-                if( strlen( (const char*) c[i]->serial_no ) )
-                {
-                    mvwprintw( main_window,
-                               yy++,
-                               2,
-                               "%s - %s (S/N:%s)",
-                               c[i]->device_name + SKIP_DEV_PREFIX,
-                               c[i]->label,
-                               c[i]->serial_no );
-                }
-                else
-                {
-                    mvwprintw( main_window, yy++, 2, "%s - %s", c[i]->device_name + SKIP_DEV_PREFIX, c[i]->label );
-                }
+                /* Print the device label. */
+                mvwprintw( main_window, yy++, 2, "%s", c[i]->device_label );
 
                 /* Check whether the child process is still running the wipe. */
                 if( c[i]->wipe_status == 1 )

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -305,31 +305,33 @@ int main( int argc, char** argv )
         */
 
         /* Print serial number of device if it exists. */
-        if( strlen( (const char*) c2[i]->serial_no ) )
+        if( strlen( (const char*) c2[i]->device_serial_no ) )
         {
-            nwipe_log( NWIPE_LOG_INFO, "Device %s has serial number %s", c2[i]->device_name, c2[i]->serial_no );
+            nwipe_log( NWIPE_LOG_INFO, "Device %s has serial number %s", c2[i]->device_name, c2[i]->device_serial_no );
         }
 
         /* Do sector size and block size checking. */
-        if( ioctl( c2[i]->device_fd, BLKSSZGET, &c2[i]->sector_size ) == 0 )
+        if( ioctl( c2[i]->device_fd, BLKSSZGET, &c2[i]->device_sector_size ) == 0 )
         {
-            nwipe_log( NWIPE_LOG_INFO, "Device '%s' has sector size %i.", c2[i]->device_name, c2[i]->sector_size );
+            nwipe_log(
+                NWIPE_LOG_INFO, "Device '%s' has sector size %i.", c2[i]->device_name, c2[i]->device_sector_size );
 
-            if( ioctl( c2[i]->device_fd, BLKBSZGET, &c2[i]->block_size ) == 0 )
+            if( ioctl( c2[i]->device_fd, BLKBSZGET, &c2[i]->device_block_size ) == 0 )
             {
-                nwipe_log( NWIPE_LOG_INFO, "Device '%s' has block size %i.", c2[i]->device_name, c2[i]->block_size );
+                nwipe_log(
+                    NWIPE_LOG_INFO, "Device '%s' has block size %i.", c2[i]->device_name, c2[i]->device_block_size );
             }
             else
             {
                 nwipe_log( NWIPE_LOG_WARNING, "Device '%s' failed BLKBSZGET ioctl.", c2[i]->device_name );
-                c2[i]->block_size = 0;
+                c2[i]->device_block_size = 0;
             }
         }
         else
         {
             nwipe_log( NWIPE_LOG_WARNING, "Device '%s' failed BLKSSZGET ioctl.", c2[i]->device_name );
-            c2[i]->sector_size = 0;
-            c2[i]->block_size = 0;
+            c2[i]->device_sector_size = 0;
+            c2[i]->device_block_size = 0;
         }
 
         /* The st_size field is zero for block devices. */


### PR DESCRIPTION
Also added a `device_label` field to centralize
the creation of the device label. This fixes the
labels for devices without a serial number, and
makes sure we have the same label format everywhere.

@PartialVolume :pray:  :eyes: 

I also changed the format of the device label a bit. I re-introduced the `/dev` prefix in the device name, since I feel it's more explicit to have the full name/path. The size is now just after the name.