### PR TITLE
Visually enhance failure messages

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -213,11 +213,17 @@ void nwipe_gui_init( void )
         /* Set white on green for success messages. */
         init_pair( 5, COLOR_WHITE, COLOR_GREEN );
 
-        /* Set white on green for failure messages. */
+        /* Set white on red for failure messages. */
         init_pair( 6, COLOR_WHITE, COLOR_RED );
 
         /* Set black on black for when hiding the display. */
         init_pair( 7, COLOR_BLACK, COLOR_BLACK );
+
+        /* Set green on blue for reverse bold messages */
+        init_pair( 8, COLOR_GREEN, COLOR_WHITE );
+
+        /* Set green on blue for reverse bold error messages */
+        init_pair( 9, COLOR_RED, COLOR_WHITE );
 
         /* Set the background style. */
         wbkgdset( stdscr, COLOR_PAIR( 1 ) | ' ' );
@@ -2375,11 +2381,15 @@ void* nwipe_gui_status( void* ptr )
                     }
                     else if( c[i]->signal )
                     {
+                        wattron( main_window, COLOR_PAIR( 9 ) );
                         mvwprintw( main_window, yy++, 4, "(>>> FAILURE! <<<, signal %i) ", c[i]->signal );
+                        wattroff( main_window, COLOR_PAIR( 9 ) );
                     }
                     else
                     {
+                        wattron( main_window, COLOR_PAIR( 9 ) );
                         mvwprintw( main_window, yy++, 4, "(>>>FAILURE!<<<, code %i) ", c[i]->result );
+                        wattroff( main_window, COLOR_PAIR( 9 ) );
                     }
 
                 } /* child returned */


### PR DESCRIPTION
When a drive fails display the failure message with red text on a white background.

This makes it more visually obvious a drive failure has occurred and is especially important when you are many disk drives simultaneously. One failure message amongst twenty eight success messages, especially when all the text is white on blue can sometimes be overlooked.

With this patch the failure message stands out.

Closes #245 

### Example: Drive failed while other drives still wiping.
![nwipe highlighted in red error messages-3](https://user-images.githubusercontent.com/22084881/77962191-0bcef580-72d3-11ea-81bb-6f5652d207b5.png)

### Example: Drive failed upon completion of all wipes.
![nwipe highlighted in red error messages-5](https://user-images.githubusercontent.com/22084881/77962793-2d7cac80-72d4-11ea-81a4-5c2d78a92c26.png)

### Example: After exiting nwipe, this is the nwipe log displayed on stdout.
```
[2020/03/30 19:59:11] notice: Opened entropy source '/dev/urandom'.
[2020/03/30 19:59:52] notice: /dev/sdf, sect/blk/dev 512/4096/359923712
[2020/03/30 19:59:52] notice: /dev/sdg has serial number (no ATA pass thru)
[2020/03/30 19:59:52] notice: /dev/sdg, sect/blk/dev 512/4096/-1578016768
[2020/03/30 19:59:52] notice: Invoking method 'Zero Fill' on /dev/sdf
[2020/03/30 19:59:52] notice: Starting round 1 of 1 on /dev/sdf
[2020/03/30 19:59:52] notice: Starting pass 1/1, round 1/1, on /dev/sdf
[2020/03/30 19:59:52] notice: /dev/sdh has serial number WD-WMAKE2378069
[2020/03/30 19:59:52] notice: Invoking method 'Zero Fill' on /dev/sdg
[2020/03/30 19:59:52] notice: Starting round 1 of 1 on /dev/sdg
[2020/03/30 19:59:52] notice: Starting pass 1/1, round 1/1, on /dev/sdg
[2020/03/30 19:59:52] notice: /dev/sdh, sect/blk/dev 512/4096/1341325312
[2020/03/30 19:59:52] notice: /dev/loop13, sect/blk/dev 512/4096/1073741824
[2020/03/30 19:59:52] notice: /dev/loop19, sect/blk/dev 512/4096/524288000
[2020/03/30 19:59:52] notice: Invoking method 'Zero Fill' on /dev/loop13
[2020/03/30 19:59:52] notice: Starting round 1 of 1 on /dev/loop13
[2020/03/30 19:59:52] notice: Starting pass 1/1, round 1/1, on /dev/loop13
[2020/03/30 19:59:52] notice: /dev/loop20, sect/blk/dev 512/4096/524288000
[2020/03/30 19:59:52] notice: Invoking method 'Zero Fill' on /dev/loop19
[2020/03/30 19:59:52] notice: Starting round 1 of 1 on /dev/loop19
[2020/03/30 19:59:52] notice: Starting pass 1/1, round 1/1, on /dev/loop19
[2020/03/30 19:59:52] notice: Invoking method 'Zero Fill' on /dev/sdh
[2020/03/30 19:59:52] notice: Starting round 1 of 1 on /dev/sdh
[2020/03/30 19:59:52] notice: Starting pass 1/1, round 1/1, on /dev/sdh
[2020/03/30 19:59:52] notice: /dev/loop21, sect/blk/dev 512/4096/524288000
[2020/03/30 19:59:52] notice: Invoking method 'Zero Fill' on /dev/loop20
[2020/03/30 19:59:52] notice: Starting round 1 of 1 on /dev/loop20
[2020/03/30 19:59:52] notice: Starting pass 1/1, round 1/1, on /dev/loop20
[2020/03/30 19:59:52] notice: Invoking method 'Zero Fill' on /dev/loop21
[2020/03/30 19:59:52] notice: Starting round 1 of 1 on /dev/loop21
[2020/03/30 19:59:52] notice: Starting pass 1/1, round 1/1, on /dev/loop21
[2020/03/30 20:00:09] error: nwipe_static_pass: fdatasync: Remote I/O error
[2020/03/30 20:00:09] warning: Buffer flush failure on '/dev/sdg'.
[2020/03/30 20:00:09] warning: Wrote 409600000 bytes on '/dev/sdg'.
[2020/03/30 20:00:09] notice: 409600000 bytes written to /dev/sdg
[2020/03/30 20:00:13] notice: 524288000 bytes written to /dev/loop19
[2020/03/30 20:00:13] notice: Finished pass 1/1, round 1/1, on /dev/loop19
[2020/03/30 20:00:13] notice: Finished final round 1 of 1 on /dev/loop19
[2020/03/30 20:00:13] notice: Blanking device /dev/loop19
[2020/03/30 20:00:14] notice: 524288000 bytes written to /dev/loop21
[2020/03/30 20:00:14] notice: Finished pass 1/1, round 1/1, on /dev/loop21
[2020/03/30 20:00:14] notice: Finished final round 1 of 1 on /dev/loop21
[2020/03/30 20:00:14] notice: Blanking device /dev/loop21
[2020/03/30 20:00:24] notice: 524288000 bytes written to /dev/loop20
[2020/03/30 20:00:24] notice: Finished pass 1/1, round 1/1, on /dev/loop20
[2020/03/30 20:00:24] notice: Finished final round 1 of 1 on /dev/loop20
[2020/03/30 20:00:24] notice: Blanking device /dev/loop20
[2020/03/30 20:00:44] notice: Verifying that /dev/loop21 is empty.
[2020/03/30 20:00:44] notice: Verifying that /dev/loop19 is empty.
[2020/03/30 20:00:45] notice: Verifying that /dev/loop20 is empty.
[2020/03/30 20:00:49] notice: 1073741824 bytes written to /dev/loop13
[2020/03/30 20:00:49] notice: Finished pass 1/1, round 1/1, on /dev/loop13
[2020/03/30 20:00:49] notice: Finished final round 1 of 1 on /dev/loop13
[2020/03/30 20:00:49] notice: Blanking device /dev/loop13
[2020/03/30 20:01:14] notice: Verifying that /dev/loop13 is empty.
[2020/03/30 20:01:19] notice: [SUCCESS] Verified that /dev/loop20 is empty.
[2020/03/30 20:01:19] notice: [SUCCESS] Blanked device /dev/loop20
[2020/03/30 20:01:29] notice: [SUCCESS] Verified that /dev/loop19 is empty.
[2020/03/30 20:01:29] notice: [SUCCESS] Blanked device /dev/loop19
[2020/03/30 20:01:29] notice: [SUCCESS] Verified that /dev/loop21 is empty.
[2020/03/30 20:01:29] notice: [SUCCESS] Blanked device /dev/loop21
[2020/03/30 20:01:37] notice: [SUCCESS] Verified that /dev/loop13 is empty.
[2020/03/30 20:01:37] notice: [SUCCESS] Blanked device /dev/loop13
[2020/03/30 20:19:58] notice: 74355769344 bytes written to /dev/sdh
[2020/03/30 20:19:58] notice: Finished pass 1/1, round 1/1, on /dev/sdh
[2020/03/30 20:19:58] notice: Finished final round 1 of 1 on /dev/sdh
[2020/03/30 20:19:58] notice: Blanking device /dev/sdh
[2020/03/30 20:38:06] notice: 81964302336 bytes written to /dev/sdf
[2020/03/30 20:38:06] notice: Finished pass 1/1, round 1/1, on /dev/sdf
[2020/03/30 20:38:06] notice: Finished final round 1 of 1 on /dev/sdf
[2020/03/30 20:38:06] notice: Blanking device /dev/sdf
[2020/03/30 20:40:01] notice: Verifying that /dev/sdh is empty.
[2020/03/30 20:59:15] notice: [SUCCESS] Verified that /dev/sdh is empty.
[2020/03/30 20:59:15] notice: [SUCCESS] Blanked device /dev/sdh
[2020/03/30 21:16:38] notice: Verifying that /dev/sdf is empty.
[2020/03/30 21:56:12] notice: [SUCCESS] Verified that /dev/sdf is empty.
[2020/03/30 21:56:12] notice: [SUCCESS] Blanked device /dev/sdf
[2020/03/30 21:57:24] error: Nwipe exited with fatal errors on device = /dev/sdg


********************************************************************************
! Device | Status | Thru-put | HH:MM:SS | Model/Serial Number
--------------------------------------------------------------------------------
     sdf | Erased |  35 MB/s | 01:56:20 | Maxtor 6 Y080P0/
!    sdg |-FAILED-|  24 MB/s | 01:00:17 | WDC WD80 0JB-00CR/(no ATA pass thru)
     sdh | Erased |  62 MB/s | 01:59:23 | ATA WDC WD740GD-0/WD-WMAKE2378069
  loop13 | Erased |  30 MB/s | 01:01:45 | Loopback device/
  loop19 | Erased |  16 MB/s | 01:01:37 | Loopback device/
  loop20 | Erased |  18 MB/s | 01:01:27 | Loopback device/
  loop21 | Erased |  16 MB/s | 01:01:37 | Loopback device/
--------------------------------------------------------------------------------
[2020/03/30 21:57:24] Total Throughput 202 MB/s, Zero Fill, 1R+B+VL
********************************************************************************
```

