### PR TITLE
Moved the temperature readout

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -727,24 +727,40 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
                 {
                     case NWIPE_SELECT_TRUE:
 
-                        wprintw( main_window, "[wipe] %s ", c[i + offset]->device_label );
+                        wprintw( main_window,
+                                 "[wipe] %s %s [%s] ",
+                                 c[i + offset]->device_name,
+                                 c[i + offset]->device_type_str,
+                                 c[i + offset]->device_size_text );
                         break;
 
                     case NWIPE_SELECT_FALSE:
                         /* Print an element that is not selected. */
-                        wprintw( main_window, "[    ] %s ", c[i + offset]->device_label );
+                        wprintw( main_window,
+                                 "[    ] %s %s [%s] ",
+                                 c[i + offset]->device_name,
+                                 c[i + offset]->device_type_str,
+                                 c[i + offset]->device_size_text );
                         break;
 
                     case NWIPE_SELECT_TRUE_PARENT:
 
                         /* This element will be wiped when its parent is wiped. */
-                        wprintw( main_window, "[****] %s ", c[i + offset]->device_label );
+                        wprintw( main_window,
+                                 "[****] %s %s [%s] ",
+                                 c[i + offset]->device_name,
+                                 c[i + offset]->device_type_str,
+                                 c[i + offset]->device_size_text );
                         break;
 
                     case NWIPE_SELECT_FALSE_CHILD:
 
                         /* We can't wipe this element because it has a child that is being wiped. */
-                        wprintw( main_window, "[----] %s ", c[i + offset]->device_label );
+                        wprintw( main_window,
+                                 "[----] %s %s [%s] ",
+                                 c[i + offset]->device_name,
+                                 c[i + offset]->device_type_str,
+                                 c[i + offset]->device_size_text );
                         break;
 
                     case NWIPE_SELECT_DISABLED:
@@ -760,7 +776,11 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
 
                 } /* switch select */
 
-                wprintw_temperature( c[i] );
+                /* print the temperature */
+                wprintw_temperature( c[i + offset] );
+
+                /* print the drive model and serial number */
+                wprintw( main_window, "%s/%s", c[i + offset]->device_model, c[i + offset]->device_serial_no );
             }
             else
             {
@@ -2625,8 +2645,16 @@ void* nwipe_gui_status( void* ptr )
             /* Print information for the user. */
             for( i = offset; i < offset + slots && i < count; i++ )
             {
-                /* Print the device label. */
-                mvwprintw( main_window, yy++, 2, "%s", c[i]->device_label );
+                /* Print the device details. */
+                mvwprintw( main_window,
+                           yy++,
+                           2,
+                           "%s %s [%s] ",
+                           c[i]->device_name,
+                           c[i]->device_type_str,
+                           c[i]->device_size_text );
+                wprintw_temperature( c[i] );
+                wprintw( main_window, "%s/%s", c[i]->device_model, c[i]->device_serial_no );
 
                 /* Check whether the child process is still running the wipe. */
                 if( c[i]->wipe_status == 1 )
@@ -2715,9 +2743,6 @@ void* nwipe_gui_status( void* ptr )
                         wprintw( main_window, "[ syncing ] " );
                     }
                 }
-
-                /* print the temperature to the screen */
-                wprintw_temperature( c[i] );
 
                 /* Determine throughput nomenclature for this drive and output drives throughput to GUI */
                 Determine_C_B_nomenclature( c[i]->throughput, nomenclature_result_str, NOMENCLATURE_RESULT_STR_SIZE );

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.32.004";
+const char* version_string = "0.32.005";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.32.004";
+const char* banner = "nwipe 0.32.005";


### PR DESCRIPTION
In both selection and wipe status windows I
moved the temperature readout to the right
of the disk size column.

Also in the wipe status window, by moving to
the right of the disk size column the
temperature is no longer on the same line as
the disk pass progress. This reduces the line
length as I found that in tests if you had
many verification errors the temperature
being on the end of the line would disappear
of the right of the screen
![nwipe_shows_new_position_of_temperature_readout_in_selection_screen](https://user-images.githubusercontent.com/22084881/141660280-57cde899-d042-4021-891b-f681358ef8d5.png)
![nwipe_shows_new_position_of_temperature_readout_in_wipe_status_screen](https://user-images.githubusercontent.com/22084881/141660289-362b0b39-29a8-4284-8410-8f22affcddab.png)

.