### PR TITLE
Fix blanking pass verification status message

### DIFF
--- a/src/method.c
+++ b/src/method.c
@@ -1048,7 +1048,9 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
             nwipe_log( NWIPE_LOG_NOTICE, "Verifying that %s is empty.", c->device_name );
 
             /* Verify the final zero pass. */
+            c->pass_type = NWIPE_PASS_VERIFY;
             r = nwipe_static_verify( c, &pattern_zero );
+            c->pass_type = NWIPE_PASS_NONE;
 
             /* Check for a fatal error. */
             if( r < 0 )

--- a/src/prng.c
+++ b/src/prng.c
@@ -9,7 +9,7 @@
  *
  *  This program is distributed in the hope that it will be useful, but WITHOUT
  *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ *  FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  *  details.
  *
  *  You should have received a copy of the GNU General Public License along with

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.30.008";
+const char* version_string = "0.30.009";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.30.008";
+const char* banner = "nwipe 0.30.009";


### PR DESCRIPTION
Although the blanking pass verification is
completed correctly the GUI status message
did not show the status as 'Verifying', the
status message continued to say blanking.

This patch fixes the GUI message so if
verification and blanking pass are enabled,
then when blanking is complete and verification
starts the drive status message changes from
'blanking' to 'Verifying'.