### PR TITLE
Fix incorrect summary duration during shutdown

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -627,15 +627,21 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
         /* Add this devices throughput to the total throughput */
         total_throughput += c[i]->throughput;
 
-        /* Retrieve the duration of the wipe in seconds and convert hours and minutes and seconds */
-        /* WARNING More work needs doing on ..
-         *
-         * model
-         * serial no
-         * the footer
-         * testing under various fault situations ... WARNING */
+        /* Retrieve the duration of the wipe in seconds and convert to hours and minutes and seconds */
 
-        c[i]->duration = difftime( c[i]->end_time, c[i]->start_time );
+        if( c[i]->start_time != 0 && c[i]->end_time != 0 )
+        {
+            /* For a summary when the wipe has finished */
+            c[i]->duration = difftime( c[i]->end_time, c[i]->start_time );
+        }
+        else
+        {
+            if( c[i]->start_time != 0 && c[i]->end_time == 0 )
+            {
+                /* For a summary in the event of a system shutdown */
+                c[i]->duration = difftime( t, c[i]->start_time );
+            }
+        }
 
         total_duration_seconds = (u64) c[i]->duration;
 

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -269,7 +269,12 @@ int main( int argc, char** argv )
         /* A result buffer for the BLKGETSIZE64 ioctl. */
         u64 size64;
 
+        /* Initialise the spinner character index */
         c2[i]->spinner_idx = 0;
+
+        /* Initialise the start and end time of the wipe */
+        c2[i]->start_time = 0;
+        c2[i]->end_time = 0;
 
         /* Initialise the wipe_status flag, -1 = wipe not yet started */
         c2[i]->wipe_status = -1;


### PR DESCRIPTION
If the system is shutdown while nwipe is still
wiping, the duration calculation would be
incorrect. This patch fixes that problem, so for
instance if a UPS signals the system running nwipe to
shutdown, nwipe typically traps that signal and
exits in an orderly manner. The log summary
is generated showing the wipe was aborted and
the wipe duration shows a valid value i.e the
elapsed time since the start of the wipe.

**Example of nwipe summary table after a shutdown is initiated mid wipe.** 
```
[2020/03/19 15:42:09] notice: Device /dev/sda excluded as per command line option -e
[2020/03/19 15:42:09] notice: Device /dev/sdb excluded as per command line option -e
[2020/03/19 15:42:09] notice: Found /dev/sdc, ATA WDC WD1600AAJS-2, 160GB, S/N=WD-WMAV2FS49552
[2020/03/19 15:42:09] notice: Device /dev/mapper/cryptswap1 excluded as per command line option -e
[2020/03/19 15:42:09] info: Automatically enumerated 1 devices.
[2020/03/19 15:42:09] notice: bios-version = E16F2IM7 V5.0E
[2020/03/19 15:42:09] notice: bios-release-date = 01/10/2012
[2020/03/19 15:42:09] notice: system-manufacturer = MEDION
[2020/03/19 15:42:09] notice: system-product-name = X681X
[2020/03/19 15:42:09] notice: system-version = To be filled by O.E.M.
[2020/03/19 15:42:09] notice: system-serial-number = To be filled by O.E.M.
[2020/03/19 15:42:09] notice: system-uuid = 03000200-0400-0500-0006-000700080009
[2020/03/19 15:42:09] notice: baseboard-manufacturer = MEDION
[2020/03/19 15:42:09] notice: baseboard-product-name = X681X
[2020/03/19 15:42:09] notice: baseboard-version = To be filled by O.E.M.
[2020/03/19 15:42:09] notice: baseboard-serial-number = To be filled by O.E.M.
[2020/03/19 15:42:09] notice: baseboard-asset-tag = To be filled by O.E.M.
[2020/03/19 15:42:09] notice: chassis-manufacturer = To Be Filled By O.E.M.
[2020/03/19 15:42:09] notice: chassis-type = Notebook
[2020/03/19 15:42:09] notice: chassis-version = To be filled by O.E.M.
[2020/03/19 15:42:09] notice: chassis-serial-number = To Be Filled By O.E.M.
[2020/03/19 15:42:09] notice: chassis-asset-tag = To Be Filled By O.E.M.
[2020/03/19 15:42:09] notice: processor-family = Core i7
[2020/03/19 15:42:09] notice: processor-manufacturer = Intel
[2020/03/19 15:42:09] notice: processor-version = Intel(R) Core(TM) i7-2670QM CPU @ 2.20GHz
[2020/03/19 15:42:09] notice: processor-frequency = 800 MHz
[2020/03/19 15:42:09] notice: Opened entropy source '/dev/urandom'.
[2020/03/19 15:42:15] notice: /dev/sdc has serial number WD-WMAV2FS49552
[2020/03/19 15:42:15] notice: /dev/sdc, sect/blk/dev 512/4096/1128095744
[2020/03/19 15:42:15] notice: Invoking method 'DoD Short' on /dev/sdc
[2020/03/19 15:42:15] notice: Starting round 1 of 1 on /dev/sdc
[2020/03/19 15:42:15] notice: Starting pass 1/3, round 1/1, on /dev/sdc
[2020/03/19 15:42:47] error: Curses endwin() failed !
[2020/03/19 15:42:49] fatal: Nwipe exited with non fatal errors on device = /dev/sdc


********************************************************************************
! Device | Status | Thru-put | HH:MM:SS | Model/Serial Number
--------------------------------------------------------------------------------
!    sdc |UABORTED|   95MB/s | 00:00:34 | ATA WDC WD1600AAJ/WD-WMAV2FS49552
--------------------------------------------------------------------------------
[2020/03/19 15:42:49] Total Throughput   95MB/s, DoD Short, 1R+B+VL
********************************************************************************
```

Closes #21 