### PR TITLE
Add --nousb option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ other items in 0.29 are proposed and yet to be implemented.
 - [DONE] Add serial number display for USB to IDE/SATA adapters. This only works if the USB to IDE/SATA adapter supports ATA pass through. See #149 for further details (Thanks PartialVolume)
 - [DONE] Fix disk capacity nomenclature, width and padding on drive selection screen. See #237 (Thanks PartialVolume)
 - [DONE] Add bus type, ATA or USB, amongst others to drive selection and wipe windows. (Thanks PartialVolume)
+- [DONE] Add --nousb option. If you use the option --nousb, all USB devices will be ignored. They won't show up in the GUI and they won't be wiped if you use the --nogui --autonuke command. They will even be ignored if you specifically name them on the command line.
 - Add enhancement fibre channel wiping of non 512 bytes/sector drives such as 524/528 bytes/sector etc (work in progress by PartialVolume)
 - HPA/DCO detection and adjustment to wipe full drive. (work in progress by PartialVolume)
 

--- a/man/nwipe.1
+++ b/man/nwipe.1
@@ -51,6 +51,10 @@ Do not wait for a key before exiting (default is to wait).
 \fB\-\-nosignals\fR
 Do not allow signals to interrupt a wipe (default is to allow).
 .TP
+\fB\-\-nousb\fR
+Do not show or wipe any USB devices, whether in GUI, --nogui or autonuke
+mode. (default is to allow USB devices to be shown and wiped).
+.TP
 \fB\-\-nogui\fR
 Do not show the GUI interface. Can only be used with the autonuke option.
 Nowait option is automatically invoked with the nogui option.

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -122,6 +122,12 @@ int main( int argc, char** argv )
         }
     }
 
+    if( terminate_signal == 1 )
+    {
+        cleanup();
+        exit( 1 );
+    }
+
     /* Log the System information */
     nwipe_log_sysinfo();
 

--- a/src/options.c
+++ b/src/options.c
@@ -84,6 +84,9 @@ int nwipe_options_parse( int argc, char** argv )
         /* Whether to blank the disk after wiping. */
         {"noblank", no_argument, 0, 0},
 
+        /* Whether to ignore all USB devices. */
+        {"nousb", no_argument, 0, 0},
+
         /* Whether to exit after wiping or wait for a keypress. */
         {"nowait", no_argument, 0, 0},
 
@@ -115,6 +118,7 @@ int nwipe_options_parse( int argc, char** argv )
     nwipe_options.prng = &nwipe_twister;
     nwipe_options.rounds = 1;
     nwipe_options.noblank = 0;
+    nwipe_options.nousb = 0;
     nwipe_options.nowait = 0;
     nwipe_options.nosignals = 0;
     nwipe_options.nogui = 0;
@@ -160,6 +164,12 @@ int nwipe_options_parse( int argc, char** argv )
                 if( strcmp( nwipe_options_long[i].name, "noblank" ) == 0 )
                 {
                     nwipe_options.noblank = 1;
+                    break;
+                }
+
+                if( strcmp( nwipe_options_long[i].name, "nousb" ) == 0 )
+                {
+                    nwipe_options.nousb = 1;
                     break;
                 }
 
@@ -509,6 +519,8 @@ void display_help()
     puts( "      --nogui             Do not show the GUI interface. Automatically invokes" );
     puts( "                          the nowait option. Must be used with the --autonuke" );
     puts( "                          option. Send SIGUSR1 to log current stats\n" );
+    puts( "      --nousb             Do show or wipe any USB devices whether in GUI" );
+    puts( "                          mode, --nogui or --autonuke modes.\n" );
     puts( "  -e, --exclude=DEVICES   Up to ten comma separated devices to be excluded" );
     puts( "                          --exclude=/dev/sdc" );
     puts( "                          --exclude=/dev/sdc,/dev/sdd" );

--- a/src/options.h
+++ b/src/options.h
@@ -50,6 +50,7 @@ typedef struct
     int autonuke;  // Do not prompt the user for confirmation when set.
     int autopoweroff;  // Power off on completion of wipe
     int noblank;  // Do not perform a final blanking pass.
+    int nousb;  // Do not show or wipe any USB devices.
     int nowait;  // Do not wait for a final key before exiting.
     int nosignals;  // Do not allow signals to interrupt a wipe.
     int nogui;  // Do not show the GUI.


### PR DESCRIPTION
If you use the option --nousb, all USB devices will be ignored.
They won't show up in the GUI and they won't be wiped if you use
the --nogui --autonuke command. They will even be ignored if you
specifically name them on the command line.

Closes #81 