### PR TITLE
Add nwipe options that have been selected to the log

### DIFF
--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -289,6 +289,9 @@ int main( int argc, char** argv )
     /* TODO: free c1 and c2 memory. */
     if( user_abort == 0 )
     {
+        /* Log the wipe options that have been selected immediately prior to the start of the wipe */
+        nwipe_options_log();
+
         /* The wipe has been initiated */
         global_wipe_status = 1;
 

--- a/src/options.c
+++ b/src/options.c
@@ -399,6 +399,9 @@ int nwipe_options_parse( int argc, char** argv )
 
 void nwipe_options_log( void )
 {
+    extern nwipe_prng_t nwipe_twister;
+    extern nwipe_prng_t nwipe_isaac;
+
     /**
      *  Prints a manifest of options to the log.
      */
@@ -444,6 +447,23 @@ void nwipe_options_log( void )
     }
 
     nwipe_log( NWIPE_LOG_NOTICE, "  banner   = %s", banner );
+
+    if( nwipe_options.prng == &nwipe_twister )
+    {
+        nwipe_log( NWIPE_LOG_NOTICE, "  prng     = Mersenne Twister" );
+    }
+    else
+    {
+        if( nwipe_options.prng == &nwipe_isaac )
+        {
+            nwipe_log( NWIPE_LOG_NOTICE, "  prng     = Isaac" );
+        }
+        else
+        {
+            nwipe_log( NWIPE_LOG_NOTICE, "  prng     = Undefined" );
+        }
+    }
+
     nwipe_log( NWIPE_LOG_NOTICE, "  method   = %s", nwipe_method_label( nwipe_options.method ) );
     nwipe_log( NWIPE_LOG_NOTICE, "  rounds   = %i", nwipe_options.rounds );
     nwipe_log( NWIPE_LOG_NOTICE, "  sync     = %i", nwipe_options.sync );


### PR DESCRIPTION
The log now contains wipe configuration detail
such as method, prng, blanking, sync, rounds etc.

This data is logged immediately prior to the wipe starting.