### PR TITLE
Fix flicker

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -325,7 +325,6 @@ void nwipe_gui_create_main_window()
 
     /* refresh main window */
     wnoutrefresh( main_window );
-    
 
 } /* nwipe_gui_create_main_window */
 
@@ -346,7 +345,7 @@ void nwipe_gui_create_header_window()
 
     /* Print the product banner. */
     nwipe_gui_title( header_window, banner );
-    
+
     /* Refresh the header window */
     wnoutrefresh( header_window );
 
@@ -974,7 +973,7 @@ void nwipe_gui_options( void )
     nwipe_gui_title( options_window, options_title );
 
     /* Refresh the window. */
-    //wrefresh( options_window );
+    // wrefresh( options_window );
     wnoutrefresh( options_window );
 
 } /* nwipe_gui_options */
@@ -2203,7 +2202,7 @@ void* nwipe_gui_status( void* ptr )
         {
             nwipe_gui_title( footer_window, "Wipe finished - press enter to exit. Logged to STDOUT" );
         }
-        //wrefresh( footer_window );
+        // wrefresh( footer_window );
         wnoutrefresh( footer_window );
 
         if( terminate_signal == 1 )
@@ -2213,7 +2212,7 @@ void* nwipe_gui_status( void* ptr )
 
         box( options_window, 0, 0 );
         nwipe_gui_title( options_window, options_title );
-        //wrefresh( options_window );
+        // wrefresh( options_window );
         wnoutrefresh( options_window );
 
         /* Try to get a keystroke. */
@@ -2443,7 +2442,7 @@ void* nwipe_gui_status( void* ptr )
             box( main_window, 0, 0 );
 
             /* Refresh the main window. */
-            //wrefresh( main_window );
+            // wrefresh( main_window );
             wnoutrefresh( main_window );
 
             /* Update the load average field, but only if we are still wiping */
@@ -2547,14 +2546,13 @@ void* nwipe_gui_status( void* ptr )
             mvwprintw( stats_window, 0, ( NWIPE_GUI_STATS_W - strlen( stats_title ) ) / 2, "%s", stats_title );
 
             /* Refresh the stats window. */
-            //wrefresh( stats_window );
-            
+            // wrefresh( stats_window );
+
             /* Refresh internal representation of stats window */
             wnoutrefresh( stats_window );
-            
+
             /* Output all windows to screen */
             doupdate();
-            
 
         }  // end blank screen if
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -27,7 +27,7 @@ void nwipe_gui_free( void );  // Stop the GUI.
 void nwipe_gui_init( void );  // Start the GUI.
 void nwipe_gui_create_main_window( void );  // Create the main window
 void nwipe_gui_create_header_window( void );  // Create the header window
-void nwipe_gui_create_footer_window( const char* );  // Create the footer window
+void nwipe_gui_create_footer_window( const char* );  // Create the footer window and write text
 void nwipe_gui_create_options_window( void );  // Create the options window
 void nwipe_gui_create_stats_window( void );  // Create the stats window
 void nwipe_gui_create_all_windows_on_terminal_resize(

--- a/src/version.c
+++ b/src/version.c
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.28-pre-release";
+const char* banner = "nwipe 0.28-pre-release-1";


### PR DESCRIPTION
This fixes screen flicker seen in the following situations:

These apply in full screen mode ONLY: i.e ALT-F2, Shredos etc.
1. When selecting a drive using up/down arrow keys
2. During a wipe the screen flashes at one second intervals.

These apply in a terminal window such as konsole, tmux etc.
1. When resizing the terminal there was a flicker.

All these problems have been fixed.

Most of the causes of the flicker was an excessive use of wrefresh() which calls
the wnoutrefresh() and doupdate() functions. This can cause flickering when a
number of calls to wrefresh happen at the same time. It is more appropriate to
replace the wrefresh() with wnoutrefresh(), then at an appropriate time call
doupate() just once. The result is that before doupdate() would have been
called multiple times and now it's called once when required.

fixes #115