### PR TITLE
Fix summary table - Control-C

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -758,7 +758,7 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
         /* Any errors ? if so set the exclamation_flag and fail message,
          * All status messages should be eight characters EXACTLY !
          */
-        if( c[i]->result < 0 )
+        if( c[i]->pass_errors != 0 || c[i]->verify_errors != 0 || c[i]->fsyncdata_errors != 0 )
         {
             strncpy( exclamation_flag, "!", 1 );
             exclamation_flag[1] = 0;
@@ -768,44 +768,32 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
         }
         else
         {
-
-            if( c[i]->pass_errors != 0 || c[i]->verify_errors != 0 )
+            if( c[i]->wipe_status == 0 )
             {
-                strncpy( exclamation_flag, "!", 1 );
+                strncpy( exclamation_flag, " ", 1 );
                 exclamation_flag[1] = 0;
 
-                strncpy( status, "-FAILED-", 8 );
+                strncpy( status, " Erased ", 8 );
                 status[8] = 0;
             }
             else
             {
-                if( c[i]->wipe_status == 0 )
+                if( user_abort == 1 )
                 {
-                    strncpy( exclamation_flag, " ", 1 );
+                    strncpy( exclamation_flag, "!", 1 );
                     exclamation_flag[1] = 0;
 
-                    strncpy( status, " Erased ", 8 );
+                    strncpy( status, "UABORTED", 8 );
                     status[8] = 0;
                 }
                 else
                 {
-                    if( user_abort == 1 )
-                    {
-                        strncpy( exclamation_flag, "!", 1 );
-                        exclamation_flag[1] = 0;
+                    /* If this ever happens, there is a bug ! */
+                    strncpy( exclamation_flag, " ", 1 );
+                    exclamation_flag[1] = 0;
 
-                        strncpy( status, "UABORTED", 8 );
-                        status[8] = 0;
-                    }
-                    else
-                    {
-                        /* If this ever happens, there is a bug ! */
-                        strncpy( exclamation_flag, " ", 1 );
-                        exclamation_flag[1] = 0;
-
-                        strncpy( status, "INSANITY", 8 );
-                        status[8] = 0;
-                    }
+                    strncpy( status, "INSANITY", 8 );
+                    status[8] = 0;
                 }
             }
         }

--- a/src/method.c
+++ b/src/method.c
@@ -804,8 +804,6 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
     /* For the selected method, calculate the correct round_size value (for correct percentage calculation) */
     calculate_round_size( c );
 
-    c->result = c->round_size;
-
     /* If only verifying then the round size is the device size */
     if( nwipe_options.method == &nwipe_verify_zero || nwipe_options.method == &nwipe_verify_one )
     {


### PR DESCRIPTION
If you used control-c during a wipe,
the summary table would report FAILED
rather than UABORTED, even though no
errors had occured and no errors were
reported in the error summary table.

The correct message on control-c abort
should be UABORTED if no errors on that
drive had so far been detected or FAILED
if errors had been detected.

nwipe reported correctly when letting
the wipe continue to it's natural completion.

This patch fixes that issue.