### PR TITLE
Fix minor error in reporting block size in log

### DIFF
--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -397,7 +397,7 @@ int main( int argc, char** argv )
         if( c2[i]->device_size == 0 )
         {
             nwipe_log( NWIPE_LOG_ERROR,
-                       "%s, sect/blk/dev %llu/%i/%i",
+                       "%s, sect/blk/dev %llu/%i/%llu",
                        c2[i]->device_name,
                        c2[i]->device_sector_size,
                        c2[i]->device_block_size,
@@ -408,7 +408,7 @@ int main( int argc, char** argv )
         else
         {
             nwipe_log( NWIPE_LOG_NOTICE,
-                       "%s, sect/blk/dev %llu/%i/%i",
+                       "%s, sect/blk/dev %llu/%i/%llu",
                        c2[i]->device_name,
                        c2[i]->device_sector_size,
                        c2[i]->device_block_size,


### PR DESCRIPTION
Fix a minor error in the reporting of the discs total number of blocks. This only affects reporting to the log file and does not affect the programs operation.