### PR TITLE
Correcting multiple definition of 'global_wipe_status'

### DIFF
--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -52,6 +52,7 @@
 
 int terminate_signal;
 int user_abort;
+int global_wipe_status;
 
 int main( int argc, char** argv )
 {

--- a/src/nwipe.h
+++ b/src/nwipe.h
@@ -74,7 +74,7 @@ void* signal_hand( void* );
 extern int errno;
 
 /* 0=wipe not yet started, 1=wipe has been started by the user */
-int global_wipe_status;
+extern int global_wipe_status;
 
 /* Global array to hold log values to print when logging to STDOUT */
 /* char **log_lines;


### PR DESCRIPTION
I just tried to build `nwipe` on:

```bash
avj@platypus ~/clones/nwipe$ lsb_release -a
LSB Version:	core-2.0-noarch:core-3.2-noarch:core-4.0-noarch:core-2.0-x86_64:core-3.2-x86_64:core-4.0-x86_64:desktop-4.0.fake-amd64:desktop-4.0.fake-noarch:graphics-2.0-amd64:graphics-2.0-noarch:graphics-3.2-amd64:graphics-3.2-noarch:graphics-4.0.fake-amd64:graphics-4.0.fake-noarch
Distributor ID:	openSUSE
Description:	openSUSE Tumbleweed
Release:	20210223
Codename:	n/a
```

with:

```bash
avj@platypus ~/clones/nwipe$ gcc --version
gcc (SUSE Linux) 10.2.1 20201202 [revision e563687cf9d3d1278f45aaebd03e0f66531076c9]
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

However, I received a lot of link time errors:

```
gcc  -g -O2 -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -I/usr/include/ncurses  -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -I/usr/include/ncurses    -o nwipe isaac_rand/nwipe-isaac_rand.o nwipe-nwipe.o nwipe-gui.o nwipe-pass.o nwipe-device.o mt19937ar-cok/nwipe-mt19937ar-cok.o nwipe-logging.o nwipe-method.o nwipe-options.o nwipe-prng.o nwipe-version.o -lparted  -lpthread -luuid  -Wl,-O2 -Wl,-Bsymbolic-functions -Wl,--as-needed -lpanel  -Wl,-O2 -Wl,-Bsymbolic-functions -Wl,--as-needed -lncurses -ltinfo
/usr/lib64/gcc/x86_64-suse-linux/10/../../../../x86_64-suse-linux/bin/ld: nwipe-gui.o:/home/avj/clones/nwipe/src/nwipe.h:77: multiple definition of `global_wipe_status'; nwipe-nwipe.o:/home/avj/clones/nwipe/src/nwipe.h:77: first defined here
/usr/lib64/gcc/x86_64-suse-linux/10/../../../../x86_64-suse-linux/bin/ld: nwipe-pass.o:/home/avj/clones/nwipe/src/nwipe.h:77: multiple definition of `global_wipe_status'; nwipe-nwipe.o:/home/avj/clones/nwipe/src/nwipe.h:77: first defined here
/usr/lib64/gcc/x86_64-suse-linux/10/../../../../x86_64-suse-linux/bin/ld: nwipe-device.o:/home/avj/clones/nwipe/src/nwipe.h:77: multiple definition of `global_wipe_status'; nwipe-nwipe.o:/home/avj/clones/nwipe/src/nwipe.h:77: first defined here
/usr/lib64/gcc/x86_64-suse-linux/10/../../../../x86_64-suse-linux/bin/ld: nwipe-logging.o:/home/avj/clones/nwipe/src/nwipe.h:77: multiple definition of `global_wipe_status'; nwipe-nwipe.o:/home/avj/clones/nwipe/src/nwipe.h:77: first defined here
/usr/lib64/gcc/x86_64-suse-linux/10/../../../../x86_64-suse-linux/bin/ld: nwipe-method.o:/home/avj/clones/nwipe/src/nwipe.h:77: multiple definition of `global_wipe_status'; nwipe-nwipe.o:/home/avj/clones/nwipe/src/nwipe.h:77: first defined here
/usr/lib64/gcc/x86_64-suse-linux/10/../../../../x86_64-suse-linux/bin/ld: nwipe-options.o:/home/avj/clones/nwipe/src/nwipe.h:77: multiple definition of `global_wipe_status'; nwipe-nwipe.o:/home/avj/clones/nwipe/src/nwipe.h:77: first defined here
/usr/lib64/gcc/x86_64-suse-linux/10/../../../../x86_64-suse-linux/bin/ld: nwipe-prng.o:/home/avj/clones/nwipe/src/nwipe.h:77: multiple definition of `global_wipe_status'; nwipe-nwipe.o:/home/avj/clones/nwipe/src/nwipe.h:77: first defined here
collect2: error: ld returned 1 exit status
```

This PR moves the **definition** of `global_wipe_status` out of `nwipe.h` and into `nwipe.c` (leaving an `extern` **declaration** in `nwipe.h`)

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>