### PR TITLE
Add a summary table to the log that shows each drives status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ other items in 0.29 are proposed and yet to be implemented.
 - [DONE] Add verbose option. -v, --verbose.
 - [DONE] Add a spinner to the GUI for each drive being wiped. When nwipe is syncing the percentage completion pauses, having a spinner gives a clear indication that the wipe is still running. Each devices spinner disappears on completion of a given devices wipe.
 - [DONE] Make log messages, especially the ones with the tag 'notice' succinct and less than 80 characters including the timestamp. This is of more importance when nwipe is used on a 80x30 terminal (ALT-F2, Shredos etc) but generally makes the logs more readable. While doing this all information was still retained.
-
+- [DONE] Add a summary table to the log that shows each drives status, i.e. erased or failed, throughput, duration of wipe, model, serial no etc. In particular it benefits
+those that wipe many drives simultaneously in rack servers. At a glance any failed drives can be seen without having to browse back through the log.
 - Add enhancement fibre channel wiping of non 512 bytes/sector drives such as 524/528 bytes/sector etc (work in progress by PartialVolume)
 - HPA/DCO detection and adjustment to wipe full drive. (work in progress by PartialVolume)
 

--- a/src/context.h
+++ b/src/context.h
@@ -120,6 +120,9 @@ typedef struct nwipe_context_t_
     int wipe_status;  // Wipe finished = 0, wipe in progress = 1, wipe yet to start = -1.
     int spinner_idx;  // Index into the spinner character array
     char spinner_character[1];  // The current spinner character
+    double duration;  // Duration of the wipe in seconds
+    time_t start_time;  // Start time of wipe
+    time_t end_time;  // End time of wipe
     /*
      * Identity contains the raw serial number of the drive
      * (where applicable), however, for use within nwipe use the

--- a/src/logging.h
+++ b/src/logging.h
@@ -32,11 +32,14 @@ typedef enum nwipe_log_t_ {
     NWIPE_LOG_WARNING,  // Things that the user should know about.
     NWIPE_LOG_ERROR,  // Non-fatal errors that result in failure.
     NWIPE_LOG_FATAL,  // Errors that cause the program to exit.
-    NWIPE_LOG_SANITY  // Programming errors.
+    NWIPE_LOG_SANITY,  // Programming errors.
+    NWIPE_LOG_NOTIMESTAMP  // logs the message without the timestamp
 } nwipe_log_t;
 
 void nwipe_log( nwipe_log_t level, const char* format, ... );
 void nwipe_perror( int nwipe_errno, const char* f, const char* s );
 int nwipe_log_sysinfo();
+void nwipe_log_summary( nwipe_context_t**, int );  // This produces the wipe status table on exit
+void Determine_bandwidth_nomenclature( u64, char*, int );
 
 #endif /* LOGGING_H_ */

--- a/src/method.c
+++ b/src/method.c
@@ -123,6 +123,9 @@ void* nwipe_zero( void* ptr )
     nwipe_context_t* c;
     c = (nwipe_context_t*) ptr;
 
+    /* get current time at the start of the wipe  */
+    time( &c->start_time );
+
     /* set wipe in progress flag for GUI */
     c->wipe_status = 1;
 
@@ -138,6 +141,9 @@ void* nwipe_zero( void* ptr )
     /* Finished. Set the wipe_status flag so that the GUI knows */
     c->wipe_status = 0;
 
+    /* get current time at the end of the wipe  */
+    time( &c->end_time );
+
     return NULL;
 } /* nwipe_zero */
 
@@ -149,6 +155,9 @@ void* nwipe_verify( void* ptr )
 
     nwipe_context_t* c;
     c = (nwipe_context_t*) ptr;
+
+    /* get current time at the start of the wipe  */
+    time( &c->start_time );
 
     /* set wipe in progress flag for GUI */
     c->wipe_status = 1;
@@ -162,6 +171,9 @@ void* nwipe_verify( void* ptr )
     /* Finished. Set the wipe_status flag so that the GUI knows */
     c->wipe_status = 0;
 
+    /* get current time at the end of the wipe  */
+    time( &c->end_time );
+
     return NULL;
 } /* nwipe_verify */
 
@@ -174,6 +186,9 @@ void* nwipe_dod522022m( void* ptr )
 
     nwipe_context_t* c;
     c = (nwipe_context_t*) ptr;
+
+    /* get current time at the start of the wipe  */
+    time( &c->start_time );
 
     /* set wipe in progress flag for GUI */
     c->wipe_status = 1;
@@ -230,6 +245,9 @@ void* nwipe_dod522022m( void* ptr )
     /* Finished. Set the wipe_status flag so that the GUI knows */
     c->wipe_status = 0;
 
+    /* get current time at the end of the wipe  */
+    time( &c->end_time );
+
     return NULL;
 } /* nwipe_dod522022m */
 
@@ -243,6 +261,9 @@ void* nwipe_dodshort( void* ptr )
 
     nwipe_context_t* c;
     c = (nwipe_context_t*) ptr;
+
+    /* get current time at the start of the wipe  */
+    time( &c->start_time );
 
     /* set wipe in progress flag for GUI */
     c->wipe_status = 1;
@@ -292,6 +313,9 @@ void* nwipe_dodshort( void* ptr )
     /* Finished. Set the wipe_status flag so that the GUI knows */
     c->wipe_status = 0;
 
+    /* get current time at the end of the wipe  */
+    time( &c->end_time );
+
     return NULL;
 } /* nwipe_dodshort */
 
@@ -304,6 +328,9 @@ void* nwipe_gutmann( void* ptr )
 
     nwipe_context_t* c;
     c = (nwipe_context_t*) ptr;
+
+    /* get current time at the start of the wipe  */
+    time( &c->start_time );
 
     /* set wipe in progress flag for GUI */
     c->wipe_status = 1;
@@ -426,6 +453,9 @@ void* nwipe_gutmann( void* ptr )
     /* Finished. Set the wipe_status flag so that the GUI knows */
     c->wipe_status = 0;
 
+    /* get current time at the end of the wipe  */
+    time( &c->end_time );
+
     return NULL;
 } /* nwipe_gutmann */
 
@@ -442,6 +472,9 @@ void* nwipe_ops2( void* ptr )
 
     nwipe_context_t* c;
     c = (nwipe_context_t*) ptr;
+
+    /* get current time at the start of the wipe  */
+    time( &c->start_time );
 
     /* set wipe in progress flag for GUI */
     c->wipe_status = 1;
@@ -588,12 +621,19 @@ void* nwipe_ops2( void* ptr )
     /* Finished. Set the wipe_status flag so that the GUI knows */
     c->wipe_status = 0;
 
+    /* get current time at the end of the wipe  */
+    time( &c->end_time );
+
     return NULL;
 } /* nwipe_ops2 */
 
 void* nwipe_is5enh( void* ptr )
 {
     nwipe_context_t* c = (nwipe_context_t*) ptr;
+
+    /* get current time at the start of the wipe  */
+    time( &c->start_time );
+
     c->wipe_status = 1;
 
     char is5enh[3] = {'\x00', '\xFF', '\x00'};
@@ -604,6 +644,10 @@ void* nwipe_is5enh( void* ptr )
     c->result = nwipe_runmethod( c, patterns );
 
     c->wipe_status = 0;
+
+    /* get current time at the end of the wipe  */
+    time( &c->end_time );
+
     return NULL;
 } /* nwipe_is5enh */
 
@@ -617,6 +661,9 @@ void* nwipe_random( void* ptr )
     nwipe_context_t* c;
     c = (nwipe_context_t*) ptr;
 
+    /* get current time at the start of the wipe  */
+    time( &c->start_time );
+
     /* set wipe in progress flag for GUI */
     c->wipe_status = 1;
 
@@ -628,6 +675,9 @@ void* nwipe_random( void* ptr )
 
     /* Finished. Set the wipe_status flag so that the GUI knows */
     c->wipe_status = 0;
+
+    /* get current time at the end of the wipe  */
+    time( &c->end_time );
 
     return NULL;
 } /* nwipe_random */
@@ -879,8 +929,19 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
 
         } /* for passes */
 
-        nwipe_log(
-            NWIPE_LOG_NOTICE, "Finished round %i of %i on %s", c->round_working, c->round_count, c->device_name );
+        if( c->round_working < c->round_count )
+        {
+            nwipe_log(
+                NWIPE_LOG_NOTICE, "Finished round %i of %i on %s", c->round_working, c->round_count, c->device_name );
+        }
+        else
+        {
+            nwipe_log( NWIPE_LOG_NOTICE,
+                       "Finished final round %i of %i on %s",
+                       c->round_working,
+                       c->round_count,
+                       c->device_name );
+        }
 
     } /* while rounds */
 
@@ -955,8 +1016,14 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
         {
             return r;
         }
-
-        nwipe_log( NWIPE_LOG_NOTICE, "[SUCCESS] Verified that %s is empty.", c->device_name );
+        if( c->verify_errors == 0 )
+        {
+            nwipe_log( NWIPE_LOG_NOTICE, "[SUCCESS] Verified that %s is empty.", c->device_name );
+        }
+        else
+        {
+            nwipe_log( NWIPE_LOG_ERROR, "[FAILURE] %s IS NOT empty.", c->device_name );
+        }
 
     } /* verify */
 
@@ -989,7 +1056,14 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
                 return r;
             }
 
-            nwipe_log( NWIPE_LOG_NOTICE, "[SUCCESS] Verified that %s is empty.", c->device_name );
+            if( c->verify_errors == 0 )
+            {
+                nwipe_log( NWIPE_LOG_NOTICE, "[SUCCESS] Verified that %s is empty.", c->device_name );
+            }
+            else
+            {
+                nwipe_log( NWIPE_LOG_NOTICE, "[FAILURE] %s Verification errors, not empty", c->device_name );
+            }
         }
 
         nwipe_log( NWIPE_LOG_NOTICE, "[SUCCESS] Blanked device %s", c->device_name );

--- a/src/nwipe.h
+++ b/src/nwipe.h
@@ -68,7 +68,7 @@ void* signal_hand( void* );
 #include <time.h>
 #include <unistd.h>
 
-#include "config.h"
+/*#include "config.h"*/
 
 /* System errors. */
 extern int errno;

--- a/src/prng.c
+++ b/src/prng.c
@@ -19,6 +19,7 @@
 
 #include "nwipe.h"
 #include "prng.h"
+#include "context.h"
 #include "logging.h"
 
 #include "mt19937ar-cok/mt19937ar-cok.h"


### PR DESCRIPTION
Add a summary table to the log that shows each drives status
i.e. erased or failed, throughput, duration of wipe, model,
serial no etc. In particular it benefits those that wipe many
drives simultaneously in rack servers. At a glance any failed
drives can be seen without having to browse back through the
log. Especially useful in --nogui mode, but also useful in GUI
mode.

Single drive example (15 drive example further down)
```
[2020/03/18 17:59:56] notice: Device /dev/sda excluded as per command line optio
[2020/03/18 17:59:56] notice: Device /dev/sdb excluded as per command line optio
[2020/03/18 17:59:56] notice: Found /dev/sdc, ATA WDC WD1600AAJS-2, 160GB, S/N=W
[2020/03/18 17:59:56] notice: Device /dev/mapper/cryptswap1 excluded as per comm
[2020/03/18 17:59:56] info: Automatically enumerated 1 devices.
[2020/03/18 17:59:56] notice: bios-version = E16F2IM7 V5.0E
[2020/03/18 17:59:56] notice: bios-release-date = 01/10/2012
[2020/03/18 17:59:56] notice: system-manufacturer = MEDION
[2020/03/18 17:59:56] notice: system-product-name = X681X
[2020/03/18 17:59:56] notice: system-version = To be filled by O.E.M.
[2020/03/18 17:59:56] notice: system-serial-number = To be filled by O.E.M.
[2020/03/18 17:59:56] notice: system-uuid = 03000200-0400-0500-0006-000700080009
[2020/03/18 17:59:56] notice: baseboard-manufacturer = MEDION
[2020/03/18 17:59:56] notice: baseboard-product-name = X681X
[2020/03/18 17:59:56] notice: baseboard-version = To be filled by O.E.M.
[2020/03/18 17:59:56] notice: baseboard-serial-number = To be filled by O.E.M.
[2020/03/18 17:59:56] notice: baseboard-asset-tag = To be filled by O.E.M.
[2020/03/18 17:59:56] notice: chassis-manufacturer = To Be Filled By O.E.M.
[2020/03/18 17:59:56] notice: chassis-type = Notebook
[2020/03/18 17:59:56] notice: chassis-version = To be filled by O.E.M.
[2020/03/18 17:59:56] notice: chassis-serial-number = To Be Filled By O.E.M.
[2020/03/18 17:59:56] notice: chassis-asset-tag = To Be Filled By O.E.M.
[2020/03/18 17:59:56] notice: processor-family = Core i7
[2020/03/18 17:59:56] notice: processor-manufacturer = Intel
[2020/03/18 17:59:56] notice: processor-version = Intel(R) Core(TM) i7-2670QM CP
[2020/03/18 17:59:56] notice: processor-frequency = 800 MHz
[2020/03/18 17:59:56] notice: Opened entropy source '/dev/urandom'.
[2020/03/18 18:00:12] notice: /dev/sdc has serial number WD-WMAV2FS49552
[2020/03/18 18:00:12] notice: /dev/sdc, sect/blk/dev 512/4096/1128095744
[2020/03/18 18:00:12] notice: Invoking method 'Verify Blank' on /dev/sdc
[2020/03/18 18:00:12] notice: Starting round 1 of 1 on /dev/sdc
[2020/03/18 18:00:12] notice: Finished final round 1 of 1 on /dev/sdc
[2020/03/18 18:00:12] notice: Verifying that /dev/sdc is empty
[2020/03/18 18:31:00] notice: [SUCCESS] Verified that /dev/sdc is empty.

********************************************************************************
! Device | Status | Thru-put | HH:MM:SS | Model/Serial Number
--------------------------------------------------------------------------------
     sdc | Erased |   61MB/s | 00:30:48 | ATA WDC WD1600AAJ/WD-WMAV2FS49552
--------------------------------------------------------------------------------
[2020/03/18 18:47:02] Total Throughput   61MB/s, Verify Blank, 1R+B+NV
********************************************************************************

[2020/03/18 18:47:02] info: Nwipe successfully exited.
```

15 Drive example: 1 160GB drive + 14 loop drives on a second drive.
```
.
..
...
....
[2020/03/18 20:15:11] notice: Finished pass 1/1, round 1/1, on /dev/loop25
[2020/03/18 20:15:11] notice: Finished final round 1 of 1 on /dev/loop25
[2020/03/18 20:15:12] notice: 524288000 bytes written to /dev/loop21
[2020/03/18 20:15:12] notice: Finished pass 1/1, round 1/1, on /dev/loop21
[2020/03/18 20:15:12] notice: Finished final round 1 of 1 on /dev/loop21
[2020/03/18 20:15:12] notice: 524288000 bytes written to /dev/loop19
[2020/03/18 20:15:12] notice: Finished pass 1/1, round 1/1, on /dev/loop19
[2020/03/18 20:15:12] notice: Finished final round 1 of 1 on /dev/loop19
[2020/03/18 20:15:17] notice: 1073741824 bytes written to /dev/loop14
[2020/03/18 20:15:17] notice: Finished pass 1/1, round 1/1, on /dev/loop14
[2020/03/18 20:15:17] notice: Finished final round 1 of 1 on /dev/loop14
[2020/03/18 20:15:18] notice: 1073741824 bytes written to /dev/loop15
[2020/03/18 20:15:18] notice: Finished pass 1/1, round 1/1, on /dev/loop15
[2020/03/18 20:15:18] notice: Finished final round 1 of 1 on /dev/loop15
[2020/03/18 20:15:19] notice: 1073741824 bytes written to /dev/loop13
[2020/03/18 20:15:19] notice: Finished pass 1/1, round 1/1, on /dev/loop13
[2020/03/18 20:15:19] notice: Finished final round 1 of 1 on /dev/loop13
[2020/03/18 20:47:52] notice: 160041885696 bytes written to /dev/sdc
[2020/03/18 20:47:52] notice: Finished pass 1/1, round 1/1, on /dev/sdc
[2020/03/18 20:47:52] notice: Finished final round 1 of 1 on /dev/sdc

********************************************************************************
! Device | Status | Thru-put | HH:MM:SS | Model/Serial Number
--------------------------------------------------------------------------------
     sdc | Erased |   54MB/s | 00:34:27 | ATA WDC WD1600AAJ/WD-WMAV2FS49552
  loop13 | Erased |    9MB/s | 00:01:54 | Loopback device/
  loop14 | Erased |    9MB/s | 00:01:52 | Loopback device/
  loop15 | Erased |    9MB/s | 00:01:53 | Loopback device/
  loop16 | Erased |    7MB/s | 00:01:16 | Loopback device/
  loop17 | Erased |    6MB/s | 00:01:22 | Loopback device/
  loop18 | Erased |    8MB/s | 00:01:00 | Loopback device/
  loop19 | Erased |    5MB/s | 00:01:47 | Loopback device/
  loop20 | Erased |    5MB/s | 00:01:31 | Loopback device/
  loop21 | Erased |    4MB/s | 00:01:47 | Loopback device/
  loop22 | Erased |    6MB/s | 00:01:26 | Loopback device/
  loop23 | Erased |    5MB/s | 00:01:31 | Loopback device/
  loop24 | Erased |    5MB/s | 00:01:40 | Loopback device/
  loop25 | Erased |    4MB/s | 00:01:46 | Loopback device/
  loop26 | Erased |    7MB/s | 00:01:18 | Loopback device/
--------------------------------------------------------------------------------
[2020/03/18 20:58:11] Total Throughput  151MB/s, Zero Fill, 1R+NB+NV
********************************************************************************

[2020/03/18 20:58:11] info: Nwipe successfully exited.
```