### PR TITLE
Add verbose option

### DIFF
--- a/man/nwipe.1
+++ b/man/nwipe.1
@@ -56,6 +56,9 @@ Do not show the GUI interface. Can only be used with the autonuke option.
 Nowait option is automatically invoked with the nogui option.
 SIGUSR1 can be used to retrieve the current wiping statistics.
 .TP
+\fB\-v\fR, \fB\-\-verbose\fR
+Log more messages, useful for debugging.
+.TP
 \fB\-\-verify\fR=\fITYPE\fR
 Whether to perform verification of erasure (default: last)
 .IP

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -462,8 +462,11 @@ int main( int argc, char** argv )
 
         if( c2[i]->thread )
         {
-            nwipe_log( NWIPE_LOG_INFO, "Requesting wipe thread cancellation for %s", c2[i]->device_name );
-            nwipe_log( NWIPE_LOG_INFO, "Please wait.." );
+            if( nwipe_options.verbose )
+            {
+                nwipe_log( NWIPE_LOG_INFO, "Requesting wipe thread cancellation for %s", c2[i]->device_name );
+                nwipe_log( NWIPE_LOG_INFO, "Please wait.." );
+            }
             pthread_cancel( c2[i]->thread );
         }
     }
@@ -471,7 +474,10 @@ int main( int argc, char** argv )
     /* Kill the GUI thread */
     if( nwipe_gui_thread )
     {
-        nwipe_log( NWIPE_LOG_INFO, "Cancelling the GUI thread." );
+        if( nwipe_options.verbose )
+        {
+            nwipe_log( NWIPE_LOG_INFO, "Cancelling the GUI thread." );
+        }
 
         /* We don't want to use pthread_cancel as our GUI thread is aware of the control-c
          *  signal and will exit itself we just join the GUI thread and wait for confirmation
@@ -481,7 +487,10 @@ int main( int argc, char** argv )
         {
             nwipe_log( NWIPE_LOG_WARNING, "main()>pthread_join():Error when waiting for GUI thread to cancel." );
         }
-        nwipe_log( NWIPE_LOG_INFO, "GUI compute_stats thread has been cancelled" );
+        if( nwipe_options.verbose )
+        {
+            nwipe_log( NWIPE_LOG_INFO, "GUI compute_stats thread has been cancelled" );
+        }
     }
 
     /* Release the gui. */
@@ -503,7 +512,12 @@ int main( int argc, char** argv )
                 nwipe_log( NWIPE_LOG_WARNING, "main()>pthread_join():Error when waiting for wipe thread to cancel." );
             }
             c2[i]->thread = 0; /* Zero the thread so we know it's been cancelled */
-            nwipe_log( NWIPE_LOG_INFO, "Wipe thread for device %s has been cancelled", c2[i]->device_name );
+
+            if( nwipe_options.verbose )
+            {
+                nwipe_log( NWIPE_LOG_INFO, "Wipe thread for device %s has been cancelled", c2[i]->device_name );
+            }
+
             /* Close the device file descriptor. */
             close( c2[i]->device_fd );
         }

--- a/src/options.c
+++ b/src/options.c
@@ -53,7 +53,7 @@ int nwipe_options_parse( int argc, char** argv )
     int i;
 
     /* The list of acceptable short options. */
-    char nwipe_options_short[] = "Vhl:m:p:r:e:";
+    char nwipe_options_short[] = "Vvhl:m:p:r:e:";
 
     /* The list of acceptable long options. */
     static struct option nwipe_options_long[] = {
@@ -100,6 +100,9 @@ int nwipe_options_parse( int argc, char** argv )
         {"verify", required_argument, 0, 0},
 
         /* Display program version. */
+        {"verbose", no_argument, 0, 'v'},
+
+        /* Display program version. */
         {"version", no_argument, 0, 'V'},
 
         /* Requisite padding for getopt(). */
@@ -116,6 +119,7 @@ int nwipe_options_parse( int argc, char** argv )
     nwipe_options.nosignals = 0;
     nwipe_options.nogui = 0;
     nwipe_options.sync = 100000;
+    nwipe_options.verbose = 0;
     nwipe_options.verify = NWIPE_VERIFY_LAST;
     memset( nwipe_options.logfile, '\0', sizeof( nwipe_options.logfile ) );
 
@@ -175,6 +179,12 @@ int nwipe_options_parse( int argc, char** argv )
                 {
                     nwipe_options.nogui = 1;
                     nwipe_options.nowait = 1;
+                    break;
+                }
+
+                if( strcmp( nwipe_options_long[i].name, "verbose" ) == 0 )
+                {
+                    nwipe_options.verbose = 1;
                     break;
                 }
 
@@ -353,6 +363,11 @@ int nwipe_options_parse( int argc, char** argv )
 
                 break;
 
+            case 'v': /* verbose */
+
+                nwipe_options.verbose = 1;
+                break;
+
             case 'V': /* Version option. */
 
                 printf( "%s version %s\n", program_name, version_string );
@@ -454,6 +469,7 @@ void display_help()
     /* Limit line length to a maximum of 80 characters so it looks good in 80x25 terminals i.e shredos */
     /*  ___12345678901234567890123456789012345678901234567890123456789012345678901234567890< Do not exceed */
     puts( "  -V, --version           Prints the version number\n" );
+    puts( "  -v, --verbose           Prints more messages to the log\n" );
     puts( "  -h, --help              Prints this help\n" );
     puts( "      --autonuke          If no devices have been specified on the command line," );
     puts( "                          starts wiping all devices immediately. If devices have" );

--- a/src/options.h
+++ b/src/options.h
@@ -60,6 +60,7 @@ typedef struct
     nwipe_prng_t* prng;  // The pseudo random number generator implementation.
     int rounds;  // The number of times that the wipe method should be called.
     int sync;  // A flag to indicate whether and how often writes should be sync'd.
+    int verbose;  // Make log more verbose
     nwipe_verify_t verify;  // A flag to indicate whether writes should be verified.
 } nwipe_options_t;
 


### PR DESCRIPTION
Add verbose option -v, --verbose
Only display thread cancellation info messages, excluding error
messages, only when verbose option is selected.

This helps to keep the log a bit cleaner especially when wiping many
drives simultaneously.