### PR TITLE
Make percentage width fixed.

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2367,7 +2367,7 @@ void* nwipe_gui_status( void* ptr )
                     mvwprintw( main_window,
                                yy++,
                                4,
-                               "[%05.2f%%, round %i of %i, pass %i of %i] ",
+                               "[%5.2f%%, round %i of %i, pass %i of %i] ",
                                c[i]->round_percent,
                                c[i]->round_working,
                                c[i]->round_count,


### PR DESCRIPTION
For drives that are wiping the percentage
completion is displayed. To retain column
alignment when wiping multiple drives, the
percentage values from 0.01% to 9.99% are
displayed with a leading space, i.e
[ 9.99%, then 10.00% to 99.99% is displayed
as, i.e [10.01%, etc..