### PR TITLE
Fix duplicated serial number

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -186,11 +186,12 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
     trim( (char*) next_device->device_serial_no );
 
     /* if we couldn't obtain serial number by using the above method .. this this */
-    nwipe_get_device_bus_type_and_serialno( next_device->device_name, &next_device->device_type, tmp_serial );
-
-    if( next_device->device_serial_no[0] == 0 )
+    if( nwipe_get_device_bus_type_and_serialno( next_device->device_name, &next_device->device_type, tmp_serial ) == 0 )
     {
-        strcpy( next_device->device_serial_no, tmp_serial );
+        if( next_device->device_serial_no[0] == 0 )
+        {
+            strcpy( next_device->device_serial_no, tmp_serial );
+        }
     }
 
     switch( next_device->device_type )


### PR DESCRIPTION
If any drive doesn't have a serial number it's
serial number field was populated with the previous
drives serial number.

This is fixed by this patch.