### PR TITLE
Add sudo/su help message

### DIFF
--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -100,7 +100,8 @@ int main( int argc, char** argv )
 
         if( nwipe_enumerated == 0 )
         {
-            nwipe_log( NWIPE_LOG_INFO, "Storage devices not found." );
+            nwipe_log( NWIPE_LOG_INFO,
+                       "Storage devices not found. Nwipe should be run as root or sudo/su, i.e sudo nwipe etc" );
             cleanup();
             return -1;
         }


### PR DESCRIPTION
When nwipe is run as user without root privileges, the message displayed will be "storage devices not found", which is true but possibly misleading to a new user. The message was amended to include a statement mentioning that nwipe needs to be run as root, sudo or su etc. 