### PR TITLE
Slow main window refresh during wipe after terminal resize

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2154,21 +2154,21 @@ void* nwipe_gui_status( void* ptr )
         /* This is the first time that we have been called. */
         nwipe_time_start = time( NULL ) - 1;
     }
-    
+
     nwipe_gui_title( footer_window, end_wipe_footer );
 
     loop_control = 1;
 
     while( loop_control )
     {
-       /* IMPORTANT ! Halfdelay(1) causes getch() to pause for 0.1 secs. This is important for two reasons.
-        * 1. Pauses the getch for 0.1 secs so that the screen is only updated max 10 times/sec. Without
-        *    this delay the loop would run hundreds of times per sec maxing out the core.
-        * 2. By keeping the delay below 0.2 seconds, i.e 0.1, it makes the keypress and resizing
-        *    nice and responsive.
-        */
-        halfdelay(1); // Important, don't change this unless you know what you are doing ! Related to getch().
-    
+        /* IMPORTANT ! Halfdelay(1) causes getch() to pause for 0.1 secs. This is important for two reasons.
+         * 1. Pauses the getch for 0.1 secs so that the screen is only updated max 10 times/sec. Without
+         *    this delay the loop would run hundreds of times per sec maxing out the core.
+         * 2. By keeping the delay below 0.2 seconds, i.e 0.1, it makes the keypress and resizing
+         *    nice and responsive.
+         */
+        halfdelay( 1 );  // Important, don't change this unless you know what you are doing ! Related to getch().
+
         keystroke = getch();  // Get user input.
 
         /* Get the current time. */
@@ -2190,19 +2190,19 @@ void* nwipe_gui_status( void* ptr )
 
         /* Erase the footer window */
         werase( footer_window );
-        
+
         /* Only repaint the windows on terminal resize if the user hasn't blanked the screen */
         if( nwipe_gui_blank == 0 )
         {
-            if ( nwipe_active != 0 )
+            if( nwipe_active != 0 )
             {
-                  /* if resizing the terminal during a wipe a specific footer is required */
-                  nwipe_gui_create_all_windows_on_terminal_resize( end_wipe_footer );
+                /* if resizing the terminal during a wipe a specific footer is required */
+                nwipe_gui_create_all_windows_on_terminal_resize( end_wipe_footer );
             }
             else
             {
-                  /* and if the wipes have finished a different footer is required */
-                  nwipe_gui_create_all_windows_on_terminal_resize( wipes_finished_footer );
+                /* and if the wipes have finished a different footer is required */
+                nwipe_gui_create_all_windows_on_terminal_resize( wipes_finished_footer );
             }
         }
 
@@ -2217,20 +2217,20 @@ void* nwipe_gui_status( void* ptr )
 
         /* Each element prints three lines. */
         slots /= 3;
-        
+
         if( nwipe_active == 0 || terminate_signal == 1 )
         {
-           nwipe_gui_title( footer_window, wipes_finished_footer );
-         
-           // Refresh the footer_window ;
-           wnoutrefresh( footer_window );
+            nwipe_gui_title( footer_window, wipes_finished_footer );
+
+            // Refresh the footer_window ;
+            wnoutrefresh( footer_window );
         }
 
         if( terminate_signal == 1 )
         {
             loop_control = 0;
         }
-            
+
         if( keystroke > 0x0a && keystroke < 0x7e && nwipe_gui_blank == 1 )
         {
             /* Show screen */
@@ -2246,10 +2246,10 @@ void* nwipe_gui_status( void* ptr )
             show_panel( stats_panel );
             show_panel( options_panel );
             show_panel( main_panel );
-            
+
             /* reprint the footer */
             nwipe_gui_title( footer_window, end_wipe_footer );
-         
+
             // Refresh the footer_window ;
             wnoutrefresh( footer_window );
 
@@ -2550,7 +2550,8 @@ void* nwipe_gui_status( void* ptr )
 
             /* Print the error count. */
             mvwprintw( stats_window, NWIPE_GUI_STATS_ERRORS_Y, NWIPE_GUI_STATS_ERRORS_X, "Errors:" );
-            mvwprintw( stats_window, NWIPE_GUI_STATS_ERRORS_Y, NWIPE_GUI_STATS_TAB, "%llu", nwipe_misc_thread_data->errors );
+            mvwprintw(
+                stats_window, NWIPE_GUI_STATS_ERRORS_Y, NWIPE_GUI_STATS_TAB, "%llu", nwipe_misc_thread_data->errors );
 
             /* Add a border. */
             box( stats_window, 0, 0 );

--- a/src/gui.c
+++ b/src/gui.c
@@ -127,6 +127,7 @@ const char* main_window_footer = "S=Start M=Method P=PRNG V=Verify R=Rounds B=Bl
 const char* selection_footer = "J=Down K=Up Space=Select Backspace=Cancel Ctrl-C=Quit";
 const char* end_wipe_footer = "B=Blank screen Ctrl-C=Quit";
 const char* rounds_footer = "Left=Erase Esc=Cancel Ctrl-C=Quit";
+const char* wipes_finished_footer = "Wipe finished - press enter to exit. Logged to STDOUT";
 
 /* The number of lines available in the terminal */
 int stdscr_lines;
@@ -2153,12 +2154,23 @@ void* nwipe_gui_status( void* ptr )
         /* This is the first time that we have been called. */
         nwipe_time_start = time( NULL ) - 1;
     }
+    
+    nwipe_gui_title( footer_window, end_wipe_footer );
 
     loop_control = 1;
 
-    // while( nwipe_active && terminate_signal != 1 )
     while( loop_control )
     {
+       /* IMPORTANT ! Halfdelay(1) causes getch() to pause for 0.1 secs. This is important for two reasons.
+        * 1. Pauses the getch for 0.1 secs so that the screen is only updated max 10 times/sec. Without
+        *    this delay the loop would run hundreds of times per sec maxing out the core.
+        * 2. By keeping the delay below 0.2 seconds, i.e 0.1, it makes the keypress and resizing
+        *    nice and responsive.
+        */
+        halfdelay(1); // Important, don't change this unless you know what you are doing ! Related to getch().
+    
+        keystroke = getch();  // Get user input.
+
         /* Get the current time. */
         if( nwipe_active && terminate_signal != 1 )
         {
@@ -2170,8 +2182,6 @@ void* nwipe_gui_status( void* ptr )
             nwipe_time_now = nwipe_time_stopped;
         }
 
-        nwipe_gui_create_all_windows_on_terminal_resize( end_wipe_footer );
-
         /* Erase the main window. */
         werase( main_window );
 
@@ -2180,6 +2190,21 @@ void* nwipe_gui_status( void* ptr )
 
         /* Erase the footer window */
         werase( footer_window );
+        
+        /* Only repaint the windows on terminal resize if the user hasn't blanked the screen */
+        if( nwipe_gui_blank == 0 )
+        {
+            if ( nwipe_active != 0 )
+            {
+                  /* if resizing the terminal during a wipe a specific footer is required */
+                  nwipe_gui_create_all_windows_on_terminal_resize( end_wipe_footer );
+            }
+            else
+            {
+                  /* and if the wipes have finished a different footer is required */
+                  nwipe_gui_create_all_windows_on_terminal_resize( wipes_finished_footer );
+            }
+        }
 
         /* Initialize our working offset to the third line. */
         yy = 2;
@@ -2192,33 +2217,21 @@ void* nwipe_gui_status( void* ptr )
 
         /* Each element prints three lines. */
         slots /= 3;
-
-        /* Add text to footer window */
-        if( nwipe_active && terminate_signal != 1 )
+        
+        if( nwipe_active == 0 || terminate_signal == 1 )
         {
-            nwipe_gui_title( footer_window, end_wipe_footer );
+           nwipe_gui_title( footer_window, wipes_finished_footer );
+         
+           // Refresh the footer_window ;
+           wnoutrefresh( footer_window );
         }
-        else
-        {
-            nwipe_gui_title( footer_window, "Wipe finished - press enter to exit. Logged to STDOUT" );
-        }
-        // wrefresh( footer_window );
-        wnoutrefresh( footer_window );
 
         if( terminate_signal == 1 )
         {
             loop_control = 0;
         }
-
-        box( options_window, 0, 0 );
-        nwipe_gui_title( options_window, options_title );
-        // wrefresh( options_window );
-        wnoutrefresh( options_window );
-
-        /* Try to get a keystroke. */
-        keystroke = getch();
-
-        if( keystroke > 0 && nwipe_gui_blank == 1 )
+            
+        if( keystroke > 0x0a && keystroke < 0x7e && nwipe_gui_blank == 1 )
         {
             /* Show screen */
             nwipe_gui_blank = 0;
@@ -2233,6 +2246,12 @@ void* nwipe_gui_status( void* ptr )
             show_panel( stats_panel );
             show_panel( options_panel );
             show_panel( main_panel );
+            
+            /* reprint the footer */
+            nwipe_gui_title( footer_window, end_wipe_footer );
+         
+            // Refresh the footer_window ;
+            wnoutrefresh( footer_window );
 
             /* Update panels */
             update_panels();
@@ -2346,10 +2365,6 @@ void* nwipe_gui_status( void* ptr )
                 } /* child running */
                 else
                 {
-                    if( nwipe_active && terminate_signal != 1 )
-                    {
-                        nwipe_active = compute_stats( ptr );  // compute the final percentage completion value.
-                    }
                     if( c[i]->result == 0 )
                     {
                         mvwprintw( main_window, yy++, 4, "[%05.2f%% complete, SUCCESS! ", c[i]->round_percent );
@@ -2442,7 +2457,6 @@ void* nwipe_gui_status( void* ptr )
             box( main_window, 0, 0 );
 
             /* Refresh the main window. */
-            // wrefresh( main_window );
             wnoutrefresh( main_window );
 
             /* Update the load average field, but only if we are still wiping */
@@ -2536,17 +2550,13 @@ void* nwipe_gui_status( void* ptr )
 
             /* Print the error count. */
             mvwprintw( stats_window, NWIPE_GUI_STATS_ERRORS_Y, NWIPE_GUI_STATS_ERRORS_X, "Errors:" );
-            mvwprintw(
-                stats_window, NWIPE_GUI_STATS_ERRORS_Y, NWIPE_GUI_STATS_TAB, "%llu", nwipe_misc_thread_data->errors );
+            mvwprintw( stats_window, NWIPE_GUI_STATS_ERRORS_Y, NWIPE_GUI_STATS_TAB, "%llu", nwipe_misc_thread_data->errors );
 
             /* Add a border. */
             box( stats_window, 0, 0 );
 
             /* Add a title. */
             mvwprintw( stats_window, 0, ( NWIPE_GUI_STATS_W - strlen( stats_title ) ) / 2, "%s", stats_title );
-
-            /* Refresh the stats window. */
-            // wrefresh( stats_window );
 
             /* Refresh internal representation of stats window */
             wnoutrefresh( stats_window );
@@ -2556,20 +2566,11 @@ void* nwipe_gui_status( void* ptr )
 
         }  // end blank screen if
 
-        /* Stop this function unnecessarily running the CPU or a CPU core at 100% */
-        if( nanosleep( &tim, &tim2 ) < 0 )
-        {
-            printf( "Nano sleep system call failed \n" );
-        }
-
-        /* Test for a thread cancellation request */
-        pthread_testcancel();
-
     } /* End of while loop */
 
     if( nwipe_options.logfile[0] == '\0' )
     {
-        nwipe_gui_title( footer_window, "Wipe finished - press enter to exit. Logged to STDOUT" );
+        nwipe_gui_title( footer_window, wipes_finished_footer );
     }
     else
     {

--- a/src/nwipe.h
+++ b/src/nwipe.h
@@ -1,4 +1,4 @@
-/*
+/*.
  *  nwipe.h: The header file of the nwipe program.
  *
  *  Copyright Darik Horn <dajhorn-dban@vanadac.com>.


### PR DESCRIPTION
Fix 1 second delay on screen update when terminal is resized.

During a wipe there is a approximately 1 second delay between  resizing the window and the screen fully updating. This has been corrected so screen updates and as a consequence key response is
faster. This makes the GUI interface feel smoother and more responsive with windows updating much quicker.