### PR TITLE
Fix individual drive throughput running after a wipe has finished

### DIFF
--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -627,7 +627,7 @@ void* signal_hand( void* ptr )
         {
 
             // Log current status. All values are automatically updated by the GUI
-            case SIGUSR1: {
+            case SIGUSR1:
                 compute_stats( ptr );
 
                 for( i = 0; i < nwipe_misc_thread_data->nwipe_selected; i++ )
@@ -697,12 +697,11 @@ void* signal_hand( void* ptr )
                 }
 
                 break;
-            }
 
             case SIGHUP:
             case SIGINT:
             case SIGQUIT:
-            case SIGTERM: {
+            case SIGTERM:
                 /* Set termination flag for main() which will do housekeeping prior to exit */
                 terminate_signal = 1;
 
@@ -713,7 +712,6 @@ void* signal_hand( void* ptr )
                 return ( (void*) 0 );
 
                 break;
-            }
         }
     }
 


### PR DESCRIPTION
Fix individual drive throughput running after a wipe has finished.

This problem was not seen when wiping multiple drives
of the same size as they all ended at the same time.
Also not seen when wiping  a single drive, but if you
wiped multiple drives of different sizes where the
drive wipes ended at different times then you could
see the throughput being calculated as steadily dropping
for a drive that had completed it's wipe.

Also fixed overall throughput. When all wipes had completed
overall throughput showed the throughput of the last drive
that finished. It should show 0 B/s as all wiping had
ceased. In the log table you will see individual drive
throughput and overall throughput which is the sum of
all the drives throughputs.