### PR TITLE
Warn user if no drives are selected, when attempting to start a wipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ other items in 0.29 are proposed and yet to be implemented.
 - [DONE] Add NVME and VIRT (loop etc) devices to device type table for display in GUI and logs. NVME devices now show up as NVME devices rather than UNK (Thanks PartialVolume)
 - [DONE] Fix very obscure segmentation fault going back to at least 0.24 in drive selection window when resizing terminal vertical axis while drive focus symbol '>' is pointing to the last drive of a multi drive selection window. See [#248](https://github.com/martijnvanbrummelen/nwipe/pull/248) for further details (Thanks PartialVolume)
 - [DONE] Warn the user if they are incorrectly typing a lower case s to start a wipe, when they should be typing a capital S [#262](https://github.com/martijnvanbrummelen/nwipe/issues/262) (Thanks PartialVolume)
+- [DONE] Warn the user if they are typing capital S in order to start a wipe but haven't yet selected any drives for wiping [#261](https://github.com/martijnvanbrummelen/nwipe/issues/261) (Thanks PartialVolume)
 - Add enhancement fibre channel wiping of non 512 bytes/sector drives such as 524/528 bytes/sector etc (work in progress by PartialVolume)
 - HPA/DCO detection and adjustment to wipe full drive. (work in progress by PartialVolume)
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -126,6 +126,8 @@ const char* stats_title = " Statistics ";
 const char* main_window_footer = "S=Start M=Method P=PRNG V=Verify R=Rounds B=Blanking Space=Select Ctrl-C=Quit";
 const char* main_window_footer_warning_lower_case_s =
     "  WARNING: To start the wipe press capital S, you pressed lower case s  ";
+const char* main_window_footer_warning_no_drive_selected =
+    "  No drives selected, use spacebar to select a drive, then press S to start  ";
 const char* selection_footer = "J=Down K=Up Space=Select Backspace=Cancel Ctrl-C=Quit";
 const char* end_wipe_footer = "B=Blank screen Ctrl-C=Quit";
 const char* rounds_footer = "Left=Erase Esc=Cancel Ctrl-C=Quit";
@@ -538,6 +540,9 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
 
     /* Flag, Valid key hit = 1, anything else = 0 */
     int validkeyhit;
+
+    /* counts number of drives and partitions that have been selected */
+    int number_of_selected_contexts = 0;
 
     /* Get the terminal size */
     getmaxyx( stdscr, stdscr_lines, stdscr_cols );
@@ -959,8 +964,36 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
 
                 case 'S':
 
-                    /* User want to start the wipe */
+                    /* User wants to start the wipe */
                     validkeyhit = 1;
+
+                    /* Have any drives have been selected ? */
+                    number_of_selected_contexts = 0;
+                    for( i = 0; i < count; i++ )
+                    {
+                        if( c[i]->select == NWIPE_SELECT_TRUE )
+                        {
+                            number_of_selected_contexts += 1;
+                        }
+                    }
+
+                    /* if no drives have been selected, print a warning on the footer */
+                    if( number_of_selected_contexts == 0 )
+                    {
+                        wattron( footer_window, COLOR_PAIR( 10 ) );
+                        nwipe_gui_amend_footer_window( main_window_footer_warning_no_drive_selected );
+                        doupdate();
+                        sleep( 3 );
+                        wattroff( footer_window, COLOR_PAIR( 10 ) );
+
+                        /* After the delay return footer text back to key help */
+                        nwipe_gui_amend_footer_window( main_window_footer );
+                        doupdate();
+
+                        /* Remove the S from keystroke, which will keep us in the drive selection menu */
+                        keystroke = 0;
+                    }
+
                     break;
 
                 case 's':
@@ -971,7 +1004,7 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
                     wattron( footer_window, COLOR_PAIR( 10 ) );
                     nwipe_gui_amend_footer_window( main_window_footer_warning_lower_case_s );
                     doupdate();
-                    sleep( 2 );
+                    sleep( 3 );
                     wattroff( footer_window, COLOR_PAIR( 10 ) );
 
                     /* After the delay return footer text back to key help */

--- a/src/version.c
+++ b/src/version.c
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.29-release candidate";
+const char* banner = "nwipe 0.29.004";


### PR DESCRIPTION
If a user attempts to start a wipe but hasn't yet selected any drives for wiping, a warning message will now appear for a few seconds suggesting they select a drive.

Prior to this patch, if you tried to start a wipe without selecting a drive, nwipe would immediately display a message saying the wipe was complete and press enter to exit. You had no choice but to exit and restart nwipe.