### PR TITLE
Fix incorrect disk capacity nomenclature.

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -67,6 +67,7 @@ typedef struct nwipe_speedring_t_
 } nwipe_speedring_t;
 
 #define NWIPE_DEVICE_LABEL_LENGTH 200
+#define NWIPE_DEVICE_SIZE_TXT_LENGTH 7
 
 typedef struct nwipe_context_t_
 {
@@ -86,6 +87,7 @@ typedef struct nwipe_context_t_
     char* device_name;  // The device file name.
     long long device_size;  // The device size in bytes.
     char* device_size_text;  // The device size in a more (human)readable format.
+    char device_size_txt[NWIPE_DEVICE_SIZE_TXT_LENGTH];  // The device size in a more (human)readable format.
     char* device_model;  // The model of the device.
     char device_label[NWIPE_DEVICE_LABEL_LENGTH];  // The label (name, model, size and serial) of the device.
     struct stat device_stat;  // The device file state from fstat().

--- a/src/device.c
+++ b/src/device.c
@@ -159,7 +159,8 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
     next_device->device_model = dev->model;
     next_device->device_name = dev->path;
     next_device->device_size = dev->length * dev->sector_size;
-    next_device->device_size_text = ped_unit_format_byte( dev, dev->length * dev->sector_size );
+    Determine_C_B_nomenclature( next_device->device_size, next_device->device_size_txt, NWIPE_DEVICE_SIZE_TXT_LENGTH );
+    next_device->device_size_text = next_device->device_size_txt;
     next_device->result = -2;
 
     /* Attempt to get serial number of device. */

--- a/src/device.h
+++ b/src/device.h
@@ -28,5 +28,6 @@ int nwipe_device_scan( nwipe_context_t*** c );  // Find devices that we can wipe
 int nwipe_device_get( nwipe_context_t*** c, char** devnamelist, int ndevnames );  // Get info about devices to wipe.
 int nwipe_get_device_bus_type_and_serialno( char*, nwipe_device_t*, char* );
 void strip_CR_LF( char* );
+void determine_disk_capacity_nomenclature( u64, char* );
 
 #endif /* DEVICE_H_ */

--- a/src/logging.c
+++ b/src/logging.c
@@ -654,7 +654,7 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
         }
 
         /* Determine the size of throughput so that the correct nomenclature can be used */
-        Determine_bandwidth_nomenclature( c[i]->throughput, throughput, 13 );
+        Determine_C_B_nomenclature( c[i]->throughput, throughput, 13 );
 
         /* Add this devices throughput to the total throughput */
         total_throughput += c[i]->throughput;
@@ -689,7 +689,7 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
         model[17] = 0;
 
         nwipe_log( NWIPE_LOG_NOTIMESTAMP,
-                   "%s %s |%s| %s | %02i:%02i:%02i | %s/%s",
+                   "%s %s |%s| %s/s | %02i:%02i:%02i | %s/%s",
                    exclamation_flag,
                    device,
                    status,
@@ -702,7 +702,7 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
     }
 
     /* Determine the size of throughput so that the correct nomenclature can be used */
-    Determine_bandwidth_nomenclature( total_throughput, total_throughput_string, 13 );
+    Determine_C_B_nomenclature( total_throughput, total_throughput_string, 13 );
 
     /* Blank abreviations used in summary table B=blank, NB=no blank */
     if( nwipe_options.noblank )
@@ -733,7 +733,7 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
     nwipe_log( NWIPE_LOG_NOTIMESTAMP,
                "--------------------------------------------------------------------------------" );
     nwipe_log( NWIPE_LOG_NOTIMESTAMP,
-               "[%i/%02i/%02i %02i:%02i:%02i] Total Throughput %s, %s, %iR+%s+%s",
+               "[%i/%02i/%02i %02i:%02i:%02i] Total Throughput %s/s, %s, %iR+%s+%s",
                1900 + p->tm_year,
                1 + p->tm_mon,
                p->tm_mday,
@@ -750,18 +750,20 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
     nwipe_log( NWIPE_LOG_NOTIMESTAMP, "" );
 }
 
-void Determine_bandwidth_nomenclature( u64 speed, char* result, int result_array_size )
+void Determine_C_B_nomenclature( u64 speed, char* result, int result_array_size )
 {
-    int idx;
 
-    /* A pointer to a result character string with a minimum of 13 characters in length
+    /* C_B ? Determine Capacity or Bandwidth nomenclature
+     *
+     * A pointer to a result character string with a minimum of 13 characters in length
      * should be provided.
      *
      * Outputs a string of the form xxxTB/s, xxxGB/s, xxxMB/s, xxxKB/s B/s depending on the value of 'speed'
      */
 
     /* Initialise the output array */
-    idx = 0;
+    int idx = 0;
+
     while( idx < result_array_size )
     {
         result[idx++] = 0;
@@ -770,23 +772,23 @@ void Determine_bandwidth_nomenclature( u64 speed, char* result, int result_array
     /* Determine the size of throughput so that the correct nomenclature can be used */
     if( speed >= INT64_C( 1000000000000 ) )
     {
-        snprintf( result, result_array_size, "%4lluTB/s", speed / INT64_C( 1000000000000 ) );
+        snprintf( result, result_array_size, "%3lluTB", speed / INT64_C( 1000000000000 ) );
     }
     else if( speed >= INT64_C( 1000000000 ) )
     {
-        snprintf( result, result_array_size, "%4lluGB/s", speed / INT64_C( 1000000000 ) );
+        snprintf( result, result_array_size, "%3lluGB", speed / INT64_C( 1000000000 ) );
     }
     else if( speed >= INT64_C( 1000000 ) )
     {
-        snprintf( result, result_array_size, "%4lluMB/s", speed / INT64_C( 1000000 ) );
+        snprintf( result, result_array_size, "%3lluMB", speed / INT64_C( 1000000 ) );
     }
     else if( speed >= INT64_C( 1000 ) )
     {
-        snprintf( result, result_array_size, "%4lluKB/s", speed / INT64_C( 1000 ) );
+        snprintf( result, result_array_size, "%3lluKB", speed / INT64_C( 1000 ) );
     }
     else
     {
-        snprintf( result, result_array_size, "%4llu B/s", speed / INT64_C( 1 ) );
+        snprintf( result, result_array_size, "%3llu B", speed / INT64_C( 1 ) );
     }
 }
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -40,7 +40,7 @@ void nwipe_log( nwipe_log_t level, const char* format, ... );
 void nwipe_perror( int nwipe_errno, const char* f, const char* s );
 int nwipe_log_sysinfo();
 void nwipe_log_summary( nwipe_context_t**, int );  // This produces the wipe status table on exit
-void Determine_bandwidth_nomenclature( u64, char*, int );
+void Determine_C_B_nomenclature( u64, char*, int );
 void convert_seconds_to_hours_minutes_seconds( u64, int*, int*, int* );
 
 #endif /* LOGGING_H_ */


### PR DESCRIPTION
I've always wondered, when you first view all the drives, why drives above 999GB appeared in their GB nomenclature instead of TB. For instance a 2TB drive would appear as 2000GB. Unlike other places in nwipe that does a proper job of describing capacity just this one location in the program was wrong.

This information was obtained by a call to a function in libparted. Maybe when libparted was written there was no such thing as a TByte drive ?? Who knows, so anyway it was far easier to use nwipes build in function called 'determine_C_B_nomenclature()' This provides us with the correct nomenclature that is a fixed number of digits (three) and prefixed with spaces so the length is always the same. In the GUI this gives a nice list when viewing multiple drives that appears in neat columns.

Below are some screenshots of the new layouts, note the following:

- New column (from a recent merge) that shows the bus type ATA/USB etc
- New calculation for disk capacity that fixes the display of TB capacity, previously was thousands of GigaBytes.
- Disk capacity has a fixed column width and prefixed with spaces to achieve the fixed width. This makes the display more visually pleasing when multiple drives are displayed, as now all the individual items now appears in fixed width columns.
- Note the model number / serial number field. To maximise the amount of limited space (i.e 80 character width as required by ShredOS, full screen terminals (ALT-F2 etc) I simply separate the model and serial number by a '/'.
- Also note, that the last two USB devices have the text (No ATA pass thru) in the serial number field. This means that the chipset used in whatever USB to IDE/ATA adapter is being used does not support ATA pass through, therefore the serial number of the drive attached to the adapter (also known as a USB bridge) can't be accessed. Without ATA pass through you also won't be able to do a disk erase using the drives firmware ( firmware erase is an nwipe future feature). If you see the text 'No ATA pass thru' you can still wipe the drive, it just means you can't see the serial number or have access to more advanced features. Maybe you should get yourself a better USB to IDE/SATA adapter. See #230 and #149 which have more details on supported chipsets and devices.

![nwipe_new_selection_layout_Screenshot_20200326_173907](https://user-images.githubusercontent.com/22084881/77690336-09029680-6f9b-11ea-98b7-89f81f64824d.png)

![nwipe_during wiping_Screenshot_20200326_174104](https://user-images.githubusercontent.com/22084881/77690349-0ef87780-6f9b-11ea-9ae2-2f0b7ace68c2.png)
