### PR TITLE
Improve GUI thread cancellation messaging

### DIFF
--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -610,9 +610,12 @@ int main( int argc, char** argv )
         {
             nwipe_log( NWIPE_LOG_WARNING, "main()>pthread_join():Error when waiting for GUI thread to cancel." );
         }
-        if( nwipe_options.verbose )
+        else
         {
-            nwipe_log( NWIPE_LOG_INFO, "GUI compute_stats thread has been cancelled" );
+            if( nwipe_options.verbose )
+            {
+                nwipe_log( NWIPE_LOG_INFO, "GUI compute_stats thread has been cancelled" );
+            }
         }
     }
 

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.32.017";
+const char* version_string = "0.32.018";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.32.017";
+const char* banner = "nwipe 0.32.018";


### PR DESCRIPTION
If pthread_join failed, nwipe would report an error
but would also report that the thread had been
cancelled. This has been corrected so that only
the error message is displayed in a fault condition.