### PR TITLE
Remove /dev/ from gui for long filenames

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -91,6 +91,8 @@ typedef struct nwipe_context_t_
     int device_minor;  // The minor device number.
     int device_part;  // The device partition or slice number.
     char* device_name;  // The device file name.
+    char device_name_without_path[100];
+    char gui_device_name[100];
     long long device_size;  // The device size in bytes.
     char* device_size_text;  // The device size in a more (human)readable format.
     char device_size_txt[NWIPE_DEVICE_SIZE_TXT_LENGTH];  // The device size in a more (human)readable format.

--- a/src/device.c
+++ b/src/device.c
@@ -207,7 +207,25 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
     /* Get device information */
     next_device->device_model = dev->model;
     remove_ATA_prefix( next_device->device_model );
+
+    /* full device name, i.e. /dev/sda */
     next_device->device_name = dev->path;
+
+    /* remove /dev/ from device, right justify and prefix name so string length is eight characters */
+    nwipe_strip_path( next_device->device_name_without_path, next_device->device_name );
+
+    /* To maintain column alignment in the gui we have to remove /dev/ from device names that
+     * exceed eight characters including the /dev/ path.
+     */
+    if( strlen( next_device->device_name ) > MAX_LENGTH_OF_DEVICE_STRING )
+    {
+        strcpy( next_device->gui_device_name, next_device->device_name_without_path );
+    }
+    else
+    {
+        strcpy( next_device->gui_device_name, next_device->device_name );
+    }
+
     next_device->device_size = dev->length * dev->sector_size;
     Determine_C_B_nomenclature( next_device->device_size, next_device->device_size_txt, NWIPE_DEVICE_SIZE_TXT_LENGTH );
     next_device->device_size_text = next_device->device_size_txt;

--- a/src/device.h
+++ b/src/device.h
@@ -23,6 +23,8 @@
 #ifndef DEVICE_H_
 #define DEVICE_H_
 
+#define MAX_LENGTH_OF_DEVICE_STRING 8
+
 void nwipe_device_identify( nwipe_context_t* c );  // Get hardware information about the device.
 int nwipe_device_scan( nwipe_context_t*** c );  // Find devices that we can wipe.
 int nwipe_device_get( nwipe_context_t*** c, char** devnamelist, int ndevnames );  // Get info about devices to wipe.

--- a/src/gui.c
+++ b/src/gui.c
@@ -729,7 +729,8 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
 
                         wprintw( main_window,
                                  "[wipe] %s %s [%s] ",
-                                 c[i + offset]->device_name,
+                                 // c[i + offset]->device_name,
+                                 c[i + offset]->gui_device_name,
                                  c[i + offset]->device_type_str,
                                  c[i + offset]->device_size_text );
                         break;
@@ -738,7 +739,8 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
                         /* Print an element that is not selected. */
                         wprintw( main_window,
                                  "[    ] %s %s [%s] ",
-                                 c[i + offset]->device_name,
+                                 // c[i + offset]->device_name,
+                                 c[i + offset]->gui_device_name,
                                  c[i + offset]->device_type_str,
                                  c[i + offset]->device_size_text );
                         break;
@@ -748,7 +750,8 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
                         /* This element will be wiped when its parent is wiped. */
                         wprintw( main_window,
                                  "[****] %s %s [%s] ",
-                                 c[i + offset]->device_name,
+                                 // c[i + offset]->device_name,
+                                 c[i + offset]->gui_device_name,
                                  c[i + offset]->device_type_str,
                                  c[i + offset]->device_size_text );
                         break;
@@ -758,7 +761,8 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
                         /* We can't wipe this element because it has a child that is being wiped. */
                         wprintw( main_window,
                                  "[----] %s %s [%s] ",
-                                 c[i + offset]->device_name,
+                                 // c[i + offset]->device_name,
+                                 c[i + offset]->gui_device_name,
                                  c[i + offset]->device_type_str,
                                  c[i + offset]->device_size_text );
                         break;

--- a/src/logging.c
+++ b/src/logging.c
@@ -607,7 +607,7 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
     int i;
     int idx_src;
     int idx_dest;
-    char device[7];
+    char device[18];
     char status[9];
     char throughput[13];
     char total_throughput_string[13];
@@ -662,7 +662,7 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
     nwipe_log( NWIPE_LOG_NOTIMESTAMP, "" );
     nwipe_log( NWIPE_LOG_NOTIMESTAMP,
                "******************************** Error Summary *********************************" );
-    nwipe_log( NWIPE_LOG_NOTIMESTAMP, "! Device | Pass Errors | Verifications Errors | Fdatasync I\\O Errors" );
+    nwipe_log( NWIPE_LOG_NOTIMESTAMP, "!   Device | Pass Errors | Verifications Errors | Fdatasync I\\O Errors" );
     nwipe_log( NWIPE_LOG_NOTIMESTAMP,
                "--------------------------------------------------------------------------------" );
 
@@ -675,11 +675,8 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
         }
         else
         {
-            if( c[i]->wipe_status == 0 )
-            {
-                strncpy( exclamation_flag, " ", 1 );
-                exclamation_flag[1] = 0;
-            }
+            strncpy( exclamation_flag, " ", 1 );
+            exclamation_flag[1] = 0;
         }
 
         /* Device name, strip any prefixed /dev/.. leaving up to 6 right justified
@@ -718,18 +715,18 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
     nwipe_log( NWIPE_LOG_NOTIMESTAMP, "" );
     nwipe_log( NWIPE_LOG_NOTIMESTAMP,
                "********************************* Drive Status *********************************" );
-    nwipe_log( NWIPE_LOG_NOTIMESTAMP, "! Device | Status | Thru-put | HH:MM:SS | Model/Serial Number" );
+    nwipe_log( NWIPE_LOG_NOTIMESTAMP, "!   Device | Status | Thru-put | HH:MM:SS | Model/Serial Number" );
     nwipe_log( NWIPE_LOG_NOTIMESTAMP,
                "--------------------------------------------------------------------------------" );
     /* Example layout:
-     *                                "!    sdv |--FAIL--|  120MB/s | 01:22:01 | WD6788.8488YNHj/ZX677888388-N       "
-     * ); "     sdv | Erased |  120MB/s | 01:25:04 | WD6784.8488JKGG/ZX677888388-N       " ); "     sdv | Erased |
+     *    "!     sdb |--FAIL--|  120MB/s | 01:22:01 | WD6788.8488YNHj/ZX677888388-N       "
+     * ); "      sdc | Erased |  120MB/s | 01:25:04 | WD6784.8488JKGG/ZX677888388-N       " ); "     sdv | Erased |
      * 120MB/s | 01:19:07 | WD6788.848HHDDR/ZX677888388-N       " ); End of Example layout */
 
     for( i = 0; i < nwipe_selected; i++ )
     {
-        /* Device name, strip any prefixed /dev/.. leaving up to 6 right justified
-         * characters eg "   sda", prefixed with space to 6 characters, note that
+        /* Device name, strip any prefixed /dev/.. leaving up to 8 right justified
+         * characters eg "   sda", prefixed with space to 8 characters, note that
          * we are processing the strings right to left */
 
         nwipe_strip_path( device, c[i]->device_name );
@@ -962,11 +959,15 @@ void convert_seconds_to_hours_minutes_seconds( u64 total_seconds, int* hours, in
 
 int nwipe_strip_path( char* output, char* input )
 {
+    /* Take the input string, say "/dev/sda" and remove the "/dev/", prefix the result
+     * with 'length' spaces. So if length=8 and input=/dev/sda, output will
+     * be "     sda", a string 8 characters long right justified with spaces.
+     */
     int idx_dest;
     int idx_src;
-    idx_dest = 6;
+    idx_dest = 8;
+    // idx_dest = length;
     output[idx_dest--] = 0;
-    // idx_src = strlen( c[i]->device_name );
     idx_src = strlen( input );
     idx_src--;
 

--- a/src/temperature.c
+++ b/src/temperature.c
@@ -111,7 +111,8 @@ int nwipe_init_temperature( nwipe_context_t* c )
                         }
                         strcpy( device, dp2->d_name );
 
-                        /* Create a copy of the device name from the context but strip the path from it. */
+                        /* Create a copy of the device name from the context but strip the path from it, right justify
+                         * device name, prefix with spaces so length is 8. */
                         nwipe_strip_path( device_context_name, c->device_name );
 
                         /* Remove leading/training whitespace from a string and left justify result */


### PR DESCRIPTION
This fixes column alignment issues in the gui
with nvme drives i.e. nvme0n1 etc. If the drive
name including path exceeds 8 characters the
/dev/ is removed and prefixed with spaces to
a total max length of 8 characters.