### PR TITLE
Fix 2nd occurrence of incorrect format specifier.

### DIFF
--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -456,7 +456,7 @@ int main( int argc, char** argv )
             else
             {
                 nwipe_log( NWIPE_LOG_NOTICE,
-                           "%s, sect/blk/dev %llu/%i/%llu",
+                           "%s, sect/blk/dev %i/%i/%llu",
                            c2[i]->device_name,
                            c2[i]->device_sector_size,
                            c2[i]->device_block_size,

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.32.015";
+const char* version_string = "0.32.016";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.32.015";
+const char* banner = "nwipe 0.32.016";


### PR DESCRIPTION
Causing incorrect sect/block/device size to be
printed in nwipe_log but only for 32 bit builds.