### PR TITLE
Fix slight screen corruption on 80 column display

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2133,7 +2133,7 @@ void nwipe_gui_method( void )
                 mvwprintw( main_window, 2, tab2, "Security Level: Not applicable" );
 
                 mvwprintw( main_window, 4, tab2, "This method only reads the device and checks     " );
-                mvwprintw( main_window, 5, tab2, "that it is all ones (0xFF).                             " );
+                mvwprintw( main_window, 5, tab2, "that it is all ones (0xFF)." );
 
                 break;
 


### PR DESCRIPTION
When highlighting the verify ones option the first two
digits of DoD 5220 .20-M disappear. This patch fixes that
issue.