### PR TITLE
Make verify & pass error succinct

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2698,11 +2698,11 @@ void* nwipe_gui_status( void* ptr )
 
                 if( c[i]->verify_errors )
                 {
-                    wprintw( main_window, "[verify errors: %llu] ", c[i]->verify_errors );
+                    wprintw( main_window, "[verr:%llu] ", c[i]->verify_errors );
                 }
                 if( c[i]->pass_errors )
                 {
-                    wprintw( main_window, "[pass errors: %llu] ", c[i]->pass_errors );
+                    wprintw( main_window, "[perr:%llu] ", c[i]->pass_errors );
                 }
                 if( c[i]->wipe_status == 1 )
                 {

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.32.007";
+const char* version_string = "0.32.008";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.32.007";
+const char* banner = "nwipe 0.32.008";


### PR DESCRIPTION
When many verification or pass errors are detected
the status line can wrap on a 80 column display.

This patch makes the error message more succinct
which will free up about 10 characters & prevents
the line wrapping.