### PR TITLE
Add serial number support for USB devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ other items in 0.29 are proposed and yet to be implemented.
 - [DONE] Add ETA to --nogui wipes status when SIGUSR1 (kill -s USR1 (nwipes PID) is issued on the command line.
 - [DONE] Fix misleading throughput calculation. Throughput now shows average throughput calculated from start of wipe.
 - [DONE] Fix system info not being displayed in Debian Sid. #229 (Thanks PartialVolume)
+- [DONE] Add serial number display for USB to IDE/SATA adapters. This only works if the USB to IDE/SATA adapter supports ATA pass through. See #149 for further details (Thanks PartialVolume)
 - Add enhancement fibre channel wiping of non 512 bytes/sector drives such as 524/528 bytes/sector etc (work in progress by PartialVolume)
 - HPA/DCO detection and adjustment to wipe full drive. (work in progress by PartialVolume)
 

--- a/src/context.h
+++ b/src/context.h
@@ -30,8 +30,9 @@ typedef enum nwipe_device_t_ {
     NWIPE_DEVICE_IDE,
     NWIPE_DEVICE_SCSI,
     NWIPE_DEVICE_COMPAQ,  // Unimplemented.
-    NWIPE_DEVICE_USB,  // Unimplemented.
-    NWIPE_DEVICE_IEEE1394  // Unimplemented.
+    NWIPE_DEVICE_USB,
+    NWIPE_DEVICE_IEEE1394,  // Unimplemented.
+    NWIPE_DEVICE_ATA
 } nwipe_device_t;
 
 typedef enum nwipe_pass_t_ {
@@ -88,7 +89,8 @@ typedef struct nwipe_context_t_
     char* device_model;  // The model of the device.
     char device_label[NWIPE_DEVICE_LABEL_LENGTH];  // The label (name, model, size and serial) of the device.
     struct stat device_stat;  // The device file state from fstat().
-    nwipe_device_t device_type;  // Indicates an IDE, SCSI, or Compaq SMART device.
+    nwipe_device_t device_type;  // Indicates an IDE, SCSI, or Compaq SMART device in enumerated form (int)
+    char device_type_str[14];  // Indicates an IDE, SCSI, USB etc as per nwipe_device_t but in ascii
     char device_serial_no[21];  // Serial number(processed, 20 characters plus null termination) of the device.
     int device_target;  // The device target.
 

--- a/src/device.h
+++ b/src/device.h
@@ -26,5 +26,6 @@
 void nwipe_device_identify( nwipe_context_t* c );  // Get hardware information about the device.
 int nwipe_device_scan( nwipe_context_t*** c );  // Find devices that we can wipe.
 int nwipe_device_get( nwipe_context_t*** c, char** devnamelist, int ndevnames );  // Get info about devices to wipe.
+int nwipe_get_device_bus_type_and_serialno( char*, nwipe_device_t*, char* );
 
 #endif /* DEVICE_H_ */


### PR DESCRIPTION
Add serial number support for USB devices for USB
to IDE/SATA adapters. Note this will only work
with USB IDE/SATA adapters that support ATA pass
through. See #149 for further details of
supported devices.

This patch requires readlink and smartmontools (smartctl)
to be installed. If not installed the serial number for
supported USB hardware will be missing.

Chipsets that support this include:
ASMedia, Initio, Oxford, newer JMicron-JM20329, JM20335-39, Prolific PL2507/3507 PL2571/2771/2773/2775 ,Sunplus SPIF215/6, SPIF225/6.
Jmicron, Prolific and Sunplus supports fully ATA pass-through.

Further information can be found here:
https://www.smartmontools.org/wiki/USB

In addition, the device type, i.e USB or ATA is now shown on the selection
and wipe windows.

Closes #149 
