### PR TITLE
Anonymize SMBIOS/DMI data if -q --quiet specified

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -498,29 +498,36 @@ int nwipe_log_sysinfo()
      * be logged, making sure the last entry in the array is a NULL string. To remove
      * an entry simply comment out the keyword with //
      */
-    char dmidecode_keywords[][24] = {
-        "bios-version",
-        "bios-release-date",
-        "system-manufacturer",
-        "system-product-name",
-        "system-version",
-        "system-serial-number",
-        "system-uuid",
-        "baseboard-manufacturer",
-        "baseboard-product-name",
-        "baseboard-version",
-        "baseboard-serial-number",
-        "baseboard-asset-tag",
-        "chassis-manufacturer",
-        "chassis-type",
-        "chassis-version",
-        "chassis-serial-number",
-        "chassis-asset-tag",
-        "processor-family",
-        "processor-manufacturer",
-        "processor-version",
-        "processor-frequency",
-        ""  // terminates the keyword array. DO NOT REMOVE
+
+    /* The 0/1 after the keyword determines whether the data for this
+     * keyword is displayed when -q (anonymize) has been specified
+     * by the user. An quick reminder about multi dimensional arrays, the first
+     * []=the keyword (0-21) including the empty string. The second [] is the
+     * 1 or 0 value (0 or 1). The third [] is the index value into either string.
+     */
+    char dmidecode_keywords[][2][24] = {
+        { "bios-version", "1" },
+        { "bios-release-date", "1" },
+        { "system-manufacturer", "1" },
+        { "system-product-name", "1" },
+        { "system-version", "1" },
+        { "system-serial-number", "0" },
+        { "system-uuid", "0" },
+        { "baseboard-manufacturer", "1" },
+        { "baseboard-product-name", "1" },
+        { "baseboard-version", "1" },
+        { "baseboard-serial-number", "0" },
+        { "baseboard-asset-tag", "0" },
+        { "chassis-manufacturer", "1" },
+        { "chassis-type", "1" },
+        { "chassis-version", "1" },
+        { "chassis-serial-number", "0" },
+        { "chassis-asset-tag", "0" },
+        { "processor-family", "1" },
+        { "processor-manufacturer", "1" },
+        { "processor-version", "1" },
+        { "processor-frequency", "1" },
+        { "", "" }  // terminates the keyword array. DO NOT REMOVE
     };
 
     char dmidecode_command[] = "dmidecode -s %s";
@@ -563,9 +570,9 @@ int nwipe_log_sysinfo()
     {
 
         /* Run the dmidecode command to retrieve each dmidecode keyword, one at a time */
-        while( dmidecode_keywords[keywords_idx][0] != 0 )
+        while( dmidecode_keywords[keywords_idx][0][0] != 0 )
         {
-            sprintf( cmd, p_dmidecode_command, &dmidecode_keywords[keywords_idx][0] );
+            sprintf( cmd, p_dmidecode_command, &dmidecode_keywords[keywords_idx][0][0] );
             fp = popen( cmd, "r" );
             if( fp == NULL )
             {
@@ -581,7 +588,22 @@ int nwipe_log_sysinfo()
                 {
                     path[len - 1] = 0;
                 }
-                nwipe_log( NWIPE_LOG_NOTICE, "%s = %s", &dmidecode_keywords[keywords_idx][0], path );
+                if( nwipe_options.quiet )
+                {
+                    if( *( &dmidecode_keywords[keywords_idx][1][0] ) == '0' )
+                    {
+                        nwipe_log(
+                            NWIPE_LOG_NOTICE, "%s = %s", &dmidecode_keywords[keywords_idx][0][0], "XXXXXXXXXXXXXXX" );
+                    }
+                    else
+                    {
+                        nwipe_log( NWIPE_LOG_NOTICE, "%s = %s", &dmidecode_keywords[keywords_idx][0][0], path );
+                    }
+                }
+                else
+                {
+                    nwipe_log( NWIPE_LOG_NOTICE, "%s = %s", &dmidecode_keywords[keywords_idx][0][0], path );
+                }
             }
             /* close */
             r = pclose( fp );


### PR DESCRIPTION
Anonymize SMBIOS/DMI data if -q --quiet specified by the user.
```
sudo ./nwipe -q
[2021/11/15 21:49:54]    info: nwipe 0.32.006
[2021/11/15 21:49:54]    info: Linux version 5.11.0-38-generic (buildd@lgw01-am
                               d64-041) (gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.
                               3.0, GNU ld (GNU Binutils for Ubuntu) 2.34) #42
                               ~20.04.1-Ubuntu SMP Tue Sep 28 20:41:07 UTC 202
                               1
[2021/11/15 21:49:54]  notice: Found /dev/sda,  ATA, SanDisk SDSSDH3, 500 GB, S/N=XXXXXXXXXXXXXXX
[2021/11/15 21:49:54]  notice: Found /dev/sdb,  ATA, ST2000LX001-1RG1,   2 TB, S/N=XXXXXXXXXXXXXXX
[2021/11/15 21:49:54]  notice: Found /dev/sdc,  USB, ST1000DM 010-2EP102,   1 TB, S/N=XXXXXXXXXXXXXXX
[2021/11/15 21:49:54]  notice: Found /dev/sdd,  USB, WDC WD20 EURS-63SPKY0,   2 TB, S/N=XXXXXXXXXXXXXXX
[2021/11/15 21:49:54]    info: Automatically enumerated 4 devices.
[2021/11/15 21:49:54]  notice: bios-version = E16F2IM7 V5.0E
[2021/11/15 21:49:54]  notice: bios-release-date = 01/10/2012
[2021/11/15 21:49:54]  notice: system-manufacturer = MEDION
[2021/11/15 21:49:54]  notice: system-product-name = X681X
[2021/11/15 21:49:54]  notice: system-version = To be filled by O.E.M.
[2021/11/15 21:49:54]  notice: system-serial-number = XXXXXXXXXXXXXXX
[2021/11/15 21:49:54]  notice: system-uuid = XXXXXXXXXXXXXXX
[2021/11/15 21:49:54]  notice: baseboard-manufacturer = MEDION
[2021/11/15 21:49:54]  notice: baseboard-product-name = X681X
[2021/11/15 21:49:54]  notice: baseboard-version = To be filled by O.E.M.
[2021/11/15 21:49:54]  notice: baseboard-serial-number = XXXXXXXXXXXXXXX
[2021/11/15 21:49:54]  notice: baseboard-asset-tag = XXXXXXXXXXXXXXX
[2021/11/15 21:49:54]  notice: chassis-manufacturer = To Be Filled By O.E.M.
[2021/11/15 21:49:54]  notice: chassis-type = Notebook
[2021/11/15 21:49:54]  notice: chassis-version = To be filled by O.E.M.
[2021/11/15 21:49:54]  notice: chassis-serial-number = XXXXXXXXXXXXXXX
[2021/11/15 21:49:54]  notice: chassis-asset-tag = XXXXXXXXXXXXXXX
[2021/11/15 21:49:54]  notice: processor-family = Core i7
[2021/11/15 21:49:54]  notice: processor-manufacturer = Intel
[2021/11/15 21:49:54]  notice: processor-version = Intel(R) Core(TM) i7-2670QM CPU @ 2.20GHz
[2021/11/15 21:49:54]  notice: processor-frequency = 800 MHz
[2021/11/15 21:49:54]  notice: Opened entropy source '/dev/urandom'.
[2021/11/15 21:49:54]  notice: hwmon: Module drivetemp loaded, drive temperatures available
[2021/11/15 21:49:54]  notice: hwmon: Device sda has 'hwmon' temperature monitoring
[2021/11/15 21:49:54]  notice: hwmon: Device sdb has 'hwmon' temperature monitoring
[2021/11/15 21:49:56]    info: Nwipe was aborted by the user prior to the wipe starting.
```