### PR TITLE
Check that the prng produces output.

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.30.006";
+const char* version_string = "0.30.007";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.30.006";
+const char* banner = "nwipe 0.30.007";


### PR DESCRIPTION
Additional log messages are produced and a failed prng
causes a wipe failure. The buffer that outputs prng data
to the disk is now initialised with zeros (calloc rather than malloc)
to avoid uninitialised memory leakage to the disk in the event of some
unforeseen bug. This initialised buffer is also required for the check
process.

Why do this check? At a future date more prng methods may be added. This
is a very basic check that they produce some output although the output
is not verified in terms of it's randomness. This check was also
implemented to show an existing bug in the Isaac implementation in nwipe.

See the example log below that shows a failed prng. This would be caused
by a bug in the prng implementation. See the last few messages after
pass 3/3 starts. 3/3 in DoD short is the prng pass.

[2021/05/29 20:30:27]  notice: Invoking method 'DoD Short' on /dev/loop29
[2021/05/29 20:30:27]  notice: Starting round 1 of 1 on /dev/loop29
[2021/05/29 20:30:27]  notice: Starting pass 1/3, round 1/1, on /dev/loop29
[2021/05/29 20:30:39]  notice: 1073741824 bytes written to /dev/loop29
[2021/05/29 20:30:39]  notice: Finished pass 1/3, round 1/1, on /dev/loop29
[2021/05/29 20:30:39]  notice: Starting pass 2/3, round 1/1, on /dev/loop29
[2021/05/29 20:30:58]  notice: 1073741824 bytes written to /dev/loop29
[2021/05/29 20:30:58]  notice: Finished pass 2/3, round 1/1, on /dev/loop29
[2021/05/29 20:30:58]  notice: Starting pass 3/3, round 1/1, on /dev/loop29
[2021/05/29 20:30:58]  notice: Initialising Isaac prng
[2021/05/29 20:30:58]   fatal: ERROR, prng wrote nothing to the buffer
[2021/05/29 20:30:58]  notice: 0 bytes written to /dev/loop29
[2021/05/29 20:31:03]   error: Nwipe exited with fatal errors on device = /dev/loop29

********************************************************************************
 ! Device | Status | Thru-put | HH:MM:SS | Model/Serial Number
--------------------------------------------------------------------------------
 ! loop29 |-FAILED-|  69 MB/s | 00:00:31 | Loopback device/
--------------------------------------------------------------------------------
[2021/05/29 20:31:03] Total Throughput  69 MB/s, DoD Short, 1R+NB+NV
********************************************************************************

A message is also shown for a successful prng output. i.e "prng is active"
See example below.

[2021/05/29 20:04:30]  notice: Invoking method 'DoD Short' on /dev/loop29
[2021/05/29 20:04:30]  notice: Starting round 1 of 1 on /dev/loop29
[2021/05/29 20:04:30]  notice: Starting pass 1/3, round 1/1, on /dev/loop29
[2021/05/29 20:04:44]  notice: 1073741824 bytes written to /dev/loop29
[2021/05/29 20:04:44]  notice: Finished pass 1/3, round 1/1, on /dev/loop29
[2021/05/29 20:04:44]  notice: Starting pass 2/3, round 1/1, on /dev/loop29
[2021/05/29 20:04:59]  notice: 1073741824 bytes written to /dev/loop29
[2021/05/29 20:04:59]  notice: Finished pass 2/3, round 1/1, on /dev/loop29
[2021/05/29 20:04:59]  notice: Starting pass 3/3, round 1/1, on /dev/loop29
[2021/05/29 20:04:59]  notice: Initialising Mersenne Twister prng
[2021/05/29 20:04:59]  notice: prng stream is active
[2021/05/29 20:05:25]  notice: 1073741824 bytes written to /dev/loop29