### PR TITLE
Fix --nousb missing a drive

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -159,7 +159,8 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
         /* retrieve bus and drive serial number, HOWEVER we are only interested in the bus at this time */
         r = nwipe_get_device_bus_type_and_serialno( dev->path, &bus, tmp_serial );
 
-        if( r == 0 || r == 5 )
+        /* See nwipe_get_device_bus_type_and_serialno() function for meaning of these codes */
+        if( r == 0 || ( r >= 3 && r <= 6 ) )
         {
             if( bus == NWIPE_DEVICE_USB )
             {


### PR DESCRIPTION
If a USB device generated a particular error code from smartmontools, the --nousb option incorrectly did not exclude it from the enumerated drives.

This has now been corrected.