### PR TITLE
Fix summary table message precedence

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -613,17 +613,18 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
         /* Any errors ? if so set the exclamation_flag and fail message,
          * All status messages should be eight characters EXACTLY !
          */
-        if( user_abort == 1 )
+        if( c[i]->result < 0 )
         {
             strncpy( exclamation_flag, "!", 1 );
             exclamation_flag[1] = 0;
 
-            strncpy( status, "UABORTED", 8 );
+            strncpy( status, "-FAILED-", 8 );
             status[8] = 0;
         }
         else
         {
-            if( c[i]->result != 0 )
+
+            if( c[i]->pass_errors != 0 )
             {
                 strncpy( exclamation_flag, "!", 1 );
                 exclamation_flag[1] = 0;
@@ -633,13 +634,12 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
             }
             else
             {
-
-                if( c[i]->pass_errors != 0 )
+                if( user_abort == 1 )
                 {
                     strncpy( exclamation_flag, "!", 1 );
                     exclamation_flag[1] = 0;
 
-                    strncpy( status, "-FAILED-", 8 );
+                    strncpy( status, "UABORTED", 8 );
                     status[8] = 0;
                 }
                 else


### PR DESCRIPTION
Previously if a drive failed during a multiple drive wipe and the user decided to abort nwipe, for instance, to remove the drive and start over, the user would use CONTROl-C to abort.

This would be reflected in the summary table as ALL drives having been aborted including the drive that failed. However, it makes more sense for a failed drive to be marked as failed in the summary table even though the user had aborted the wipe.

This patch fixes that, so that if a drive failed it reflects that drives status as failed in the summary table even if the user had aborted the wipe.