### PR TITLE
Add -q --quiet option - anonymize serial numbers

### DIFF
--- a/man/nwipe.1
+++ b/man/nwipe.1
@@ -114,6 +114,11 @@ Filename to log to. Default is STDOUT
 \fB\-p\fR, \fB\-\-prng\fR=\fIMETHOD\fR
 PRNG option (mersenne|twister|isaac)
 .TP
+\fB\-q\fR, \fB\-\-quiet\fR
+Anonymize serial numbers, Gui & logs display:
+ XXXXXXXX = S/N obtained & anonymized.
+ ???????? = S/N not available.
+.TP
 \fB\-r\fR, \fB\-\-rounds\fR=\fINUM\fR
 Number of times to wipe the device using the selected method (default: 1)
 .TP

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -206,7 +206,7 @@ int main( int argc, char** argv )
     /* Makesure the drivetemp module is loaded, else drives hwmon entries won't appear in /sys/class/hwmon */
     if( system( "modprobe drivetemp" ) != 0 )
     {
-        nwipe_log( NWIPE_LOG_ERROR, "hwmon: Unable to load module drivetemp, drive temperatures may not be available" );
+        nwipe_log( NWIPE_LOG_WARNING, "hwmon: Unable to load module drivetemp, drivetemp may be build into kernel?" );
     }
     else
     {

--- a/src/options.c
+++ b/src/options.c
@@ -53,7 +53,7 @@ int nwipe_options_parse( int argc, char** argv )
     int i;
 
     /* The list of acceptable short options. */
-    char nwipe_options_short[] = "Vvhl:m:p:r:e:";
+    char nwipe_options_short[] = "Vvhl:m:p:qr:e:";
 
     /* The list of acceptable long options. */
     static struct option nwipe_options_long[] = {
@@ -93,8 +93,11 @@ int nwipe_options_parse( int argc, char** argv )
         /* Whether to allow signals to interrupt a wipe. */
         { "nosignals", no_argument, 0, 0 },
 
-        /* Whether to exit after wiping or wait for a keypress. */
+        /* Whether to display the gui. */
         { "nogui", no_argument, 0, 0 },
+
+        /* Whether to anonymize the serial numbers. */
+        { "quiet", no_argument, 0, 'q' },
 
         /* A flag to indicate whether the devices would be opened in sync mode. */
         { "sync", required_argument, 0, 0 },
@@ -122,6 +125,7 @@ int nwipe_options_parse( int argc, char** argv )
     nwipe_options.nowait = 0;
     nwipe_options.nosignals = 0;
     nwipe_options.nogui = 0;
+    nwipe_options.quiet = 0;
     nwipe_options.sync = DEFAULT_SYNC_RATE;
     nwipe_options.verbose = 0;
     nwipe_options.verify = NWIPE_VERIFY_LAST;
@@ -375,6 +379,11 @@ int nwipe_options_parse( int argc, char** argv )
                 fprintf( stderr, "Error: Unknown prng '%s'.\n", optarg );
                 exit( EINVAL );
 
+            case 'q': /* Anonymize serial numbers */
+
+                nwipe_options.quiet = 1;
+                break;
+
             case 'r': /* Rounds option. */
 
                 if( sscanf( optarg, " %i", &nwipe_options.rounds ) != 1 || nwipe_options.rounds < 1 )
@@ -477,6 +486,7 @@ void nwipe_options_log( void )
     }
 
     nwipe_log( NWIPE_LOG_NOTICE, "  method   = %s", nwipe_method_label( nwipe_options.method ) );
+    nwipe_log( NWIPE_LOG_NOTICE, "  quiet    = %i", nwipe_options.quiet );
     nwipe_log( NWIPE_LOG_NOTICE, "  rounds   = %i", nwipe_options.rounds );
     nwipe_log( NWIPE_LOG_NOTICE, "  sync     = %i", nwipe_options.sync );
 
@@ -546,6 +556,8 @@ void display_help()
     puts( "                          verify_one             - Verifies disk is 0xFF filled\n" );
     puts( "  -l, --logfile=FILE      Filename to log to. Default is STDOUT\n" );
     puts( "  -p, --prng=METHOD       PRNG option (mersenne|twister|isaac)\n" );
+    puts( "  -q, --quiet             Anonymize logs/GUI by removing serial numbers" );
+    puts( "                          XXXXXX = S/N exists, ????? = S/N not obtainable \n" );
     puts( "  -r, --rounds=NUM        Number of times to wipe the device using the selected" );
     puts( "                          method (default: 1)\n" );
     puts( "      --noblank           Do NOT blank disk after wipe" );

--- a/src/options.h
+++ b/src/options.h
@@ -60,6 +60,7 @@ typedef struct
     char logfile[FILENAME_MAX];  // The filename to log the output to.
     char exclude[MAX_NUMBER_EXCLUDED_DRIVES][MAX_DRIVE_PATH_LENGTH];  // Drives excluded from the search.
     nwipe_prng_t* prng;  // The pseudo random number generator implementation.
+    int quiet;  // Anonymize serial numbers
     int rounds;  // The number of times that the wipe method should be called.
     int sync;  // A flag to indicate whether and how often writes should be sync'd.
     int verbose;  // Make log more verbose

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.32.005";
+const char* version_string = "0.32.006";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.32.005";
+const char* banner = "nwipe 0.32.006";


### PR DESCRIPTION
Anonymize the serial numbers in the gui, the
log and the summary table.

If a serial number was obtained from the device,
it is replaced with "XXXXXXXXXXXXXXX".

If the serial number could not be obtained from the
device, it's replaced with "???????????????".

![nwipe_serial_numbers_anonymized_when_serial_number_not_obtainable](https://user-images.githubusercontent.com/22084881/141834787-a5ffc0b9-ba5f-4123-8434-c1cc917a38c8.png)

![nwipe_serial_numbers_anonymized_when_serial_number_not_obtainable_wipe_complete](https://user-images.githubusercontent.com/22084881/141834962-8b748c7c-0cfb-483f-91db-1bacb29ec32a.png)

```
sudo ./nwipe -v -q /dev/loop39 /dev/loop40
[2021/11/15 18:24:12]    info: nwipe 0.32.006
[2021/11/15 18:24:12]    info: Linux version 5.11.0-38-generic (buildd@lgw01-am
                               d64-041) (gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.
                               3.0, GNU ld (GNU Binutils for Ubuntu) 2.34) #42
                               ~20.04.1-Ubuntu SMP Tue Sep 28 20:41:07 UTC 202
                               1
[2021/11/15 18:24:12]   debug: Readlink: ../devices/virtual/block/loop39 
[2021/11/15 18:24:12]   debug: smartctl: smartctl 7.1 2019-12-30 r5022 [x86_64-linux-5.11.0-38-generic] (local build) 
[2021/11/15 18:24:12]   debug: smartctl: Copyright (C) 2002-19, Bruce Allen, Christian Franke, www.smartmontools.org 
[2021/11/15 18:24:12]   debug: smartctl: /dev/loop39: Unable to detect device type 
[2021/11/15 18:24:12]   debug: smartctl: Please specify device type with the -d option. 
[2021/11/15 18:24:12]   debug: smartctl: Use smartctl -h to get a usage summary 
[2021/11/15 18:24:12] warning: /dev/loop39 USB bridge, no pass-through support
[2021/11/15 18:24:12]  notice: Found /dev/loop39, VIRT, Loopback device, 524 MB, S/N=???????????????
[2021/11/15 18:24:12]   debug: Readlink: ../devices/virtual/block/loop40 
[2021/11/15 18:24:12]   debug: smartctl: smartctl 7.1 2019-12-30 r5022 [x86_64-linux-5.11.0-38-generic] (local build) 
[2021/11/15 18:24:12]   debug: smartctl: Copyright (C) 2002-19, Bruce Allen, Christian Franke, www.smartmontools.org 
[2021/11/15 18:24:12]   debug: smartctl: /dev/loop40: Unable to detect device type 
[2021/11/15 18:24:12]   debug: smartctl: Please specify device type with the -d option. 
[2021/11/15 18:24:12]   debug: smartctl: Use smartctl -h to get a usage summary 
[2021/11/15 18:24:12] warning: /dev/loop40 USB bridge, no pass-through support
[2021/11/15 18:24:12]  notice: Found /dev/loop40, VIRT, Loopback device, 524 MB, S/N=???????????????
[2021/11/15 18:24:12]  notice: bios-version = E16F2IM7 V5.0E
[2021/11/15 18:24:12]  notice: bios-release-date = 01/10/2012
[2021/11/15 18:24:12]  notice: system-manufacturer = MEDION
[2021/11/15 18:24:12]  notice: system-product-name = X681X
[2021/11/15 18:24:12]  notice: system-version = To be filled by O.E.M.
[2021/11/15 18:24:12]  notice: system-serial-number = To be filled by O.E.M.
[2021/11/15 18:24:12]  notice: system-uuid = 03000200-0400-0500-0006-000700080009
[2021/11/15 18:24:12]  notice: baseboard-manufacturer = MEDION
[2021/11/15 18:24:12]  notice: baseboard-product-name = X681X
[2021/11/15 18:24:12]  notice: baseboard-version = To be filled by O.E.M.
[2021/11/15 18:24:12]  notice: baseboard-serial-number = To be filled by O.E.M.
[2021/11/15 18:24:12]  notice: baseboard-asset-tag = To be filled by O.E.M.
[2021/11/15 18:24:12]  notice: chassis-manufacturer = To Be Filled By O.E.M.
[2021/11/15 18:24:12]  notice: chassis-type = Notebook
[2021/11/15 18:24:12]  notice: chassis-version = To be filled by O.E.M.
[2021/11/15 18:24:12]  notice: chassis-serial-number = To Be Filled By O.E.M.
[2021/11/15 18:24:12]  notice: chassis-asset-tag = To Be Filled By O.E.M.
[2021/11/15 18:24:12]  notice: processor-family = Core i7
[2021/11/15 18:24:12]  notice: processor-manufacturer = Intel
[2021/11/15 18:24:12]  notice: processor-version = Intel(R) Core(TM) i7-2670QM CPU @ 2.20GHz
[2021/11/15 18:24:12]  notice: processor-frequency = 800 MHz
[2021/11/15 18:24:12]  notice: Opened entropy source '/dev/urandom'.
[2021/11/15 18:24:12]  notice: hwmon: Module drivetemp loaded, drive temperatures available
[2021/11/15 18:24:12]  notice: hwmon: Device /dev/loop39 hwmon path = 
[2021/11/15 18:24:12]  notice: hwmon: Unable to  open /temp1_crit
[2021/11/15 18:24:12]  notice: hwmon: Unable to  open /temp1_highest
[2021/11/15 18:24:12]  notice: hwmon: Unable to  open /temp1_input
[2021/11/15 18:24:12]  notice: hwmon: Unable to  open /temp1_lcrit
[2021/11/15 18:24:12]  notice: hwmon: Unable to  open /temp1_lowest
[2021/11/15 18:24:12]  notice: hwmon: Unable to  open /temp1_max
[2021/11/15 18:24:12]  notice: hwmon: Unable to  open /temp1_min
[2021/11/15 18:24:12]  notice: hwmon: Device /dev/loop40 hwmon path = 
[2021/11/15 18:24:12]  notice: hwmon: Unable to  open /temp1_crit
[2021/11/15 18:24:12]  notice: hwmon: Unable to  open /temp1_highest
[2021/11/15 18:24:12]  notice: hwmon: Unable to  open /temp1_input
[2021/11/15 18:24:12]  notice: hwmon: Unable to  open /temp1_lcrit
[2021/11/15 18:24:12]  notice: hwmon: Unable to  open /temp1_lowest
[2021/11/15 18:24:12]  notice: hwmon: Unable to  open /temp1_max
[2021/11/15 18:24:12]  notice: hwmon: Unable to  open /temp1_min
[2021/11/15 18:24:21]  notice: Program options are set as follows...
[2021/11/15 18:24:21]  notice:   autonuke = 0 (off)
[2021/11/15 18:24:21]  notice:   autopoweroff = 0 (off)
[2021/11/15 18:24:21]  notice:   banner   = nwipe 0.32.006
[2021/11/15 18:24:21]  notice:   prng     = Mersenne Twister
[2021/11/15 18:24:21]  notice:   method   = Fill With Zeros
[2021/11/15 18:24:21]  notice:   quiet    = 1
[2021/11/15 18:24:21]  notice:   rounds   = 1
[2021/11/15 18:24:21]  notice:   sync     = 100000
[2021/11/15 18:24:21]  notice:   verify   = 1 (last pass)
[2021/11/15 18:24:21]  notice: /dev/loop39 has serial number ???????????????
[2021/11/15 18:24:21]  notice: /dev/loop39, sect/blk/dev 512/4096/524288000
[2021/11/15 18:24:21]  notice: /dev/loop40 has serial number ???????????????
[2021/11/15 18:24:21]  notice: /dev/loop40, sect/blk/dev 512/4096/524288000
[2021/11/15 18:24:21]  notice: Invoking method 'Fill With Zeros' on /dev/loop39
[2021/11/15 18:24:21]  notice: Starting round 1 of 1 on /dev/loop39
[2021/11/15 18:24:21]  notice: Starting pass 1/1, round 1/1, on /dev/loop39
[2021/11/15 18:24:21]  notice: Invoking method 'Fill With Zeros' on /dev/loop40
[2021/11/15 18:24:21]  notice: Starting round 1 of 1 on /dev/loop40
[2021/11/15 18:24:21]  notice: Starting pass 1/1, round 1/1, on /dev/loop40
[2021/11/15 18:24:33]  notice: 524288000 bytes written to /dev/loop39
[2021/11/15 18:24:33]  notice: Finished pass 1/1, round 1/1, on /dev/loop39
[2021/11/15 18:24:33]  notice: Finished final round 1 of 1 on /dev/loop39
[2021/11/15 18:24:33]  notice: Blanking device /dev/loop39
[2021/11/15 18:24:34]  notice: 524288000 bytes written to /dev/loop40
[2021/11/15 18:24:34]  notice: Finished pass 1/1, round 1/1, on /dev/loop40
[2021/11/15 18:24:34]  notice: Finished final round 1 of 1 on /dev/loop40
[2021/11/15 18:24:34]  notice: Blanking device /dev/loop40
[2021/11/15 18:24:45]  notice: 524288000 bytes written to /dev/loop40
[2021/11/15 18:24:45]  notice: Verifying that /dev/loop40 is empty.
[2021/11/15 18:24:46]  notice: 524288000 bytes read from /dev/loop40
[2021/11/15 18:24:46]  notice: [SUCCESS] Verified that /dev/loop40 is empty.
[2021/11/15 18:24:46]  notice: [SUCCESS] Blanked device /dev/loop40
[2021/11/15 18:24:48]  notice: 524288000 bytes written to /dev/loop39
[2021/11/15 18:24:48]  notice: Verifying that /dev/loop39 is empty.
[2021/11/15 18:24:48]  notice: 524288000 bytes read from /dev/loop39
[2021/11/15 18:24:48]  notice: [SUCCESS] Verified that /dev/loop39 is empty.
[2021/11/15 18:24:48]  notice: [SUCCESS] Blanked device /dev/loop39
[2021/11/15 18:25:13]  notice: hwmon: Unable to  open /temp1_crit
[2021/11/15 18:25:13]  notice: hwmon: Unable to  open /temp1_highest
[2021/11/15 18:25:13]  notice: hwmon: Unable to  open /temp1_input
[2021/11/15 18:25:13]  notice: hwmon: Unable to  open /temp1_lcrit
[2021/11/15 18:25:13]  notice: hwmon: Unable to  open /temp1_lowest
[2021/11/15 18:25:13]  notice: hwmon: Unable to  open /temp1_max
[2021/11/15 18:25:13]  notice: hwmon: Unable to  open /temp1_min
[2021/11/15 18:25:13]  notice: hwmon: Unable to  open /temp1_crit
[2021/11/15 18:25:13]  notice: hwmon: Unable to  open /temp1_highest
[2021/11/15 18:25:13]  notice: hwmon: Unable to  open /temp1_input
[2021/11/15 18:25:13]  notice: hwmon: Unable to  open /temp1_lcrit
[2021/11/15 18:25:13]  notice: hwmon: Unable to  open /temp1_lowest
[2021/11/15 18:25:13]  notice: hwmon: Unable to  open /temp1_max
[2021/11/15 18:25:13]  notice: hwmon: Unable to  open /temp1_min
[2021/11/15 18:26:12]    info: Exit in progress
[2021/11/15 18:26:12]    info: Requesting wipe thread cancellation for /dev/loop39
[2021/11/15 18:26:12]    info: Please wait..
[2021/11/15 18:26:12]    info: Requesting wipe thread cancellation for /dev/loop40
[2021/11/15 18:26:12]    info: Please wait..
[2021/11/15 18:26:12]    info: Cancelling the GUI thread.
[2021/11/15 18:26:12]    info: GUI compute_stats thread has been cancelled
[2021/11/15 18:26:12]    info: Wipe thread for device /dev/loop39 has been cancelled
[2021/11/15 18:26:12]    info: Wipe thread for device /dev/loop40 has been cancelled

******************************** Error Summary *********************************
!   Device | Pass Errors | Verifications Errors | Fdatasync I\O Errors
--------------------------------------------------------------------------------
    loop39 |           0 |                    0 |                    0
    loop40 |           0 |                    0 |                    0
********************************************************************************

********************************* Drive Status *********************************
!   Device | Status | Thru-put | HH:MM:SS | Model/Serial Number
--------------------------------------------------------------------------------
    loop39 | Erased |  51 MB/s | 00:00:27 | Loopback device/???????????????
    loop40 | Erased |  55 MB/s | 00:00:25 | Loopback device/???????????????
--------------------------------------------------------------------------------
[2021/11/15 18:26:12] Total Throughput 106 MB/s, Fill With Zeros, 1R+B+VL
********************************************************************************

[2021/11/15 18:26:12]    info: Nwipe was aborted by the user. Check the summary table for the drive status.
```
![nwipe_serial_numbers_anonymized_when_serial_number_was_obtainable](https://user-images.githubusercontent.com/22084881/141836143-9e81a7fd-d709-4e0e-9c9c-86f73e8b491c.png)

![nwipe_serial_numbers_anonymized_when_serial_number_was_obtainable_during_wipe](https://user-images.githubusercontent.com/22084881/141836170-60937b6b-b59c-4dc7-88fd-37ac142e490c.png)


```
sudo ./nwipe -v -q
[2021/11/15 18:33:17]    info: nwipe 0.32.006
[2021/11/15 18:33:17]    info: Linux version 5.11.0-38-generic (buildd@lgw01-am
                               d64-041) (gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.
                               3.0, GNU ld (GNU Binutils for Ubuntu) 2.34) #42
                               ~20.04.1-Ubuntu SMP Tue Sep 28 20:41:07 UTC 202
                               1
[2021/11/15 18:33:17]   debug: Readlink: ../devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda 
[2021/11/15 18:33:17]   debug: smartctl: smartctl 7.1 2019-12-30 r5022 [x86_64-linux-5.11.0-38-generic] (local build) 
[2021/11/15 18:33:17]   debug: smartctl: Copyright (C) 2002-19, Bruce Allen, Christian Franke, www.smartmontools.org 
[2021/11/15 18:33:17]   debug: smartctl: === START OF INFORMATION SECTION === 
[2021/11/15 18:33:17]   debug: smartctl: Device Model:     SanDisk SDSSDH3 500G 
[2021/11/15 18:33:17]   debug: smartctl: Serial Number:    XXXXXXXXXXXX 
[2021/11/15 18:33:17]   debug: smartctl: LU WWN Device Id: 5 001b44 4a8325368 
[2021/11/15 18:33:17]   debug: smartctl: Firmware Version: 401120RL 
[2021/11/15 18:33:17]   debug: smartctl: User Capacity:    500,107,862,016 bytes [500 GB] 
[2021/11/15 18:33:17]   debug: smartctl: Sector Size:      512 bytes logical/physical 
[2021/11/15 18:33:17]   debug: smartctl: Rotation Rate:    Solid State Device 
[2021/11/15 18:33:17]   debug: smartctl: Form Factor:      2.5 inches 
[2021/11/15 18:33:17]   debug: smartctl: Device is:        Not in smartctl database [for details use: -P showall] 
[2021/11/15 18:33:17]   debug: smartctl: ATA Version is:   ACS-4 T13/BSR INCITS 529 revision 5 
[2021/11/15 18:33:17]   debug: smartctl: SATA Version is:  SATA 3.3, 6.0 Gb/s (current: 6.0 Gb/s) 
[2021/11/15 18:33:17]   debug: smartctl: Local Time is:    Mon Nov 15 18:33:17 2021 GMT 
[2021/11/15 18:33:17]   debug: smartctl: SMART support is: Available - device has SMART capability. 
[2021/11/15 18:33:17]   debug: smartctl: SMART support is: Enabled 
[2021/11/15 18:33:17]  notice: Found /dev/sda,  ATA, SanDisk SDSSDH3, 500 GB, S/N=XXXXXXXXXXXXXXX
[2021/11/15 18:33:17]   debug: Readlink: ../devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb 
[2021/11/15 18:33:17]   debug: smartctl: smartctl 7.1 2019-12-30 r5022 [x86_64-linux-5.11.0-38-generic] (local build) 
[2021/11/15 18:33:17]   debug: smartctl: Copyright (C) 2002-19, Bruce Allen, Christian Franke, www.smartmontools.org 
[2021/11/15 18:33:18]   debug: smartctl: === START OF INFORMATION SECTION === 
[2021/11/15 18:33:18]   debug: smartctl: Model Family:     Seagate FireCuda 2.5 
[2021/11/15 18:33:18]   debug: smartctl: Device Model:     ST2000LX001-1RG174 
[2021/11/15 18:33:18]   debug: smartctl: Serial Number:    XXXXXXXX 
[2021/11/15 18:33:18]   debug: smartctl: LU WWN Device Id: 5 000c50 0c0bcd5bc 
[2021/11/15 18:33:18]   debug: smartctl: Firmware Version: SDM1 
[2021/11/15 18:33:18]   debug: smartctl: User Capacity:    2,000,398,934,016 bytes [2.00 TB] 
[2021/11/15 18:33:18]   debug: smartctl: Sector Sizes:     512 bytes logical, 4096 bytes physical 
[2021/11/15 18:33:18]   debug: smartctl: Rotation Rate:    5400 rpm 
[2021/11/15 18:33:18]   debug: smartctl: Form Factor:      2.5 inches 
[2021/11/15 18:33:18]   debug: smartctl: Device is:        In smartctl database [for details use: -P show] 
[2021/11/15 18:33:18]   debug: smartctl: ATA Version is:   ACS-3 T13/2161-D revision 3b 
[2021/11/15 18:33:18]   debug: smartctl: SATA Version is:  SATA 3.1, 6.0 Gb/s (current: 6.0 Gb/s) 
[2021/11/15 18:33:18]   debug: smartctl: Local Time is:    Mon Nov 15 18:33:18 2021 GMT 
[2021/11/15 18:33:18]   debug: smartctl: SMART support is: Available - device has SMART capability. 
[2021/11/15 18:33:18]   debug: smartctl: SMART support is: Enabled 
[2021/11/15 18:33:18]  notice: Found /dev/sdb,  ATA, ST2000LX001-1RG1,   2 TB, S/N=XXXXXXXXXXXXXXX
[2021/11/15 18:33:18]   debug: Readlink: ../devices/pci0000:00/0000:00:1c.3/0000:04:00.0/usb4/4-2/4-2:1.0/host6/target6:0:0/6:0:0:0/block/sdc 
[2021/11/15 18:33:18]   debug: smartctl: smartctl 7.1 2019-12-30 r5022 [x86_64-linux-5.11.0-38-generic] (local build) 
[2021/11/15 18:33:18]   debug: smartctl: Copyright (C) 2002-19, Bruce Allen, Christian Franke, www.smartmontools.org 
[2021/11/15 18:33:18]   debug: smartctl: === START OF INFORMATION SECTION === 
[2021/11/15 18:33:18]   debug: smartctl: Model Family:     Seagate Barracuda 3.5 
[2021/11/15 18:33:18]   debug: smartctl: Device Model:     ST1000DM010-2EP102 
[2021/11/15 18:33:18]   debug: smartctl: Serial Number:    XXXXXXXX 
[2021/11/15 18:33:18]   debug: smartctl: LU WWN Device Id: 5 000c50 0cfe5ec01 
[2021/11/15 18:33:18]   debug: smartctl: Firmware Version: CC43 
[2021/11/15 18:33:18]   debug: smartctl: User Capacity:    1,000,204,886,016 bytes [1.00 TB] 
[2021/11/15 18:33:18]   debug: smartctl: Sector Sizes:     512 bytes logical, 4096 bytes physical 
[2021/11/15 18:33:18]   debug: smartctl: Rotation Rate:    7200 rpm 
[2021/11/15 18:33:18]   debug: smartctl: Form Factor:      3.5 inches 
[2021/11/15 18:33:18]   debug: smartctl: Device is:        In smartctl database [for details use: -P show] 
[2021/11/15 18:33:18]   debug: smartctl: ATA Version is:   ATA8-ACS T13/1699-D revision 4 
[2021/11/15 18:33:18]   debug: smartctl: SATA Version is:  SATA 3.0, 6.0 Gb/s (current: 3.0 Gb/s) 
[2021/11/15 18:33:18]   debug: smartctl: Local Time is:    Mon Nov 15 18:33:18 2021 GMT 
[2021/11/15 18:33:18]   debug: smartctl: SMART support is: Available - device has SMART capability. 
[2021/11/15 18:33:18]   debug: smartctl: SMART support is: Enabled 
[2021/11/15 18:33:18]  notice: Found /dev/sdc,  USB, ST1000DM 010-2EP102,   1 TB, S/N=XXXXXXXXXXXXXXX
[2021/11/15 18:33:18]   debug: Readlink: ../devices/pci0000:00/0000:00:1d.0/usb2/2-1/2-1.1/2-1.1:1.0/host7/target7:0:0/7:0:0:0/block/sdd 
[2021/11/15 18:33:18]   debug: smartctl: smartctl 7.1 2019-12-30 r5022 [x86_64-linux-5.11.0-38-generic] (local build) 
[2021/11/15 18:33:18]   debug: smartctl: Copyright (C) 2002-19, Bruce Allen, Christian Franke, www.smartmontools.org 
[2021/11/15 18:33:18]   debug: smartctl: === START OF INFORMATION SECTION === 
[2021/11/15 18:33:18]   debug: smartctl: Model Family:     Western Digital AV-GP (AF) 
[2021/11/15 18:33:18]   debug: smartctl: Device Model:     WDC WD20EURS-63SPKY0 
[2021/11/15 18:33:18]   debug: smartctl: Serial Number:    XXXXXXXXXXXXXXX 
[2021/11/15 18:33:18]   debug: smartctl: LU WWN Device Id: 5 0014ee 2b35d64d4 
[2021/11/15 18:33:18]   debug: smartctl: Firmware Version: 80.00A80 
[2021/11/15 18:33:18]   debug: smartctl: User Capacity:    2,000,398,934,016 bytes [2.00 TB] 
[2021/11/15 18:33:18]   debug: smartctl: Sector Sizes:     512 bytes logical, 4096 bytes physical 
[2021/11/15 18:33:18]   debug: smartctl: Device is:        In smartctl database [for details use: -P show] 
[2021/11/15 18:33:18]   debug: smartctl: ATA Version is:   ACS-2 (minor revision not indicated) 
[2021/11/15 18:33:18]   debug: smartctl: SATA Version is:  SATA 3.0, 3.0 Gb/s (current: 1.5 Gb/s) 
[2021/11/15 18:33:18]   debug: smartctl: Local Time is:    Mon Nov 15 18:33:18 2021 GMT 
[2021/11/15 18:33:18]   debug: smartctl: SMART support is: Available - device has SMART capability. 
[2021/11/15 18:33:18]   debug: smartctl: SMART support is: Enabled 
[2021/11/15 18:33:18]  notice: Found /dev/sdd,  USB, WDC WD20 EURS-63SPKY0,   2 TB, S/N=XXXXXXXXXXXXXXX
[2021/11/15 18:33:18]    info: Automatically enumerated 4 devices.
[2021/11/15 18:33:18]  notice: bios-version = E16F2IM7 V5.0E
[2021/11/15 18:33:18]  notice: bios-release-date = 01/10/2012
[2021/11/15 18:33:18]  notice: system-manufacturer = MEDION
[2021/11/15 18:33:18]  notice: system-product-name = X681X
[2021/11/15 18:33:18]  notice: system-version = To be filled by O.E.M.
[2021/11/15 18:33:18]  notice: system-serial-number = To be filled by O.E.M.
[2021/11/15 18:33:18]  notice: system-uuid = 03000200-0400-0500-0006-000700080009
[2021/11/15 18:33:18]  notice: baseboard-manufacturer = MEDION
[2021/11/15 18:33:18]  notice: baseboard-product-name = X681X
[2021/11/15 18:33:18]  notice: baseboard-version = To be filled by O.E.M.
[2021/11/15 18:33:18]  notice: baseboard-serial-number = To be filled by O.E.M.
[2021/11/15 18:33:18]  notice: baseboard-asset-tag = To be filled by O.E.M.
[2021/11/15 18:33:18]  notice: chassis-manufacturer = To Be Filled By O.E.M.
[2021/11/15 18:33:18]  notice: chassis-type = Notebook
[2021/11/15 18:33:18]  notice: chassis-version = To be filled by O.E.M.
[2021/11/15 18:33:18]  notice: chassis-serial-number = To Be Filled By O.E.M.
[2021/11/15 18:33:18]  notice: chassis-asset-tag = To Be Filled By O.E.M.
[2021/11/15 18:33:18]  notice: processor-family = Core i7
[2021/11/15 18:33:18]  notice: processor-manufacturer = Intel
[2021/11/15 18:33:18]  notice: processor-version = Intel(R) Core(TM) i7-2670QM CPU @ 2.20GHz
[2021/11/15 18:33:18]  notice: processor-frequency = 800 MHz
[2021/11/15 18:33:18]  notice: Opened entropy source '/dev/urandom'.
[2021/11/15 18:33:18]  notice: hwmon: Module drivetemp loaded, drive temperatures available
[2021/11/15 18:33:18]  notice: hwmon: Device sda has 'hwmon' temperature monitoring
[2021/11/15 18:33:18]  notice: hwmon: Device /dev/sda hwmon path = /sys/class/hwmon/hwmon4
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /sys/class/hwmon/hwmon4/temp1_crit
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /sys/class/hwmon/hwmon4/temp1_highest
[2021/11/15 18:33:18]  notice: hwmon: /sys/class/hwmon/hwmon4/temp1_input 27C
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /sys/class/hwmon/hwmon4/temp1_lcrit
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /sys/class/hwmon/hwmon4/temp1_lowest
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /sys/class/hwmon/hwmon4/temp1_max
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /sys/class/hwmon/hwmon4/temp1_min
[2021/11/15 18:33:18]  notice: hwmon: Device sdb has 'hwmon' temperature monitoring
[2021/11/15 18:33:18]  notice: hwmon: Device /dev/sdb hwmon path = /sys/class/hwmon/hwmon5
[2021/11/15 18:33:18]  notice: hwmon: /sys/class/hwmon/hwmon5/temp1_crit 60C
[2021/11/15 18:33:18]  notice: hwmon: /sys/class/hwmon/hwmon5/temp1_highest 37C
[2021/11/15 18:33:18]  notice: hwmon: /sys/class/hwmon/hwmon5/temp1_input 37C
[2021/11/15 18:33:18]  notice: hwmon: /sys/class/hwmon/hwmon5/temp1_lcrit 10C
[2021/11/15 18:33:18]  notice: hwmon: /sys/class/hwmon/hwmon5/temp1_lowest 18C
[2021/11/15 18:33:18]  notice: hwmon: /sys/class/hwmon/hwmon5/temp1_max 55C
[2021/11/15 18:33:18]  notice: hwmon: /sys/class/hwmon/hwmon5/temp1_min 14C
[2021/11/15 18:33:18]  notice: hwmon: Device /dev/sdc hwmon path = 
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /temp1_crit
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /temp1_highest
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /temp1_input
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /temp1_lcrit
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /temp1_lowest
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /temp1_max
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /temp1_min
[2021/11/15 18:33:18]  notice: hwmon: Device /dev/sdd hwmon path = 
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /temp1_crit
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /temp1_highest
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /temp1_input
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /temp1_lcrit
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /temp1_lowest
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /temp1_max
[2021/11/15 18:33:18]  notice: hwmon: Unable to  open /temp1_min
[2021/11/15 18:34:58]  notice: Program options are set as follows...
[2021/11/15 18:34:58]  notice:   autonuke = 0 (off)
[2021/11/15 18:34:58]  notice:   autopoweroff = 0 (off)
[2021/11/15 18:34:58]  notice:   banner   = nwipe 0.32.006
[2021/11/15 18:34:58]  notice:   prng     = Mersenne Twister
[2021/11/15 18:34:58]  notice:   method   = DoD Short
[2021/11/15 18:34:58]  notice:   quiet    = 1
[2021/11/15 18:34:58]  notice:   rounds   = 1
[2021/11/15 18:34:58]  notice:   sync     = 100000
[2021/11/15 18:34:58]  notice:   verify   = 1 (last pass)
[2021/11/15 18:34:58]  notice: /dev/sdc has serial number XXXXXXXXXXXXXXX
[2021/11/15 18:34:58]  notice: /dev/sdc, sect/blk/dev 512/4096/1000204886016
[2021/11/15 18:34:58]  notice: /dev/sdd has serial number XXXXXXXXXXXXXXX
[2021/11/15 18:34:58]  notice: /dev/sdd, sect/blk/dev 512/4096/2000398934016
[2021/11/15 18:34:58]  notice: Invoking method 'DoD Short' on /dev/sdc
[2021/11/15 18:34:58]  notice: Starting round 1 of 1 on /dev/sdc
[2021/11/15 18:34:58]  notice: Starting pass 1/3, round 1/1, on /dev/sdc
[2021/11/15 18:34:58]  notice: Invoking method 'DoD Short' on /dev/sdd
[2021/11/15 18:34:58]  notice: Starting round 1 of 1 on /dev/sdd
[2021/11/15 18:34:58]  notice: Starting pass 1/3, round 1/1, on /dev/sdd
[2021/11/15 18:34:58]  notice: hwmon: Unable to  open /temp1_crit
[2021/11/15 18:34:58]  notice: hwmon: Unable to  open /temp1_highest
[2021/11/15 18:34:58]  notice: hwmon: Unable to  open /temp1_input
[2021/11/15 18:34:58]  notice: hwmon: Unable to  open /temp1_lcrit
[2021/11/15 18:34:58]  notice: hwmon: Unable to  open /temp1_lowest
[2021/11/15 18:34:58]  notice: hwmon: Unable to  open /temp1_max
[2021/11/15 18:34:58]  notice: hwmon: Unable to  open /temp1_min
[2021/11/15 18:34:58]  notice: hwmon: Unable to  open /temp1_crit
[2021/11/15 18:34:58]  notice: hwmon: Unable to  open /temp1_highest
[2021/11/15 18:34:58]  notice: hwmon: Unable to  open /temp1_input
[2021/11/15 18:34:58]  notice: hwmon: Unable to  open /temp1_lcrit
[2021/11/15 18:34:58]  notice: hwmon: Unable to  open /temp1_lowest
[2021/11/15 18:34:58]  notice: hwmon: Unable to  open /temp1_max
[2021/11/15 18:34:58]  notice: hwmon: Unable to  open /temp1_min
[2021/11/15 18:35:59]  notice: hwmon: Unable to  open /temp1_crit
[2021/11/15 18:35:59]  notice: hwmon: Unable to  open /temp1_highest
[2021/11/15 18:35:59]  notice: hwmon: Unable to  open /temp1_input
[2021/11/15 18:35:59]  notice: hwmon: Unable to  open /temp1_lcrit
[2021/11/15 18:35:59]  notice: hwmon: Unable to  open /temp1_lowest
[2021/11/15 18:35:59]  notice: hwmon: Unable to  open /temp1_max
[2021/11/15 18:35:59]  notice: hwmon: Unable to  open /temp1_min
[2021/11/15 18:35:59]  notice: hwmon: Unable to  open /temp1_crit
[2021/11/15 18:35:59]  notice: hwmon: Unable to  open /temp1_highest
[2021/11/15 18:35:59]  notice: hwmon: Unable to  open /temp1_input
[2021/11/15 18:35:59]  notice: hwmon: Unable to  open /temp1_lcrit
[2021/11/15 18:35:59]  notice: hwmon: Unable to  open /temp1_lowest
[2021/11/15 18:35:59]  notice: hwmon: Unable to  open /temp1_max
[2021/11/15 18:35:59]  notice: hwmon: Unable to  open /temp1_min
[2021/11/15 18:36:06]    info: Exit in progress
[2021/11/15 18:36:06]    info: Requesting wipe thread cancellation for /dev/sdc
[2021/11/15 18:36:06]    info: Please wait..
[2021/11/15 18:36:06]    info: Requesting wipe thread cancellation for /dev/sdd
[2021/11/15 18:36:06]    info: Please wait..
[2021/11/15 18:36:06]    info: Cancelling the GUI thread.
[2021/11/15 18:36:06]    info: GUI compute_stats thread has been cancelled
[2021/11/15 18:36:08]    info: Wipe thread for device /dev/sdc has been cancelled
[2021/11/15 18:36:09]    info: Wipe thread for device /dev/sdd has been cancelled
[2021/11/15 18:36:09]   fatal: Nwipe exited with non fatal errors on device = /dev/sdc

[2021/11/15 18:36:09]   error: Nwipe exited with fatal errors on device = /dev/sdd


******************************** Error Summary *********************************
!   Device | Pass Errors | Verifications Errors | Fdatasync I\O Errors
--------------------------------------------------------------------------------
       sdc |           0 |                    0 |                    0
       sdd |           0 |                    0 |                    0
********************************************************************************

********************************* Drive Status *********************************
!   Device | Status | Thru-put | HH:MM:SS | Model/Serial Number
--------------------------------------------------------------------------------
!      sdc |UABORTED| 144 MB/s | 00:01:11 | ST1000DM 010-2EP1/XXXXXXXXXXXXXXX
!      sdd |-FAILED-|  36 MB/s | 00:01:11 | WDC WD20 EURS-63S/XXXXXXXXXXXXXXX
--------------------------------------------------------------------------------
[2021/11/15 18:36:09] Total Throughput 180 MB/s, DoD Short, 1R+B+VL
********************************************************************************
```


