### PR TITLE
Add a spinner to the GUI for each drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ other items in 0.29 are proposed and yet to be implemented.
 - [DONE] Add auto power off option on completion of wipe ( --autopoweroff ) (Thanks PartialVolume)
 - [DONE] Fix --nowait option that wasn't working. (Thanks PartialVolume)
 - [DONE] Add verbose option. -v, --verbose.
+- [DONE] Add a spinner to the GUI for each drive being wiped. When nwipe is syncing the percentage completion pauses, having a spinner gives a clear indication that the wipe is still running. Each devices spinner disappears on completion of a given devices wipe.
 - Add enhancement fibre channel wiping of non 512 bytes/sector drives such as 524/528 bytes/sector etc (work in progress by PartialVolume)
 - HPA/DCO detection and adjustment to wipe full drive. (work in progress by PartialVolume)
 

--- a/src/context.h
+++ b/src/context.h
@@ -118,6 +118,8 @@ typedef struct nwipe_context_t_
     u64 throughput;  // Average throughput in bytes per second.
     u64 verify_errors;  // The number of verification errors across all passes.
     int wipe_status;  // Wipe finished = 0, wipe in progress = 1, wipe yet to start = -1.
+    int spinner_idx;  // Index into the spinner character array
+    char spinner_character[1];  // The current spinner character
     /*
      * Identity contains the raw serial number of the drive
      * (where applicable), however, for use within nwipe use the

--- a/src/gui.c
+++ b/src/gui.c
@@ -2089,6 +2089,9 @@ void* nwipe_gui_status( void* ptr )
     /* The throughput format pointer. */
     char* nwipe_format;
 
+    /* Spinner character */
+    char spinner_string[2];
+
     /* We count time from when this function is first called. */
     static time_t nwipe_time_start = 0;
 
@@ -2449,6 +2452,20 @@ void* nwipe_gui_status( void* ptr )
 
                 /* Insert whitespace. */
                 yy += 1;
+
+                /* Increment the next spinner character for this context if the thread is active */
+                if( c[i]->wipe_status == 1 )
+                {
+                    spinner( c, i );
+                    spinner_string[0] = c[i]->spinner_character[0];
+                }
+                else
+                {
+                    /* if the wipe thread is no longer active, replace the spinner with a space */
+                    spinner_string[0] = ' ';
+                }
+                spinner_string[1] = 0;
+                wprintw( main_window, " %s ", spinner_string );
             }
 
             if( offset > 0 )
@@ -2703,4 +2720,31 @@ void nwipe_update_speedring( nwipe_speedring_t* speedring, u64 speedring_bytes, 
     {
         speedring->position = 0;
     }
+}
+
+int spinner( nwipe_context_t** ptr, int device_idx )
+{
+    nwipe_context_t** c;
+
+    c = ptr;
+
+    /* The spinner characters |/-\|/-\ */
+    char sc[9] = "|/-\\|/-\\/";
+
+    /* check sanity of index */
+    if( c[device_idx]->spinner_idx < 0 || c[device_idx]->spinner_idx > 7 )
+    {
+        return 1;
+    }
+
+    c[device_idx]->spinner_character[0] = sc[c[device_idx]->spinner_idx];
+
+    c[device_idx]->spinner_idx++;
+
+    if( c[device_idx]->spinner_idx > 7 )
+    {
+        c[device_idx]->spinner_idx = 0;
+    }
+
+    return 0;
 }

--- a/src/gui.h
+++ b/src/gui.h
@@ -40,6 +40,7 @@ void nwipe_gui_prng( void );  // Change the prng option.
 void nwipe_gui_rounds( void );  // Change the rounds option.
 void nwipe_gui_verify( void );  // Change the verify option.
 void nwipe_gui_noblank( void );  // Change the noblank option.
+int spinner( nwipe_context_t** ptr, int );  // Return the next spinner character
 
 int compute_stats( void* ptr );
 void nwipe_update_speedring( nwipe_speedring_t* speedring, u64 speedring_done, time_t speedring_now );

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -265,6 +265,8 @@ int main( int argc, char** argv )
         /* A result buffer for the BLKGETSIZE64 ioctl. */
         u64 size64;
 
+        c2[i]->spinner_idx = 0;
+
         /* Initialise the wipe_status flag, -1 = wipe not yet started */
         c2[i]->wipe_status = -1;
 


### PR DESCRIPTION
Add a spinner to the GUI for each drive being wiped.
When nwipe is syncing the percentage completion pauses,
having a spinner gives a clear indication that the wipe
is still running. Each devices spinner disappears on completion
of a given devices wipe.

![nwipe4](https://user-images.githubusercontent.com/22084881/76669690-aebe0a80-6584-11ea-8e31-45c286564404.gif)
