### PR TITLE
Allow Last Pass Verify to work without requiring final blanking (zero) pass.

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -125,6 +125,13 @@ const char* stats_title = " Statistics ";
 /* Footer labels. */
 const char* main_window_footer = "S=Start m=Method p=PRNG v=Verify r=Rounds b=Blanking Space=Select CTRL+C=Quit";
 const char* main_window_footer_warning_lower_case_s = "  WARNING: To start the wipe press SHIFT+S (uppercase S)  ";
+
+const char* main_window_fotter_warning_no_blanking_with_ops2 =
+    "  WARNING: Zero blanking is not allowed with ops2 method  ";
+
+const char* main_window_fotter_warning_no_blanking_with_verify_only =
+    "  WARNING: Zero blanking is not allowed with verify method  ";
+
 const char* main_window_footer_warning_no_drive_selected =
     "  No drives selected, use spacebar to select a drive, then press S to start  ";
 
@@ -970,6 +977,38 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
 
                     validkeyhit = 1;
 
+                    if( nwipe_options.method == &nwipe_ops2 )
+                    {
+                        /* Warn the user about that zero blanking with the ops2 method is not allowed */
+                        wattron( footer_window, COLOR_PAIR( 10 ) );
+                        nwipe_gui_amend_footer_window( main_window_fotter_warning_no_blanking_with_ops2 );
+                        doupdate();
+                        sleep( 3 );
+                        wattroff( footer_window, COLOR_PAIR( 10 ) );
+
+                        /* After the delay return footer text back to key help */
+                        nwipe_gui_amend_footer_window( main_window_footer );
+                        doupdate();
+
+                        break;
+                    }
+
+                    if( nwipe_options.method == &nwipe_verify )
+                    {
+                        /* Warn the user about that zero blanking with the ops2 method is not allowed */
+                        wattron( footer_window, COLOR_PAIR( 10 ) );
+                        nwipe_gui_amend_footer_window( main_window_fotter_warning_no_blanking_with_verify_only );
+                        doupdate();
+                        sleep( 3 );
+                        wattroff( footer_window, COLOR_PAIR( 10 ) );
+
+                        /* After the delay return footer text back to key help */
+                        nwipe_gui_amend_footer_window( main_window_footer );
+                        doupdate();
+
+                        break;
+                    }
+
                     /* Run the noblank dialog. */
                     nwipe_gui_noblank();
                     break;
@@ -1148,6 +1187,13 @@ void nwipe_gui_options( void )
     } /* switch verify */
 
     mvwprintw( options_window, NWIPE_GUI_OPTIONS_ROUNDS_Y, NWIPE_GUI_OPTIONS_ROUNDS_X, "Rounds:  " );
+
+    /* Disable blanking for ops2 and verify methods */
+    if( nwipe_options.method == &nwipe_ops2 || nwipe_options.method == &nwipe_verify )
+    {
+        nwipe_options.noblank = 1;
+    }
+
     if( nwipe_options.noblank )
     {
         wprintw( options_window, "%i (no final blanking pass)", nwipe_options.rounds );
@@ -1820,10 +1866,6 @@ void nwipe_gui_noblank( void )
                 if( focus >= 0 && focus < count )
                 {
                     nwipe_options.noblank = focus;
-                }
-                if( nwipe_options.noblank )
-                {
-                    nwipe_options.verify = NWIPE_VERIFY_NONE;
                 }
                 return;
 

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.30.010";
+const char* version_string = "0.30.011";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.30.010";
+const char* banner = "nwipe 0.30.011";


### PR DESCRIPTION
1. Allows zero fill to be verified when blanking off. Prior to this if you wanted to verify a zero pass, blanking had to be on. This meant a zero pass, then a blanking pass then a verify, effectively two zero passes and a verify. This is now fixed so you can now do a zero pass with verification without a blanking pass. This knocks a third off the wipe time of a zero fill with verification !. This also means all other methods can have either all their passes  or just the last pass verified, whether static or random, without blanking being enabled. Optionally a blanking pass with or without verification can be selected except for the Ops2 method which requires a mandatory random pass.

2. OPS2 method requires the last pass to be random, the GUI now disables the use of the blanking option for this message and displays a warning message that a final blanking pass is not allowed for OPS2. It never did a final blanking pass anyway, even if it was selected, but this makes it clearer in the GUI that a blanking pass is not an option.

3. The calculate_round_size() function was improved by reducing some duplicated code and bringing the full calculation into this function. Corrected OPS2 and HMG IS5 Enhanced 'additional calculations' due to verification being allowed without a final blanking pass.

4. On completion of each pass or verification the total number of bytes written or read for each pass or verification is logged.

Verified correct round size and thus correct percentage completion values all 84 possible combinations of wipe.
|                                                                   | zerofill|OPS-II| DoD-S | DoD-F| GutM | PRNG | V.Blank | IS5
| :------------                                                   | :------: |:------:|:----------:| :-------: | :------: | :-------: | :---------: | :---: |
|  Verify Last Pass, Blanking On,  1R           | 100%  | N/A  | 100% |100%|100%  |100%|  N/A   |100%|
|  Verify Last Pass, Blanking On,  2R           | 100%  | N/A  | 100% |100%|100%  |100%|   N/A  |100%|
|  Verify Last Pass, Blanking Off,  1R           | 100%  |100%| 100% |100%|100%  |100%| 100% |100%|
|  Verify Last Pass, Blanking Off,  2R           | 100%  |100%| 100% |100%|100%  |100%| 100% |100%|
|  Verify Off, Blanking On, 1R                       | 100% |  N/A  | 100% |100%|100%  |100%|  N/A   |100%|
|  Verify Off, Blanking On, 2R                       | 100% |  N/A  | 100% |100%|100%  |100%|  N/A   |100%|
|  Verify Off, Blanking Off, 1R                       | 100% |100% | 100% |100%|100%  |100%| 100% |100%|
|  Verify Off, Blanking Off, 2R                       | 100% |100% | 100% |100%|100%  |100%| 100% |100%|
|  Verify All, Blanking On, 1R                        | 100% |  N/A   | 100% |100%| 100%  |100%|  N/A  |100%|
|  Verify All, Blanking On, 2R                        | 100% |  N/A   | 100% |100%| 100%  |100%|  N/A  |100%|
|  Verify All, Blanking Off, 1R                        | 100% |100% | 100% |100%| 100%  |100%| 100% |100%|
|  Verify All, Blanking Off, 2R                        | 100% |100% | 100% |100%| 100%  |100%| 100% |100%|
