### PR TITLE
Fixes contradictory log messages.

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -711,7 +711,7 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
         else
         {
 
-            if( c[i]->pass_errors != 0 )
+            if( c[i]->pass_errors != 0 || c[i]->verify_errors != 0 )
             {
                 strncpy( exclamation_flag, "!", 1 );
                 exclamation_flag[1] = 0;

--- a/src/method.c
+++ b/src/method.c
@@ -1066,7 +1066,14 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
             }
         }
 
-        nwipe_log( NWIPE_LOG_NOTICE, "[SUCCESS] Blanked device %s", c->device_name );
+        if( c->verify_errors == 0 && c->pass_errors == 0 )
+        {
+            nwipe_log( NWIPE_LOG_NOTICE, "[SUCCESS] Blanked device %s", c->device_name );
+        }
+        else
+        {
+            nwipe_log( NWIPE_LOG_NOTICE, "[FAILURE] %s may not be blanked", c->device_name );
+        }
 
     } /* final blank */
 

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -91,8 +91,9 @@ int main( int argc, char** argv )
     /* Initialise, flag indicating whether a wipe has actually started or not 0=no, 1=yes */
     global_wipe_status = 0;
 
-    /* Initialise, flag that indicates whether a fatal error occured on ANY drive */
+    /* Initialise flags that indicates whether a fatal or non fatal error occured on ANY drive */
     int fatal_errors_flag = 0;
+    int non_fatal_errors_flag = 0;
 
     /* Two arrays are used, containing pointers to the the typedef for each disk */
     /* The first array (c1) points to all devices, the second points to only     */
@@ -592,6 +593,7 @@ int main( int argc, char** argv )
             if( c2[i]->result > 0 )
             {
                 nwipe_log( NWIPE_LOG_FATAL, "Nwipe exited with non fatal errors on device = %s\n", c2[i]->device_name );
+                non_fatal_errors_flag = 1;
                 return_status = 1;
             }
         }
@@ -628,10 +630,10 @@ int main( int argc, char** argv )
         }
         else
         {
-            if( fatal_errors_flag == 1 )
+            if( fatal_errors_flag == 1 || non_fatal_errors_flag == 1 )
             {
                 nwipe_log( NWIPE_LOG_INFO,
-                           "Nwipe exited with fatal errors, check the summary table for individual drive status." );
+                           "Nwipe exited with errors, check the log & summary table for individual drive status." );
             }
             else
             {

--- a/src/version.c
+++ b/src/version.c
@@ -4,14 +4,14 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.30.003";
+const char* version_string = "0.30.004";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
-const char* years = "2020";
+const char* years = "2021";
 const char* copyright = "Copyright Darik Horn <dajhorn-dban@vanadac.com>\n\
 Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.30.003";
+const char* banner = "nwipe 0.30.004";


### PR DESCRIPTION
1. The log reported verification errors while also
showing an entry in the log that said "[SUCCESS] Blanked /dev/...".
The blanked device message now shows [FAILURE] /dev/... may not be blanked"
if any verification errors are detected for a specific drive.

2. If a verification error occurred, the error would be correctly
shown in the GUI and in the logs but the summary table drive status
would show 'ERASED' not 'FAILED'. Now corrected so that the tables
drive status field shows 'FAILED' if any verification error is detected.
Prior to this it was marking the status as 'FAILED' only if the O.S
detected write errors. In practise most drive errors are detected
by the write I/O process on syncing but this will now detect errors not
recognised by the O.S. and found by the verification process. Despite
this the textual log and GUI correcty reported verification errors.

3. The final log message "Nwipe exited successfully" was checking for
fatal errors but ignoring non fatal errors despite being reported in
the log.

The final message now reads
either "Nwipe Exited Succesfully" if no fatal and non fatal errors were
detected. Alternatively it displays ...
"Nwipe exited with errors, check the log & summary table for individual drive status."
if any fatal OR non fatal errors are detected.