### PR TITLE
Fix individual device throughput.

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2622,7 +2622,7 @@ int compute_stats( void* ptr )
          * correct. Maintain a rolling average of throughput. */
         nwipe_update_speedring( &c[i]->speedring, c[i]->round_done, nwipe_time_now );
 
-        if( c[i]->speedring.timestotal > 0 )
+        if( c[i]->speedring.timestotal > 0 && c[i]->wipe_status == 1 )
         {
             /* Update the current average throughput in bytes-per-second. */
             c[i]->throughput = c[i]->speedring.bytestotal / c[i]->speedring.timestotal;


### PR DESCRIPTION
On completion of a device wipe, the throughput was continuing
to be calculated for a completed wipe which resulted in the
throughput for that particular device to gradually drop over time
to zero if other drives were still

This has now been corrected. Throughput calculation for a given
device is stopped when the particular device has completed its wipe.