### PR TITLE
Warn user if they press 's' instead of 'S'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ other items in 0.29 are proposed and yet to be implemented.
 - [DONE] Improve visibility of failure messages with red text on white background. (Thanks PartialVolume)
 - [DONE] Add NVME and VIRT (loop etc) devices to device type table for display in GUI and logs. NVME devices now show up as NVME devices rather than UNK (Thanks PartialVolume)
 - [DONE] Fix very obscure segmentation fault going back to at least 0.24 in drive selection window when resizing terminal vertical axis while drive focus symbol '>' is pointing to the last drive of a multi drive selection window. See [#248](https://github.com/martijnvanbrummelen/nwipe/pull/248) for further details (Thanks PartialVolume)
+- [DONE] Warn the user if they are incorrectly typing a lower case s to start a wipe, when they should be typing a capital S [#262](https://github.com/martijnvanbrummelen/nwipe/issues/262) (Thanks PartialVolume)
 - Add enhancement fibre channel wiping of non 512 bytes/sector drives such as 524/528 bytes/sector etc (work in progress by PartialVolume)
 - HPA/DCO detection and adjustment to wipe full drive. (work in progress by PartialVolume)
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -124,6 +124,8 @@ const char* stats_title = " Statistics ";
 
 /* Footer labels. */
 const char* main_window_footer = "S=Start M=Method P=PRNG V=Verify R=Rounds B=Blanking Space=Select Ctrl-C=Quit";
+const char* main_window_footer_warning_lower_case_s =
+    "  WARNING: To start the wipe press capital S, you pressed lower case s  ";
 const char* selection_footer = "J=Down K=Up Space=Select Backspace=Cancel Ctrl-C=Quit";
 const char* end_wipe_footer = "B=Blank screen Ctrl-C=Quit";
 const char* rounds_footer = "Left=Erase Esc=Cancel Ctrl-C=Quit";
@@ -224,6 +226,9 @@ void nwipe_gui_init( void )
 
         /* Set green on blue for reverse bold error messages */
         init_pair( 9, COLOR_RED, COLOR_WHITE );
+
+        /* Set black on yellow for warning messages */
+        init_pair( 10, COLOR_BLACK, COLOR_YELLOW );
 
         /* Set the background style. */
         wbkgdset( stdscr, COLOR_PAIR( 1 ) | ' ' );
@@ -956,6 +961,32 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
 
                     /* User want to start the wipe */
                     validkeyhit = 1;
+                    break;
+
+                case 's':
+
+                    /* user has mistakenly hit the lower case 's' instead of capital 'S' */
+
+                    /* Warn the user about their mistake */
+                    wattron( footer_window, COLOR_PAIR( 10 ) );
+                    nwipe_gui_amend_footer_window( main_window_footer_warning_lower_case_s );
+                    doupdate();
+                    sleep( 2 );
+                    wattroff( footer_window, COLOR_PAIR( 10 ) );
+
+                    /* After the delay return footer text back to key help */
+                    nwipe_gui_amend_footer_window( main_window_footer );
+                    doupdate();
+
+                    /* if user insists on holding the s key down, without this the gui would hang
+                     * for a period of time, i.e sleep above x number of repeated 's' keystrokes
+                     * which could run into minutes */
+                    do
+                    {
+                        timeout( 250 );  // block getch() for 250ms.
+                        keystroke = getch();  // Get user input.
+                        timeout( -1 );  // Switch back to blocking mode.
+                    } while( keystroke == 's' );
                     break;
 
             } /* keystroke switch */


### PR DESCRIPTION
I have come across a new user that couldn't start a wipe, until it was pointed out that to start a wipe you needed to type shift S. While this is often true, shift S doesn't start a wipe if you have caps lock on. To be precise you need to type a capital S. Confusing to a new user because if they have been told to type shift S but their caps lock is on, then nothing happens. Also how would you know you are supposed to type a capital S when the key info puts all keys in caps.

The fix for this is to trap the lower case s and then print a message on the status line that says "Use capital S to start a wipe". This message could remain on the status line for 3 seconds then revert back to the standard key info.

The use of capital S is to try to reduce the likelihood of an accidental wipe you didn't mean to start, however, I've always thought that maybe we should have a 'are you sure ?' after the user types 'S' . A non issue once you're familiar with nwipe but probably irritating to a new user.

The video below shows the user pressing the lower case s three times, each time the warning message is displayed:
![nwipe_warning_message_s](https://user-images.githubusercontent.com/22084881/79390236-4093ab80-7f67-11ea-844a-a3ec614ba2c4.gif)
