### PR TITLE
Add NVME & VIRT to device types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ other items in 0.29 are proposed and yet to be implemented.
 - [DONE] Add --nousb option. If you use the option --nousb, all USB devices will be ignored. They won't show up in the GUI and they won't be wiped if you use the --nogui --autonuke command. They will even be ignored if you specifically name them on the command line.
 - [DONE] Miscellaneous GUI fixes, throughput display format, percentage display format to improve column alignment when wiping multiple discs. (Thanks PartialVolume)
 - [DONE] Improve visibility of failure messages with red text on white background. (Thanks PartialVolume)
+- [DONE] Add NVME and VIRT (loop etc) devices to device type table for display in GUI and logs. NVME devices now shoe up as NVME devices rather than UNK (Thanks PartialVolume)
 - Add enhancement fibre channel wiping of non 512 bytes/sector drives such as 524/528 bytes/sector etc (work in progress by PartialVolume)
 - HPA/DCO detection and adjustment to wipe full drive. (work in progress by PartialVolume)
 

--- a/src/context.h
+++ b/src/context.h
@@ -32,7 +32,9 @@ typedef enum nwipe_device_t_ {
     NWIPE_DEVICE_COMPAQ,  // Unimplemented.
     NWIPE_DEVICE_USB,
     NWIPE_DEVICE_IEEE1394,  // Unimplemented.
-    NWIPE_DEVICE_ATA
+    NWIPE_DEVICE_ATA,
+    NWIPE_DEVICE_NVME,
+    NWIPE_DEVICE_VIRT
 } nwipe_device_t;
 
 typedef enum nwipe_pass_t_ {

--- a/src/device.c
+++ b/src/device.c
@@ -236,7 +236,7 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
     // Remove leading/trailing whitespace from serial number and left justify.
     trim( (char*) next_device->device_serial_no );
 
-    /* if we couldn't obtain serial number by using the above method .. this this */
+    /* if we couldn't obtain serial number by using the above method .. try this */
     r = nwipe_get_device_bus_type_and_serialno( next_device->device_name, &next_device->device_type, tmp_serial );
 
     /* If serial number & bus retrieved (0) OR unsupported USB bus identified (5) */
@@ -249,34 +249,43 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
         }
     }
 
+    /* All device strings should be 4 characters, prefix with space if under 4 characters */
     switch( next_device->device_type )
     {
         case NWIPE_DEVICE_UNKNOWN:
-            strcpy( next_device->device_type_str, "UNK" );
+            strcpy( next_device->device_type_str, " UNK" );
             break;
 
         case NWIPE_DEVICE_IDE:
-            strcpy( next_device->device_type_str, "IDE" );
+            strcpy( next_device->device_type_str, " IDE" );
             break;
 
         case NWIPE_DEVICE_SCSI:
-            strcpy( next_device->device_type_str, "SCSI" );
+            strcpy( next_device->device_type_str, " SCSI" );
             break;
 
         case NWIPE_DEVICE_COMPAQ:
-            strcpy( next_device->device_type_str, "CPQ" );
+            strcpy( next_device->device_type_str, " CPQ" );
             break;
 
         case NWIPE_DEVICE_USB:
-            strcpy( next_device->device_type_str, "USB" );
+            strcpy( next_device->device_type_str, " USB" );
             break;
 
         case NWIPE_DEVICE_IEEE1394:
-            strcpy( next_device->device_type_str, "IEEE1394" );
+            strcpy( next_device->device_type_str, "1394" );
             break;
 
         case NWIPE_DEVICE_ATA:
-            strcpy( next_device->device_type_str, "ATA" );
+            strcpy( next_device->device_type_str, " ATA" );
+            break;
+
+        case NWIPE_DEVICE_NVME:
+            strcpy( next_device->device_type_str, "NVME" );
+            break;
+
+        case NWIPE_DEVICE_VIRT:
+            strcpy( next_device->device_type_str, "VIRT" );
             break;
     }
 
@@ -513,6 +522,20 @@ int nwipe_get_device_bus_type_and_serialno( char* device, nwipe_device_t* bus, c
                     if( strstr( result, "/ata" ) != 0 )
                     {
                         *bus = NWIPE_DEVICE_ATA;
+                    }
+                    else
+                    {
+                        if( strstr( result, "/nvme/" ) != 0 )
+                        {
+                            *bus = NWIPE_DEVICE_NVME;
+                        }
+                        else
+                        {
+                            if( strstr( result, "/virtual/" ) != 0 )
+                            {
+                                *bus = NWIPE_DEVICE_VIRT;
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Added NVME and VIRT to device type table.

VIRT are virtual devices such as loop devices
created with losetup.

NVME for solid state storage devices.

Due to the longer device names used for NVME, I will
need to do some work on the device name in the selection
window so column alignment is maintained.