### PR TITLE
Add ctrl a to select/deselect wipe for ALL drives.

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.29.004";
+const char* banner = "nwipe 0.29.005";


### PR DESCRIPTION
To select or deselect all drives for wiping you can now type ctrl a.

Useful for users that are wiping many drives simultaneously.

Closes #266 