### PR TITLE
Fixes ETA under fault condition

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2926,18 +2926,18 @@ int compute_stats( void* ptr )
                 /* Update the current average throughput in bytes-per-second. */
                 c[i]->throughput = c[i]->speedring.bytestotal / c[i]->speedring.timestotal;
 
-                /* Update the estimated remaining runtime. */
-                /* Check that throughput is not zero (sometimes caused during a sync) */
-                if( c[i]->throughput == 0 )
+                /* Only update the estimated remaining runtime if the
+                 * throughput for a given drive is greater than 100,000 bytes per second
+                 * This prevents enormous ETA's being calculated on an unresponsive
+                 * drive */
+                if( c[i]->throughput > 100000 )
                 {
-                    c[i]->throughput = 1;
-                }
+                    c[i]->eta = ( c[i]->round_size - c[i]->round_done ) / c[i]->throughput;
 
-                c[i]->eta = ( c[i]->round_size - c[i]->round_done ) / c[i]->throughput;
-
-                if( c[i]->eta > nwipe_misc_thread_data->maxeta )
-                {
-                    nwipe_misc_thread_data->maxeta = c[i]->eta;
+                    if( c[i]->eta > nwipe_misc_thread_data->maxeta )
+                    {
+                        nwipe_misc_thread_data->maxeta = c[i]->eta;
+                    }
                 }
             }
 

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.32.008";
+const char* version_string = "0.32.009";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.32.008";
+const char* banner = "nwipe 0.32.009";


### PR DESCRIPTION
If a faulty drive fails mid wipe and it's
throughput drops until eventually reaching
zero. The ETA calculation grows to an enormously
high value.

This patch prevents the ETA being calculated if
the throughput for a given drive drops below
100,000 bytes per second. In this way we can still
see that something is wrong because the ETA is much
higher than normal but prevents the sort of calculation
that looks like this ! 90867213:29:12 i.e ..
90,867,213 hours, 29 minutes and 12 seconds, or put
another way, 3,786,133 days or 10,372 years.

Fixes #372 