### PR TITLE
Added temperature to drive selection window

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -299,7 +299,7 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
     {
         snprintf( next_device->device_label,
                   NWIPE_DEVICE_LABEL_LENGTH,
-                  "%s %s (%s) %s/%s",
+                  "%s %s [%s] %s/%s",
                   next_device->device_name,
                   next_device->device_type_str,
                   next_device->device_size_text,
@@ -310,7 +310,7 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
     {
         snprintf( next_device->device_label,
                   NWIPE_DEVICE_LABEL_LENGTH,
-                  "%s %s (%s) %s",
+                  "%s %s [%s] %s",
                   next_device->device_name,
                   next_device->device_type_str,
                   next_device->device_size_text,

--- a/src/gui.h
+++ b/src/gui.h
@@ -43,6 +43,7 @@ void nwipe_gui_verify( void );  // Change the verify option.
 void nwipe_gui_noblank( void );  // Change the noblank option.
 int spinner( nwipe_context_t** ptr, int );  // Return the next spinner character
 void temp1_flash( nwipe_context_t* );  // toggles term1_flash_status, which flashes the temperature
+void wprintw_temperature( nwipe_context_t* );
 
 int compute_stats( void* ptr );
 void nwipe_update_speedring( nwipe_speedring_t* speedring, u64 speedring_done, time_t speedring_now );

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.32.003";
+const char* version_string = "0.32.004";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.32.003";
+const char* banner = "nwipe 0.32.004";


### PR DESCRIPTION
Added temperature to drive selection window.

Also removed 1. 2. etc from drive selection line
to reduce the line length. Also removed the
space between > and [, ie "> [wipe]" becomes
">[wipe]" These changes remove 3 characters
and help to reduce the affect of the additional
temperature field [30C] which add 5 characters.
Therefore the line length overall, increased by
two characters.

This helps to reduce line wrapping on 80
character terminals when the drive model length
exceeds 24 characters.