### PR TITLE
Fixes to summary table & fix final status message

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -646,8 +646,8 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
     /* A pointer to the system time struct. */
     struct tm* p;
 
-    /* Nothing to do, user didn't select any devices */
-    if( nwipe_selected == 0 )
+    /* Nothing to do, user never started a wipe so no summary table required. */
+    if( global_wipe_status == 0 )
     {
         return;
     }
@@ -721,21 +721,33 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
             }
             else
             {
-                if( user_abort == 1 )
-                {
-                    strncpy( exclamation_flag, "!", 1 );
-                    exclamation_flag[1] = 0;
-
-                    strncpy( status, "UABORTED", 8 );
-                    status[8] = 0;
-                }
-                else
+                if( c[i]->wipe_status == 0 )
                 {
                     strncpy( exclamation_flag, " ", 1 );
                     exclamation_flag[1] = 0;
 
                     strncpy( status, " Erased ", 8 );
                     status[8] = 0;
+                }
+                else
+                {
+                    if( user_abort == 1 )
+                    {
+                        strncpy( exclamation_flag, "!", 1 );
+                        exclamation_flag[1] = 0;
+
+                        strncpy( status, "UABORTED", 8 );
+                        status[8] = 0;
+                    }
+                    else
+                    {
+                        /* If this ever happens, there is a bug ! */
+                        strncpy( exclamation_flag, " ", 1 );
+                        exclamation_flag[1] = 0;
+
+                        strncpy( status, "INSANITY", 8 );
+                        status[8] = 0;
+                    }
                 }
             }
         }

--- a/src/nwipe.h
+++ b/src/nwipe.h
@@ -73,6 +73,9 @@ void* signal_hand( void* );
 /* System errors. */
 extern int errno;
 
+/* 0=wipe not yet started, 1=wipe has been started by the user */
+int global_wipe_status;
+
 /* Global array to hold log values to print when logging to STDOUT */
 /* char **log_lines;
 int log_current_element = 0;

--- a/src/version.c
+++ b/src/version.c
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.30.001";
+const char* banner = "nwipe 0.30.002";


### PR DESCRIPTION
1. Prior to this fix, if a user aborted a multi drive using control-C,
and if some of the drives had completed their wipe either
successfully or with a I/O failures, the summary log would say
UABORTED for all drives. UABORTED is acceptable status for drives that
hadn't completed their wipe but for drives that had completed the wipe,
the summary table should have gave either a ERASED or FAILED status
message. This fix corrects the summary status when using control-c to
abort a multi drive wipe where some drives have completed and some have
not.

2. If I wipe was selected but not started and then the user used
control-C to abort nwipe, the summary table would possibly
intermittently be displayed showing the last drive wiped. The correct
behaviour is that no summary table is displayed if the wipe hasn't been
started yet. This fix corrects the behaviour of the summary table when
control-c is used and a drive has been selected for wiping but not
started, in this scenario the summary table is NOT displayed.

3. When nwipe exits it always prints the message "nwipe successfully
exited". To make this single line message more informative it now
reports a different message depending upon the wipe status.

These four messages are:

"Nwipe was aborted by the user. Check the summary table for the drive
status" -  When the user aborts during a wipe.

"Nwipe was aborted by the user prior to the wipe starting."

"Nwipe exited with fatal errors, check the summary table for individual
drive status." - When one or more drives failed.

"Nwipe successfully completed. See summary table for details." - When
selected drives were all erased without error.