### PR TITLE
Make the [syncing] a bit easier on the eyes

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2401,32 +2401,59 @@ void* nwipe_gui_status( void* ptr )
                 {
                     wprintw( main_window, "[pass errors: %llu] ", c[i]->pass_errors );
                 }
-
-                switch( c[i]->pass_type )
+                if( c[i]->wipe_status == 1 )
                 {
-                    case NWIPE_PASS_FINAL_BLANK:
-                        wprintw( main_window, "[blanking] " );
-                        break;
+                    switch( c[i]->pass_type )
+                    {
+                        case NWIPE_PASS_FINAL_BLANK:
+                            if( !c[i]->sync_status )
+                            {
+                                wprintw( main_window, "[blanking] " );
+                            }
+                            else
+                            {
+                                wprintw( main_window, "[--------] " );
+                            }
+                            break;
 
-                    case NWIPE_PASS_FINAL_OPS2:
-                        wprintw( main_window, "[OPS-II final] " );
-                        break;
+                        case NWIPE_PASS_FINAL_OPS2:
+                            if( !c[i]->sync_status )
+                            {
+                                wprintw( main_window, "[OPS-II final] " );
+                            }
+                            else
+                            {
+                                wprintw( main_window, "[------------] " );
+                            }
+                            break;
 
-                    case NWIPE_PASS_WRITE:
-                        wprintw( main_window, "[writing] " );
-                        break;
+                        case NWIPE_PASS_WRITE:
+                            if( !c[i]->sync_status )
+                            {
+                                wprintw( main_window, "[writing] " );
+                            }
+                            else
+                            {
+                                wprintw( main_window, "[-------] " );
+                            }
+                            break;
 
-                    case NWIPE_PASS_VERIFY:
-                        wprintw( main_window, "[verifying] " );
-                        break;
+                        case NWIPE_PASS_VERIFY:
+                            wprintw( main_window, "[verifying] " );
+                            break;
 
-                    case NWIPE_PASS_NONE:
-                        break;
-                }
+                        case NWIPE_PASS_NONE:
+                            break;
+                    }
 
-                if( c[i]->sync_status )
-                {
-                    wprintw( main_window, "[syncing] " );
+                    if( c[i]->sync_status )
+                    {
+                        wprintw( main_window, "[syncing] " );
+                    }
+                    else
+                    {
+                        wprintw( main_window, "[-------] " );
+                    }
                 }
 
                 if( c[i]->throughput >= INT64_C( 1000000000000 ) )


### PR DESCRIPTION
I don't know if it's just me, but I'm not keen on the
way the status line length changes every few seconds
depending on whether nwipe is syncing or not. So
while still retaining the syncing message I think
it looks better if when not syncing, [syncing] is
replaced with [-------]. This keeps the status line
length pretty much constant and I find it easier on
my eyes.