### PR TITLE
Fix window/panel resizing & display when terminal resized by user

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.64])
-AC_INIT([nwipe], [0.27], [git@brumit.nl])
+AC_INIT([nwipe], [0.28-pre-release], [git@brumit.nl])
 AM_INIT_AUTOMAKE(foreign subdir-objects)
 AC_OUTPUT(Makefile src/Makefile man/Makefile)
 AC_CONFIG_SRCDIR([src/nwipe.c])

--- a/man/nwipe.1
+++ b/man/nwipe.1
@@ -1,4 +1,4 @@
-.TH NWIPE "4" "March 2020" "nwipe version 0.27" "User Commands"
+.TH NWIPE "4" "March 2020" "nwipe version 0.28-pre-release" "User Commands"
 .SH NAME
 nwipe \- securely erase disks
 .SH SYNOPSIS

--- a/src/gui.h
+++ b/src/gui.h
@@ -25,6 +25,13 @@
 
 void nwipe_gui_free( void );  // Stop the GUI.
 void nwipe_gui_init( void );  // Start the GUI.
+void nwipe_gui_create_main_window( void );  // Create the main window
+void nwipe_gui_create_header_window( void );  // Create the header window
+void nwipe_gui_create_footer_window( const char* );  // Create the footer window
+void nwipe_gui_create_options_window( void );  // Create the options window
+void nwipe_gui_create_stats_window( void );  // Create the stats window
+void nwipe_gui_create_all_windows_on_terminal_resize(
+    const char* footer_text );  // If terminal is resized recreate all windows
 void nwipe_gui_select( int count, nwipe_context_t** c );  // Select devices to wipe.
 void* nwipe_gui_status( void* ptr );  // Update operation progress.
 void nwipe_gui_method( void );  // Change the method option.

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -442,15 +442,15 @@ int main( int argc, char** argv )
     if( terminate_signal == 1 )
     {
         nwipe_log( NWIPE_LOG_INFO, "Program interrupted" );
-        printf( "Program interrupted" );
     }
     else
     {
         if( !nwipe_options.nowait )
         {
-            /* Wait for the user to press enter to exit */
-            nocbreak();
-            getch();
+            do
+            {
+                sleep( 1 );
+            } while( terminate_signal != 1 );
         }
     }
     nwipe_log( NWIPE_LOG_INFO, "Exit in progress" );

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.27";
+const char* version_string = "0.28-pre-release";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.27";
+const char* banner = "nwipe 0.28-pre-release";


### PR DESCRIPTION
Also fixes an issue where program exits when terminal resized but
only after all the wipes have finished. You can now resize the
terminal, before, during and after the wipes have completed and
the windows are now all correctly updated and sized.

Updated version to 0.28-pre-release

Removed unnecessary zero of gui thread pointer.

Created six new functions in gui.c in order to fix the above problem
and reduce existing duplicated code.

Fixes #195