### PR TITLE
Release 0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 RELEASE NOTES
 =============
 
-v0.27 (pending release, proposed date end of February 2020)
+v0.27
 -----------------------
 - Add `verify` method to verify a disk is zero filled [#128](https://github.com/martijnvanbrummelen/nwipe/pull/128) (Thanks Legogizmo)
 - Add new HMG IS5 enhanced wipe method [#168](https://github.com/martijnvanbrummelen/nwipe/pull/168) (Thanks infrastation)

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.64])
-AC_INIT([nwipe], [0.26], [git@brumit.nl])
+AC_INIT([nwipe], [0.27], [git@brumit.nl])
 AM_INIT_AUTOMAKE(foreign subdir-objects)
 AC_OUTPUT(Makefile src/Makefile man/Makefile)
 AC_CONFIG_SRCDIR([src/nwipe.c])

--- a/man/nwipe.1
+++ b/man/nwipe.1
@@ -1,4 +1,4 @@
-.TH NWIPE "1" "December 2019" "nwipe version 0.26" "User Commands"
+.TH NWIPE "4" "March 2020" "nwipe version 0.27" "User Commands"
 .SH NAME
 nwipe \- securely erase disks
 .SH SYNOPSIS

--- a/src/version.c
+++ b/src/version.c
@@ -4,14 +4,14 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.27rc1";
+const char* version_string = "0.27";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
-const char* years = "2019";
+const char* years = "2020";
 const char* copyright = "Copyright Darik Horn <dajhorn-dban@vanadac.com>\n\
 Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.27rc1";
+const char* banner = "nwipe 0.27";


### PR DESCRIPTION
Release 0.27.
Tested on the following distros:

- Debian SID (as of 02/Mar/2020)

- Debian Stable 10.3.0

- Ubuntu 19.10

- KDE Neon 5.18.2 (based on Ubuntu 18.04LTS)

- Fedora 31