### PR TITLE
Fix non functional isaac prng

### DIFF
--- a/src/isaac_rand/isaac_rand.h
+++ b/src/isaac_rand/isaac_rand.h
@@ -16,7 +16,7 @@ MODIFIED:
 
 #ifndef RAND
 #define RAND
-#define RANDSIZL   (8)  /* I recommend 8 for crypto, 4 for simulations */
+#define RANDSIZL   (4)  /* I recommend 8 for crypto, 4 for simulations */
 #define RANDSIZ    (1<<RANDSIZL)
 
 /* context of random number generator */

--- a/src/prng.c
+++ b/src/prng.c
@@ -140,18 +140,31 @@ int nwipe_isaac_init( NWIPE_PRNG_INIT_SIGNATURE )
 
 int nwipe_isaac_read( NWIPE_PRNG_READ_SIGNATURE )
 {
-    /* The purpose of this function is unclear, as it does not do anything except immediately return !
-     * Because the variables in the macro NWIPE_PRNG_READ_SIGNATURE were then unused this throws
-     * up a handful of compiler warnings, related to variables being unused. To stop the compiler warnings
-     * I've simply put in a (void) var so that compiler sees the variable are supposed to be unused.
-     *
-     * As this code works, I thought it best not to remove this function, just in case it serves
-     * some purpose or is there for future use.
-     */
+    u32 i = 0;
+    u32 ii;
+    u32 words = count / SIZE_OF_ISAAC;  // the values of isaac is strictly 4 bytes
+    u32 remain = count % SIZE_OF_ISAAC;  // the values of isaac is strictly 4 bytes
 
-    (void) state;
-    (void) buffer;
-    (void) count;
+    randctx* isaac_state = *state;
+
+    /* Isaac returns 4-bytes per call, so progress by 4 bytes. */
+    for( ii = 0; ii < words; ++ii )
+    {
+        /* get the next 32bit random number */
+        isaac( isaac_state );
+
+        nwipe_u32tobuffer( (u8*) ( buffer + i ), isaac_state->randrsl[0], SIZE_OF_ISAAC );
+        i = i + SIZE_OF_ISAAC;
+    }
+
+    /* If there is some remainder copy only relevant number of bytes to not overflow the buffer. */
+    if( remain > 0 )
+    {
+        /* get the next 32bit random number */
+        isaac( isaac_state );
+
+        nwipe_u32tobuffer( (u8*) ( buffer + i ), isaac_state->randrsl[0], SIZE_OF_ISAAC );
+    }
 
     return 0;
 }

--- a/src/prng.h
+++ b/src/prng.h
@@ -54,4 +54,7 @@ int nwipe_isaac_read( NWIPE_PRNG_READ_SIGNATURE );
 /* Size of the twister is not derived from the architecture, but it is strictly 4 bytes */
 #define SIZE_OF_TWISTER 4
 
+/* Size of the isaac is not derived from the architecture, but it is strictly 4 bytes */
+#define SIZE_OF_ISAAC 4
+
 #endif /* PRNG_H_ */

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.30.007";
+const char* version_string = "0.30.008";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.30.007";
+const char* banner = "nwipe 0.30.008";


### PR DESCRIPTION
Since at least 2013 (the initial nwipe commit),
isaac has never functioned. When the issac prng
was selected in the GUI, nwipe used the mersenne
twister prng instead. Not that you would ever
have known, as there were no log entries saying which
prng was being actively used.

However, I don't believe this was just an nwipe
issue, looking at the code for DBAN's dwipe the
same function nwipe_isaac_read( NWIPE_PRNG_READ_SIGNATURE )
exists as it does in nwipe. In both cases the function
has no code that actually does anything.

This patch populates this function and brings isaac
back to life !

This bug was also responsible for verification errors
when the option prng=isaac was used on the command
line. Worse still, if you used prng=isaac on the
command line then wiped using method=prng, no verification
and no blanking you would expect to see random data. You
don't, instead you would see either all zeros or mainly
zeros because the uninitialised buffer that should have
contained random data instead contained initialised text
data such as partial log entries. This patch and previously
submitted patches fix all these problems related to the
isaac implementation.

A separate commit will fix the GUI prng selection which
was leading everybody to believe isaac was being used
when in fact it was mersenne all along.