### PR TITLE
Distinguish between a wipe & verify

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -727,19 +727,28 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
                 {
                     case NWIPE_SELECT_TRUE:
 
-                        wprintw( main_window,
-                                 "[wipe] %s %s [%s] ",
-                                 // c[i + offset]->device_name,
-                                 c[i + offset]->gui_device_name,
-                                 c[i + offset]->device_type_str,
-                                 c[i + offset]->device_size_text );
+                        if( nwipe_options.method == &nwipe_verify_zero || nwipe_options.method == &nwipe_verify_one )
+                        {
+                            wprintw( main_window,
+                                     "[vrfy] %s %s [%s] ",
+                                     c[i + offset]->gui_device_name,
+                                     c[i + offset]->device_type_str,
+                                     c[i + offset]->device_size_text );
+                        }
+                        else
+                        {
+                            wprintw( main_window,
+                                     "[wipe] %s %s [%s] ",
+                                     c[i + offset]->gui_device_name,
+                                     c[i + offset]->device_type_str,
+                                     c[i + offset]->device_size_text );
+                        }
                         break;
 
                     case NWIPE_SELECT_FALSE:
                         /* Print an element that is not selected. */
                         wprintw( main_window,
                                  "[    ] %s %s [%s] ",
-                                 // c[i + offset]->device_name,
                                  c[i + offset]->gui_device_name,
                                  c[i + offset]->device_type_str,
                                  c[i + offset]->device_size_text );
@@ -750,7 +759,6 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
                         /* This element will be wiped when its parent is wiped. */
                         wprintw( main_window,
                                  "[****] %s %s [%s] ",
-                                 // c[i + offset]->device_name,
                                  c[i + offset]->gui_device_name,
                                  c[i + offset]->device_type_str,
                                  c[i + offset]->device_size_text );
@@ -761,7 +769,6 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
                         /* We can't wipe this element because it has a child that is being wiped. */
                         wprintw( main_window,
                                  "[----] %s %s [%s] ",
-                                 // c[i + offset]->device_name,
                                  c[i + offset]->gui_device_name,
                                  c[i + offset]->device_type_str,
                                  c[i + offset]->device_size_text );


### PR DESCRIPTION
In the drive selection window when you
select a drive, the drive is identified
as selected for wiping with the [wipe]
label, however if you then select a
verify only method such as 'verify with
ones' or 'verify with zeros' it still
says [wipe] which is technically a
contradiction.

This patch changes the [wipe] to a
[vrfy] when a verify only method is
selected. If a method is selected
that writes data to the disc then the
label is displayed as [wipe]

https://user-images.githubusercontent.com/22084881/142231125-7c7945d0-8aae-4c7e-8cc0-0bdea9d336f5.mp4