### PR TITLE
Fix shutdown on buildroot based distros

### DIFF
--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -812,7 +812,7 @@ int cleanup()
 }
 void check_for_autopoweroff( void )
 {
-    char cmd[] = "shutdown -P +1 \"System going down in one minute\"";
+    char cmd[] = "shutdown -Ph +1 \"System going down in one minute\"";
     FILE* fp;
     int r;  // A result buffer.
 


### PR DESCRIPTION
The shutdown command that nwipe currently uses is
"shutdown -P +1 "Broadcast shutdown message".
While the above command works works fine on Ubuntu 18.04 LTS it
does not work on the version of shutdown used in buildroot, failing
with the error:
"shutdown -H and -P flags can only be used along with -h flag"

Luckily there is a shutdown command with options that work correctly
on both buildroot (ShredOS) and Ubuntu 18.04 LTS, this is
shutdown -Ph +1 "Broadcast shutdown message". i.e. the option -h has been added.