### PR TITLE
Added /proc/version info to log

### DIFF
--- a/src/logging.h
+++ b/src/logging.h
@@ -24,6 +24,10 @@
 /* Maximum size of a log message */
 #define MAX_LOG_LINE_CHARS 512
 
+#define MAX_SIZE_OS_STRING 512 /* Maximum size of acceptable OS string */
+#define OS_info_Line_offset 31 /* OS_info line offset in log */
+#define OS_info_Line_Length 48 /* OS_info line length */
+
 typedef enum nwipe_log_t_ {
     NWIPE_LOG_NONE = 0,
     NWIPE_LOG_DEBUG,  // TODO:  Very verbose logging.
@@ -38,6 +42,7 @@ typedef enum nwipe_log_t_ {
 
 void nwipe_log( nwipe_log_t level, const char* format, ... );
 void nwipe_perror( int nwipe_errno, const char* f, const char* s );
+void nwipe_log_OSinfo();
 int nwipe_log_sysinfo();
 void nwipe_log_summary( nwipe_context_t**, int );  // This produces the wipe status table on exit
 void Determine_C_B_nomenclature( u64, char*, int );

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -49,6 +49,7 @@
 
 #include <parted/parted.h>
 #include <parted/debug.h>
+#include "version.h"
 
 int terminate_signal;
 int user_abort;
@@ -71,6 +72,12 @@ int main( int argc, char** argv )
 
     /* The generic result buffer. */
     int r;
+
+    /* Log nwipes version */
+    nwipe_log( NWIPE_LOG_INFO, "%s", banner );
+
+    /* Log OS info */
+    nwipe_log_OSinfo();
 
     /* Initialise the termintaion signal, 1=terminate nwipe */
     terminate_signal = 0;
@@ -119,7 +126,7 @@ int main( int argc, char** argv )
         if( nwipe_enumerated == 0 )
         {
             nwipe_log( NWIPE_LOG_ERROR, "Devices not found. Check you're not excluding drives unnecessarily." );
-            printf( "No drives found" );
+            printf( "No drives found\n" );
             cleanup();
             exit( 1 );
         }


### PR DESCRIPTION
This commit adds nwipes banner version number and OS info derived from /proc/version to the nwipe log. This information may be useful when a user has an issue and submits a log file.