### PR TITLE
Using git-diff --exit-code for diff details.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,4 +6,4 @@ format:
 	clang-format -i -style=file $(FORMATSOURCES)
 
 check-format:
-	clang-format -i -style=file $(FORMATSOURCES) && git diff-index --quiet HEAD
+	clang-format -i -style=file $(FORMATSOURCES) && git diff --exit-code


### PR DESCRIPTION
@PartialVolume Not sure why I used `diff-index` for that, but now we will see the entire formatting diff in the CI logs.