### PR TITLE
Fix throughput so it shows the average throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ other items in 0.29 are proposed and yet to be implemented.
 - [DONE] Make log messages, especially the ones with the tag 'notice' succinct and less than 80 characters including the timestamp. This is of more importance when nwipe is used on a 80x30 terminal (ALT-F2, Shredos etc) but generally makes the logs more readable. While doing this all information was still retained. (Thanks PartialVolume)
 - [DONE] Add a summary table to the log that shows each drives status, i.e. erased or failed, throughput, duration of wipe, model, serial no etc. In particular it benefits those that wipe many drives simultaneously in rack servers. At a glance any failed drives can be seen without having to browse back through the log. (Thanks PartialVolume)
 - [DONE] Add ETA to --nogui wipes status when SIGUSR1 (kill -s USR1 (nwipes PID) is issued on the command line.
+- [DONE] Fix misleading throughput calculation. Throughput now shows average throughput calculated from start of wipe.
 - Add enhancement fibre channel wiping of non 512 bytes/sector drives such as 524/528 bytes/sector etc (work in progress by PartialVolume)
 - HPA/DCO detection and adjustment to wipe full drive. (work in progress by PartialVolume)
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -2669,6 +2669,9 @@ int compute_stats( void* ptr )
             }
         }
 
+        /* Calculate the average throughput */
+        c[i]->throughput = (double) c[i]->round_done / (double) difftime( nwipe_time_now, c[i]->start_time );
+
         /* Update the percentage value. */
         c[i]->round_percent = (double) c[i]->round_done / (double) c[i]->round_size * 100;
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -645,31 +645,6 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
 
         total_duration_seconds = (u64) c[i]->duration;
 
-        //        if( total_duration_seconds % 60 )
-        //        {
-        //            minutes = total_duration_seconds / 60;
-        //
-        //            seconds = total_duration_seconds - ( minutes * 60 );
-        //        }
-        //        else
-        //        {
-        //            minutes = total_duration_seconds / 60;
-        //
-        //            seconds = 0;
-        //        }
-        //        if( minutes > 59 )
-        //        {
-        //            hours = minutes / 60;
-        //            if( minutes % 60 )
-        //            {
-        //                minutes = minutes - ( hours * 60 );
-        //            }
-        //            else
-        //            {
-        //                minutes = 0;
-        //            }
-        //        }
-
         /* Convert binary seconds into three binary variables, hours, minutes and seconds */
         convert_seconds_to_hours_minutes_seconds( total_duration_seconds, &hours, &minutes, &seconds );
 


### PR DESCRIPTION
Fix throughput so it shows the average throughput
calculated from the start of the wipe.

Because we currently use cached access to the disks
initially for a few seconds or minute the throughput looks high
as nwipes writes are cached in memory before being written to disc.

When we change to a non cached or nwipe buffered model the
throughput will reflect a throughput that is actual
disc throughput.

Using an averaged throughput means that when the wipe finishes it will show
a higher value than the previous calculation but this new calculation is the
actual averaged speed of the wipe and reflects a value that is closer to what
you would expect a given drive to exhibit.

For instance a 160GB WD1600AAJS using Dod-S, B+VL, using the old
calculation would finish with a throughput of 48MB/s, using the
new calculation it finishes with a throughput of 76MB/s. This was tested
over multiple wipes and multiple rounds and gave consistently similiar
results.

Throughput is not so accurate on small loop drives due to the fact the drive
is so small it fits within CPU memory so when reading back to verify your're
actually reading back from cache not the disk. Another reason I want to move
to non cached I/O and have nwipe manage buffering and size of block writes.