### PR TITLE
Keep nwipe_log notices succinct

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -197,13 +197,13 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
                   next_device->device_size_text,
                   next_device->device_model );
     }
-
-    nwipe_log( NWIPE_LOG_INFO,
-               "Found drive model=\"%s\", device path=\"%s\", size=\"%s\", serial number=\"%s\"",
-               next_device->device_model,
-               next_device->device_name,
-               next_device->device_size_text,
-               next_device->device_serial_no );
+    
+        nwipe_log( NWIPE_LOG_NOTICE,
+                 "Found %s, %s, %s, S/N=%s",
+                  next_device->device_name,
+                  next_device->device_model,
+                  next_device->device_size_text,
+                  next_device->device_serial_no );
 
     ( *c )[dcount] = next_device;
     return 1;

--- a/src/logging.c
+++ b/src/logging.c
@@ -80,7 +80,7 @@ void nwipe_log( nwipe_log_t level, const char* format, ... )
     /* Print the date. The rc script uses the same format. */
     chars_written = snprintf( message_buffer,
                               MAX_LOG_LINE_CHARS,
-                              "[%i/%02i/%02i %02i:%02i:%02i] nwipe: ",
+                              "[%i/%02i/%02i %02i:%02i:%02i] ",
                               1900 + p->tm_year,
                               1 + p->tm_mon,
                               p->tm_mday,
@@ -443,7 +443,7 @@ int nwipe_log_sysinfo()
         fp = popen( cmd, "r" );
         if( fp == NULL )
         {
-            nwipe_log( NWIPE_LOG_INFO, "nwipe_log_sysinfo: Failed to create stream to %s", cmd );
+            nwipe_log( NWIPE_LOG_WARNING, "nwipe_log_sysinfo: Failed to create stream to %s", cmd );
             return 1;
         }
         /* Read the output a line at a time - output it. */
@@ -455,13 +455,13 @@ int nwipe_log_sysinfo()
             {
                 path[len - 1] = 0;
             }
-            nwipe_log( NWIPE_LOG_INFO, "%s = %s", &dmidecode_keywords[keywords_idx][0], path );
+            nwipe_log( NWIPE_LOG_NOTICE, "%s = %s", &dmidecode_keywords[keywords_idx][0], path );
         }
         /* close */
         r = pclose( fp );
         if( r > 0 )
         {
-            nwipe_log( NWIPE_LOG_INFO,
+            nwipe_log( NWIPE_LOG_WARNING,
                        "nwipe_log_sysinfo(): dmidecode failed, \"%s\" exit status = %u",
                        cmd,
                        WEXITSTATUS( r ) );

--- a/src/method.c
+++ b/src/method.c
@@ -704,7 +704,7 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
     c->round_working = 0;
 
     nwipe_log( NWIPE_LOG_NOTICE,
-               "Invoking method '%s' on device '%s'.",
+               "Invoking method '%s' on %s",
                nwipe_method_label( nwipe_options.method ),
                c->device_name );
 
@@ -714,7 +714,7 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
         c->round_working += 1;
 
         nwipe_log( NWIPE_LOG_NOTICE,
-                   "Starting round %i of %i on device '%s'.",
+                   "Starting round %i of %i on %s",
                    c->round_working,
                    c->round_count,
                    c->device_name );
@@ -738,7 +738,7 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
             }
 
             nwipe_log( NWIPE_LOG_NOTICE,
-                       "Starting pass %i of %i, round %i of %i, on device '%s'.",
+                       "Starting pass %i/%i, round %i/%i, on %s",
                        c->pass_working,
                        c->pass_count,
                        c->round_working,
@@ -761,7 +761,7 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
                 c->pass_type = NWIPE_PASS_NONE;
 
                 /* Log number of bytes written to disk */
-                nwipe_log( NWIPE_LOG_NOTICE, "%llu bytes written to device '%s'.", c->pass_done, c->device_name );
+                nwipe_log( NWIPE_LOG_NOTICE, "%llu bytes written to %s", c->pass_done, c->device_name );
 
                 /* Check for a fatal error. */
                 if( r < 0 )
@@ -773,7 +773,7 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
                 {
 
                     nwipe_log( NWIPE_LOG_NOTICE,
-                               "Verifying pass %i of %i, round %i of %i, on device '%s'.",
+                               "Verifying pass %i of %i, round %i of %i, on %s",
                                c->pass_working,
                                c->pass_count,
                                c->round_working,
@@ -792,7 +792,7 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
                     }
 
                     nwipe_log( NWIPE_LOG_NOTICE,
-                               "Verified pass %i of %i, round %i of %i, on device '%s'.",
+                               "Verified pass %i of %i, round %i of %i, on '%s'.",
                                c->pass_working,
                                c->pass_count,
                                c->round_working,
@@ -831,7 +831,7 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
                 c->pass_type = NWIPE_PASS_NONE;
 
                 /* Log number of bytes written to disk */
-                nwipe_log( NWIPE_LOG_NOTICE, "%llu bytes written to device '%s'.", c->pass_done, c->device_name );
+                nwipe_log( NWIPE_LOG_NOTICE, "%llu bytes written to %s", c->pass_done, c->device_name );
 
                 /* Check for a fatal error. */
                 if( r < 0 )
@@ -845,7 +845,7 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
                 if( nwipe_options.verify == NWIPE_VERIFY_ALL || lastpass == 1 || nwipe_options.method == &nwipe_is5enh )
                 {
                     nwipe_log( NWIPE_LOG_NOTICE,
-                               "Verifying pass %i of %i, round %i of %i, on device '%s'.",
+                               "Verifying pass %i of %i, round %i of %i, on %s",
                                c->pass_working,
                                c->pass_count,
                                c->round_working,
@@ -864,7 +864,7 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
                     }
 
                     nwipe_log( NWIPE_LOG_NOTICE,
-                               "Verified pass %i of %i, round %i of %i, on device '%s'.",
+                               "Verified pass %i of %i, round %i of %i, on '%s'.",
                                c->pass_working,
                                c->pass_count,
                                c->round_working,
@@ -875,7 +875,7 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
             } /* random pass */
 
             nwipe_log( NWIPE_LOG_NOTICE,
-                       "Finished pass %i of %i, round %i of %i, on device '%s'.",
+                       "Finished pass %i/%i, round %i/%i, on %s",
                        c->pass_working,
                        c->pass_count,
                        c->round_working,
@@ -885,7 +885,7 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
         } /* for passes */
 
         nwipe_log( NWIPE_LOG_NOTICE,
-                   "Finished round %i of %i on device '%s'.",
+                   "Finished round %i of %i on %s",
                    c->round_working,
                    c->round_count,
                    c->device_name );
@@ -931,7 +931,7 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
 
         if( nwipe_options.verify == NWIPE_VERIFY_LAST || nwipe_options.verify == NWIPE_VERIFY_ALL )
         {
-            nwipe_log( NWIPE_LOG_NOTICE, "Verifying the final random pattern on '%s' is empty.", c->device_name );
+            nwipe_log( NWIPE_LOG_NOTICE, "Verifying the final random pattern on %s is empty.", c->device_name );
 
             /* Verify the final zero pass. */
             r = nwipe_random_verify( c );
@@ -951,7 +951,7 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
 
     else if( nwipe_options.method == &nwipe_verify )
     {
-        nwipe_log( NWIPE_LOG_NOTICE, "Verifying that '%s' is empty.", c->device_name );
+        nwipe_log( NWIPE_LOG_NOTICE, "Verifying that %s is empty", c->device_name );
 
         /* Verify the final zero pass. */
         c->pass_type = NWIPE_PASS_VERIFY;
@@ -964,7 +964,7 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
             return r;
         }
 
-        nwipe_log( NWIPE_LOG_NOTICE, "Verified that '%s' is empty.", c->device_name );
+        nwipe_log( NWIPE_LOG_NOTICE, "[SUCCESS] Verified that %s is empty.", c->device_name );
 
     } /* verify */
 
@@ -973,7 +973,7 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
         /* Tell the user that we are on the final pass. */
         c->pass_type = NWIPE_PASS_FINAL_BLANK;
 
-        nwipe_log( NWIPE_LOG_NOTICE, "Blanking device '%s'.", c->device_name );
+        nwipe_log( NWIPE_LOG_NOTICE, "Blanking device %s", c->device_name );
 
         /* The final zero pass. */
         r = nwipe_static_pass( c, &pattern_zero );
@@ -986,7 +986,7 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
 
         if( nwipe_options.verify == NWIPE_VERIFY_LAST || nwipe_options.verify == NWIPE_VERIFY_ALL )
         {
-            nwipe_log( NWIPE_LOG_NOTICE, "Verifying that '%s' is empty.", c->device_name );
+            nwipe_log( NWIPE_LOG_NOTICE, "Verifying that %s is empty.", c->device_name );
 
             /* Verify the final zero pass. */
             r = nwipe_static_verify( c, &pattern_zero );
@@ -997,10 +997,10 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
                 return r;
             }
 
-            nwipe_log( NWIPE_LOG_NOTICE, "Verified that '%s' is empty.", c->device_name );
+            nwipe_log( NWIPE_LOG_NOTICE, "[SUCCESS] Verified that %s is empty.", c->device_name );
         }
 
-        nwipe_log( NWIPE_LOG_NOTICE, "Blanked device '%s'.", c->device_name );
+        nwipe_log( NWIPE_LOG_NOTICE, "[SUCCESS] Blanked device %s", c->device_name );
 
     } /* final blank */
 
@@ -1014,13 +1014,13 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
     if( c->verify_errors > 0 )
     {
         /* We finished, but with non-fatal verification errors. */
-        nwipe_log( NWIPE_LOG_ERROR, "%llu verification errors on device '%s'.", c->verify_errors, c->device_name );
+        nwipe_log( NWIPE_LOG_ERROR, "%llu verification errors on '%s'.", c->verify_errors, c->device_name );
     }
 
     if( c->pass_errors > 0 )
     {
         /* We finished, but with non-fatal wipe errors. */
-        nwipe_log( NWIPE_LOG_ERROR, "%llu wipe errors on device '%s'.", c->pass_errors, c->device_name );
+        nwipe_log( NWIPE_LOG_ERROR, "%llu wipe errors on '%s'.", c->pass_errors, c->device_name );
     }
 
     /* FIXME: The 'round_errors' context member is not being used. */

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -317,13 +317,13 @@ int main( int argc, char** argv )
         /* Do sector size and block size checking. */
         if( ioctl( c2[i]->device_fd, BLKSSZGET, &c2[i]->device_sector_size ) == 0 )
         {
-            nwipe_log(
-                NWIPE_LOG_INFO, "Device '%s' has sector size %i.", c2[i]->device_name, c2[i]->device_sector_size );
+            //nwipe_log(
+                //NWIPE_LOG_INFO, "Device '%s' has sector size %i.", c2[i]->device_name, c2[i]->device_sector_size );
 
             if( ioctl( c2[i]->device_fd, BLKBSZGET, &c2[i]->device_block_size ) == 0 )
             {
-                nwipe_log(
-                    NWIPE_LOG_INFO, "Device '%s' has block size %i.", c2[i]->device_name, c2[i]->device_block_size );
+                //nwipe_log(
+                    //NWIPE_LOG_INFO, "Device '%s' has block size %i.", c2[i]->device_name, c2[i]->device_block_size );
             }
             else
             {
@@ -386,13 +386,13 @@ int main( int argc, char** argv )
 
         if( c2[i]->device_size == 0 )
         {
-            nwipe_log( NWIPE_LOG_ERROR, "Device '%s' is size %llu.", c2[i]->device_name, c2[i]->device_size );
+            nwipe_log( NWIPE_LOG_ERROR, "%s, sect/blk/dev %llu/%i/%i", c2[i]->device_name, c2[i]->device_sector_size, c2[i]->device_block_size,  c2[i]->device_size );
             nwipe_error++;
             continue;
         }
         else
         {
-            nwipe_log( NWIPE_LOG_INFO, "Device '%s' is size %llu.", c2[i]->device_name, c2[i]->device_size );
+            nwipe_log( NWIPE_LOG_NOTICE, "%s, sect/blk/dev %llu/%i/%i", c2[i]->device_name, c2[i]->device_sector_size, c2[i]->device_block_size,  c2[i]->device_size );
         }
 
         /* Fork a child process. */


### PR DESCRIPTION
1. Keep nwipe_log notices succinct and below 80 chars in length including
timestamp. This is especially relevant for 80x30 terminal use such
as ALT-F2 etc or Shredos without losing any information.

2. Add [SUCCESS] to blanked & verified messages to make them stand out for quicker checking.

3. Combine the three sector size, block size, device size into a single message for each device.

These changes are most relevant when wiping many drives simultaneously.

**Example after changes**
> [2020/03/13 16:44:34] notice: Found /dev/loop13, Loopback device, 1074MB, S/N=
[2020/03/13 16:44:34] notice: Found /dev/loop14, Loopback device, 1074MB, S/N=
[2020/03/13 16:44:34] notice: Found /dev/loop15, Loopback device, 1074MB, S/N=
[2020/03/13 16:44:34] notice: Found /dev/loop16, Loopback device, 524MB, S/N=
[2020/03/13 16:44:35] notice: Found /dev/loop17, Loopback device, 524MB, S/N=
[2020/03/13 16:44:35] notice: Found /dev/loop18, Loopback device, 524MB, S/N=
[2020/03/13 16:44:35] notice: Found /dev/loop19, Loopback device, 524MB, S/N=
[2020/03/13 16:44:35] notice: Found /dev/loop20, Loopback device, 524MB, S/N=
[2020/03/13 16:44:35] notice: Found /dev/loop21, Loopback device, 524MB, S/N=
[2020/03/13 16:44:35] notice: Found /dev/loop22, Loopback device, 524MB, S/N=
[2020/03/13 16:44:35] notice: Found /dev/loop23, Loopback device, 524MB, S/N=
[2020/03/13 16:44:35] notice: Found /dev/loop24, Loopback device, 524MB, S/N=
[2020/03/13 16:44:35] notice: Found /dev/loop25, Loopback device, 524MB, S/N=
[2020/03/13 16:44:36] notice: Found /dev/loop26, Loopback device, 524MB, S/N=
[2020/03/13 16:44:36] notice: bios-version = E16F2IM7 V5.0E
[2020/03/13 16:44:36] notice: bios-release-date = 01/10/2012
[2020/03/13 16:44:36] notice: system-manufacturer = MEDION
[2020/03/13 16:44:36] notice: system-product-name = X681X
[2020/03/13 16:44:36] notice: system-version = To be filled by O.E.M.
[2020/03/13 16:44:36] notice: system-serial-number = To be filled by O.E.M.
[2020/03/13 16:44:36] notice: system-uuid = 03000200-0400-0500-0006-000700080009
[2020/03/13 16:44:36] notice: baseboard-manufacturer = MEDION
[2020/03/13 16:44:36] notice: baseboard-product-name = X681X
[2020/03/13 16:44:36] notice: baseboard-version = To be filled by O.E.M.
[2020/03/13 16:44:36] notice: baseboard-serial-number = To be filled by O.E.M.
[2020/03/13 16:44:36] notice: baseboard-asset-tag = To be filled by O.E.M.
[2020/03/13 16:44:36] notice: chassis-manufacturer = To Be Filled By O.E.M.
[2020/03/13 16:44:36] notice: chassis-type = Notebook
[2020/03/13 16:44:36] notice: chassis-version = To be filled by O.E.M.
[2020/03/13 16:44:36] notice: chassis-serial-number = To Be Filled By O.E.M.
[2020/03/13 16:44:36] notice: chassis-asset-tag = To Be Filled By O.E.M.
[2020/03/13 16:44:36] notice: processor-family = Core i7
[2020/03/13 16:44:36] notice: processor-manufacturer = Intel
[2020/03/13 16:44:36] notice: processor-version = Intel(R) Core(TM) i7-2670QM CPU @ 2.20GHz
[2020/03/13 16:44:36] notice: processor-frequency = 800 MHz
[2020/03/13 16:44:36] notice: Opened entropy source '/dev/urandom'.
[2020/03/13 16:44:46] notice: /dev/loop13, sect/blk/dev 512/4096/1073741824
[2020/03/13 16:44:46] notice: /dev/loop14, sect/blk/dev 512/4096/1073741824
[2020/03/13 16:44:46] notice: Invoking method 'Zero Fill' on /dev/loop13
[2020/03/13 16:44:46] notice: Starting round 1 of 1 on /dev/loop13
[2020/03/13 16:44:46] notice: Starting pass 1/1, round 1/1, on /dev/loop13
[2020/03/13 16:44:46] notice: /dev/loop15, sect/blk/dev 512/4096/1073741824
[2020/03/13 16:44:46] notice: Invoking method 'Zero Fill' on /dev/loop14
[2020/03/13 16:44:46] notice: Starting round 1 of 1 on /dev/loop14
[2020/03/13 16:44:46] notice: Starting pass 1/1, round 1/1, on /dev/loop14
[2020/03/13 16:44:46] notice: Invoking method 'Zero Fill' on /dev/loop15
[2020/03/13 16:44:46] notice: Starting round 1 of 1 on /dev/loop15
[2020/03/13 16:44:46] notice: /dev/loop16, sect/blk/dev 512/4096/524288000
[2020/03/13 16:44:46] notice: Starting pass 1/1, round 1/1, on /dev/loop15
[2020/03/13 16:44:46] notice: /dev/loop17, sect/blk/dev 512/4096/524288000
[2020/03/13 16:44:46] notice: Invoking method 'Zero Fill' on /dev/loop16
[2020/03/13 16:44:46] notice: Starting round 1 of 1 on /dev/loop16
[2020/03/13 16:44:46] notice: Starting pass 1/1, round 1/1, on /dev/loop16
[2020/03/13 16:44:46] notice: /dev/loop18, sect/blk/dev 512/4096/524288000
[2020/03/13 16:44:46] notice: Invoking method 'Zero Fill' on /dev/loop17
[2020/03/13 16:44:46] notice: Starting round 1 of 1 on /dev/loop17
[2020/03/13 16:44:46] notice: Starting pass 1/1, round 1/1, on /dev/loop17
[2020/03/13 16:44:46] notice: /dev/loop19, sect/blk/dev 512/4096/524288000
[2020/03/13 16:44:46] notice: Invoking method 'Zero Fill' on /dev/loop18
[2020/03/13 16:44:46] notice: Starting round 1 of 1 on /dev/loop18
[2020/03/13 16:44:46] notice: Starting pass 1/1, round 1/1, on /dev/loop18
[2020/03/13 16:44:46] notice: /dev/loop20, sect/blk/dev 512/4096/524288000
[2020/03/13 16:44:46] notice: /dev/loop21, sect/blk/dev 512/4096/524288000
[2020/03/13 16:44:46] notice: /dev/loop22, sect/blk/dev 512/4096/524288000
[2020/03/13 16:44:46] notice: /dev/loop23, sect/blk/dev 512/4096/524288000
[2020/03/13 16:44:46] notice: /dev/loop24, sect/blk/dev 512/4096/524288000
[2020/03/13 16:44:46] notice: /dev/loop25, sect/blk/dev 512/4096/524288000
[2020/03/13 16:44:46] notice: /dev/loop26, sect/blk/dev 512/4096/524288000
[2020/03/13 16:44:46] notice: Invoking method 'Zero Fill' on /dev/loop19
[2020/03/13 16:44:46] notice: Starting round 1 of 1 on /dev/loop19
[2020/03/13 16:44:46] notice: Starting pass 1/1, round 1/1, on /dev/loop19
[2020/03/13 16:44:46] notice: Invoking method 'Zero Fill' on /dev/loop23
[2020/03/13 16:44:46] notice: Starting round 1 of 1 on /dev/loop23
[2020/03/13 16:44:46] notice: Starting pass 1/1, round 1/1, on /dev/loop23
[2020/03/13 16:44:46] notice: Invoking method 'Zero Fill' on /dev/loop24
[2020/03/13 16:44:46] notice: Starting round 1 of 1 on /dev/loop24
[2020/03/13 16:44:46] notice: Starting pass 1/1, round 1/1, on /dev/loop24
[2020/03/13 16:44:46] notice: Invoking method 'Zero Fill' on /dev/loop21
[2020/03/13 16:44:46] notice: Starting round 1 of 1 on /dev/loop21
[2020/03/13 16:44:46] notice: Starting pass 1/1, round 1/1, on /dev/loop21
[2020/03/13 16:44:46] notice: Invoking method 'Zero Fill' on /dev/loop20
[2020/03/13 16:44:46] notice: Starting round 1 of 1 on /dev/loop20
[2020/03/13 16:44:46] notice: Invoking method 'Zero Fill' on /dev/loop25
[2020/03/13 16:44:46] notice: Starting round 1 of 1 on /dev/loop25
[2020/03/13 16:44:46] notice: Starting pass 1/1, round 1/1, on /dev/loop25
[2020/03/13 16:44:46] notice: Invoking method 'Zero Fill' on /dev/loop22
[2020/03/13 16:44:46] notice: Starting round 1 of 1 on /dev/loop22
[2020/03/13 16:44:46] notice: Starting pass 1/1, round 1/1, on /dev/loop22
[2020/03/13 16:44:46] notice: Starting pass 1/1, round 1/1, on /dev/loop20
[2020/03/13 16:44:46] notice: Invoking method 'Zero Fill' on /dev/loop26
[2020/03/13 16:44:46] notice: Starting round 1 of 1 on /dev/loop26
[2020/03/13 16:44:46] notice: Starting pass 1/1, round 1/1, on /dev/loop26
[2020/03/13 16:45:42] notice: 524288000 bytes written to /dev/loop21
[2020/03/13 16:45:42] notice: Finished pass 1/1, round 1/1, on /dev/loop21
[2020/03/13 16:45:42] notice: Finished round 1 of 1 on /dev/loop21
[2020/03/13 16:45:42] notice: Blanking device /dev/loop21
[2020/03/13 16:46:03] notice: 524288000 bytes written to /dev/loop23
[2020/03/13 16:46:03] notice: Finished pass 1/1, round 1/1, on /dev/loop23
[2020/03/13 16:46:03] notice: Finished round 1 of 1 on /dev/loop23
[2020/03/13 16:46:03] notice: Blanking device /dev/loop23
[2020/03/13 16:46:08] notice: 524288000 bytes written to /dev/loop17
[2020/03/13 16:46:08] notice: Finished pass 1/1, round 1/1, on /dev/loop17
[2020/03/13 16:46:08] notice: Finished round 1 of 1 on /dev/loop17
[2020/03/13 16:46:08] notice: Blanking device /dev/loop17
[2020/03/13 16:46:22] notice: 524288000 bytes written to /dev/loop20
[2020/03/13 16:46:22] notice: Finished pass 1/1, round 1/1, on /dev/loop20
[2020/03/13 16:46:22] notice: Finished round 1 of 1 on /dev/loop20
[2020/03/13 16:46:22] notice: Blanking device /dev/loop20
[2020/03/13 16:46:43] notice: 524288000 bytes written to /dev/loop19
[2020/03/13 16:46:43] notice: Finished pass 1/1, round 1/1, on /dev/loop19
[2020/03/13 16:46:43] notice: Finished round 1 of 1 on /dev/loop19
[2020/03/13 16:46:43] notice: Blanking device /dev/loop19
[2020/03/13 16:46:44] notice: 524288000 bytes written to /dev/loop22
[2020/03/13 16:46:44] notice: Finished pass 1/1, round 1/1, on /dev/loop22
[2020/03/13 16:46:44] notice: Finished round 1 of 1 on /dev/loop22
[2020/03/13 16:46:44] notice: Blanking device /dev/loop22
[2020/03/13 16:46:44] notice: 524288000 bytes written to /dev/loop26
[2020/03/13 16:46:44] notice: Finished pass 1/1, round 1/1, on /dev/loop26
[2020/03/13 16:46:44] notice: Finished round 1 of 1 on /dev/loop26
[2020/03/13 16:46:44] notice: Blanking device /dev/loop26
[2020/03/13 16:46:59] notice: 524288000 bytes written to /dev/loop16
[2020/03/13 16:46:59] notice: Finished pass 1/1, round 1/1, on /dev/loop16
[2020/03/13 16:46:59] notice: Finished round 1 of 1 on /dev/loop16
[2020/03/13 16:46:59] notice: Blanking device /dev/loop16
[2020/03/13 16:47:03] notice: 1073741824 bytes written to /dev/loop14
[2020/03/13 16:47:03] notice: Finished pass 1/1, round 1/1, on /dev/loop14
[2020/03/13 16:47:03] notice: Finished round 1 of 1 on /dev/loop14
[2020/03/13 16:47:03] notice: Blanking device /dev/loop14
[2020/03/13 16:47:05] notice: Verifying that /dev/loop21 is empty.
[2020/03/13 16:47:24] notice: 524288000 bytes written to /dev/loop24
[2020/03/13 16:47:24] notice: Finished pass 1/1, round 1/1, on /dev/loop24
[2020/03/13 16:47:24] notice: Finished round 1 of 1 on /dev/loop24
[2020/03/13 16:47:24] notice: Blanking device /dev/loop24
[2020/03/13 16:47:24] notice: 524288000 bytes written to /dev/loop25
[2020/03/13 16:47:24] notice: Finished pass 1/1, round 1/1, on /dev/loop25
[2020/03/13 16:47:24] notice: Finished round 1 of 1 on /dev/loop25
[2020/03/13 16:47:24] notice: Blanking device /dev/loop25
[2020/03/13 16:47:30] notice: Verifying that /dev/loop20 is empty.
[2020/03/13 16:47:51] notice: Verifying that /dev/loop19 is empty.
[2020/03/13 16:47:55] notice: [SUCCESS] Verified that /dev/loop20 is empty.
[2020/03/13 16:47:55] notice: [SUCCESS] Blanked device /dev/loop20
[2020/03/13 16:47:56] notice: 524288000 bytes written to /dev/loop18
[2020/03/13 16:47:56] notice: Finished pass 1/1, round 1/1, on /dev/loop18
[2020/03/13 16:47:56] notice: Finished round 1 of 1 on /dev/loop18
[2020/03/13 16:47:56] notice: Blanking device /dev/loop18
[2020/03/13 16:47:59] notice: Verifying that /dev/loop26 is empty.
[2020/03/13 16:48:00] notice: Verifying that /dev/loop23 is empty.
[2020/03/13 16:48:11] notice: Verifying that /dev/loop17 is empty.
[2020/03/13 16:48:13] notice: 1073741824 bytes written to /dev/loop13
[2020/03/13 16:48:13] notice: Finished pass 1/1, round 1/1, on /dev/loop13
[2020/03/13 16:48:13] notice: Finished round 1 of 1 on /dev/loop13
[2020/03/13 16:48:13] notice: Blanking device /dev/loop13
[2020/03/13 16:48:17] notice: Verifying that /dev/loop22 is empty.
[2020/03/13 16:48:29] notice: Verifying that /dev/loop16 is empty.
[2020/03/13 16:48:38] notice: [SUCCESS] Verified that /dev/loop16 is empty.
[2020/03/13 16:48:38] notice: [SUCCESS] Blanked device /dev/loop16
[2020/03/13 16:48:44] notice: [SUCCESS] Verified that /dev/loop19 is empty.
[2020/03/13 16:48:44] notice: [SUCCESS] Blanked device /dev/loop19
[2020/03/13 16:48:59] notice: [SUCCESS] Verified that /dev/loop26 is empty.
[2020/03/13 16:48:59] notice: [SUCCESS] Blanked device /dev/loop26
[2020/03/13 16:49:05] notice: [SUCCESS] Verified that /dev/loop23 is empty.
[2020/03/13 16:49:05] notice: [SUCCESS] Blanked device /dev/loop23
[2020/03/13 16:49:06] notice: [SUCCESS] Verified that /dev/loop21 is empty.
[2020/03/13 16:49:06] notice: [SUCCESS] Blanked device /dev/loop21
[2020/03/13 16:49:07] notice: [SUCCESS] Verified that /dev/loop17 is empty.
[2020/03/13 16:49:07] notice: [SUCCESS] Blanked device /dev/loop17
[2020/03/13 16:49:08] notice: 1073741824 bytes written to /dev/loop15
[2020/03/13 16:49:08] notice: Finished pass 1/1, round 1/1, on /dev/loop15
[2020/03/13 16:49:08] notice: Finished round 1 of 1 on /dev/loop15
[2020/03/13 16:49:08] notice: Blanking device /dev/loop15
[2020/03/13 16:49:09] notice: Verifying that /dev/loop24 is empty.
[2020/03/13 16:49:09] notice: Verifying that /dev/loop18 is empty.
[2020/03/13 16:49:17] notice: [SUCCESS] Verified that /dev/loop22 is empty.
[2020/03/13 16:49:17] notice: [SUCCESS] Blanked device /dev/loop22
[2020/03/13 16:49:17] notice: Verifying that /dev/loop25 is empty.
[2020/03/13 16:49:24] notice: [SUCCESS] Verified that /dev/loop25 is empty.
[2020/03/13 16:49:24] notice: [SUCCESS] Blanked device /dev/loop25
[2020/03/13 16:49:31] notice: Verifying that /dev/loop14 is empty.
[2020/03/13 16:49:38] notice: [SUCCESS] Verified that /dev/loop24 is empty.
[2020/03/13 16:49:38] notice: [SUCCESS] Blanked device /dev/loop24
[2020/03/13 16:49:46] notice: [SUCCESS] Verified that /dev/loop18 is empty.
[2020/03/13 16:49:46] notice: [SUCCESS] Blanked device /dev/loop18
[2020/03/13 16:49:48] notice: [SUCCESS] Verified that /dev/loop14 is empty.
[2020/03/13 16:49:48] notice: [SUCCESS] Blanked device /dev/loop14
[2020/03/13 16:49:48] notice: Verifying that /dev/loop13 is empty.
[2020/03/13 16:49:49] notice: [SUCCESS] Verified that /dev/loop13 is empty.
[2020/03/13 16:49:49] notice: [SUCCESS] Blanked device /dev/loop13
[2020/03/13 16:49:51] notice: Verifying that /dev/loop15 is empty.
[2020/03/13 16:49:57] notice: [SUCCESS] Verified that /dev/loop15 is empty.
[2020/03/13 16:49:57] notice: [SUCCESS] Blanked device /dev/loop15
[2020/03/13 16:51:07] info: Exit in progress
[2020/03/13 16:51:08] info: Nwipe successfully exited.