### PR TITLE
bits/sigthread.h is a glibc only and is not needed

### DIFF
--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -32,7 +32,6 @@
 #include <signal.h>
 #include <pthread.h>
 #include <sys/types.h>
-#include <bits/sigthread.h>
 
 #include "nwipe.h"
 #include "context.h"


### PR DESCRIPTION
Removing still allows glibc to build and fixes builds for musl.
https://github.com/void-linux/void-packages/pull/27327