### PR TITLE
Add a .codespellrc file to run codespell

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+skip = ./.git


### PR DESCRIPTION
It is much easier to setup [codespell](https://github.com/codespell-project/codespell) in Python projects, as the configuration can be added to the standard Python file `setup.cfg`. Here, we have to add the new `.codespellrc` file.