### PR TITLE
Update temperature for some nvme devices

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.32.012";
+const char* version_string = "0.32.013";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.32.012";
+const char* banner = "nwipe 0.32.013";


### PR DESCRIPTION
Add /sys/class/hwmon/hwmonX/device/ to the list
of directories to search for a given device.

Some nvme devices/controllers put the device name
in /sys/class/hwmon/hwmonX/device/ rather than
/sys/class/hwmon/hwmonX/device/nvme/nvme0/

Update debug messaging.