### PR TITLE
Make it clear we are in anonymized mode

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -401,6 +401,9 @@ void nwipe_gui_create_main_window()
 
 void nwipe_gui_create_header_window()
 {
+    char anon_label[] = " (ANONYMIZED)";
+    char bannerplus[80];
+
     /* Create the header window. */
     header_window = newwin( NWIPE_GUI_HEADER_H, NWIPE_GUI_HEADER_W, NWIPE_GUI_HEADER_Y, NWIPE_GUI_HEADER_X );
     header_panel = new_panel( header_window );
@@ -419,8 +422,16 @@ void nwipe_gui_create_header_window()
     /* Clear the header window. */
     werase( header_window );
 
+    /* If in anonymized mode modify the title banner to reflect this */
+    strcpy( bannerplus, banner );
+
+    if( nwipe_options.quiet )
+    {
+        strcat( bannerplus, anon_label );
+    }
+
     /* Print the product banner. */
-    nwipe_gui_title( header_window, banner );
+    nwipe_gui_title( header_window, bannerplus );
 
     /* Refresh the header window */
     wnoutrefresh( header_window );

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.32.010";
+const char* version_string = "0.32.011";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.32.010";
+const char* banner = "nwipe 0.32.011";


### PR DESCRIPTION
When selecting -q or --quiet as an nwipe
option, append " (ANONYMIZED)" to the nwipe
banner.

![nwipe_anonymized_banner](https://user-images.githubusercontent.com/22084881/142239901-088b3d66-6ce7-4abe-935e-1738d729fffd.png)


