### PR TITLE
Add SAS to GUI.

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -34,7 +34,8 @@ typedef enum nwipe_device_t_ {
     NWIPE_DEVICE_IEEE1394,  // Unimplemented.
     NWIPE_DEVICE_ATA,
     NWIPE_DEVICE_NVME,
-    NWIPE_DEVICE_VIRT
+    NWIPE_DEVICE_VIRT,
+    NWIPE_DEVICE_SAS
 } nwipe_device_t;
 
 typedef enum nwipe_pass_t_ {

--- a/src/device.c
+++ b/src/device.c
@@ -289,6 +289,10 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
         case NWIPE_DEVICE_VIRT:
             strcpy( next_device->device_type_str, "VIRT" );
             break;
+
+        case NWIPE_DEVICE_SAS:
+            strcpy( next_device->device_type_str, " SAS" );
+            break;
     }
 
     if( strlen( (const char*) next_device->device_serial_no ) )
@@ -628,6 +632,19 @@ int nwipe_get_device_bus_type_and_serialno( char* device, nwipe_device_t* bus, c
                     trim( &result[15] );
 
                     strncpy( serialnumber, &result[15], 20 );
+                }
+                if( *bus == 0 )
+                {
+                    if( strstr( result, "Transport protocol:" ) != 0 )
+                    {
+                        /* strip any leading or trailing spaces and left justify, +4 is the length of "bus type:" */
+                        trim( &result[19] );
+
+                        if( strncmp( &result[19], "SAS", 3 ) == 0 )
+                        {
+                            *bus = NWIPE_DEVICE_SAS;
+                        }
+                    }
                 }
             }
 

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.32";
+const char* version_string = "0.32.001";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.32";
+const char* banner = "nwipe 0.32.001";


### PR DESCRIPTION
For some controllers/drivers the readlink method of
obtaining the bus type for GUI display does not work.

If we haven't already resolved the bus type, we then
also check smartctl for the transport protocol
for SAS.