### PR TITLE
Fix_error_reporting_on_ctrl_C before wipe starts

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.29.005";
+const char* banner = "nwipe 0.29.006";


### PR DESCRIPTION
If you do a ctrl c to exit nwipe before you have even started a wipe, it will be reported in the logs that there are fatal or non fatal errors. This is incorrect as no wipe has even been started.

This error is only relevant to when using ctrl c before a wipe has started and not after a wipe has started.

Basically the variables that hold the errors are in an indeterminate state before wiping begins and in the case of a user abort we mistakenly checked those values and reported. They should only be used after a thread has completed or failed when their values are then valid.

Now if you exit nwipe before any wiping started there are no fatal/non fatal errors reported.