### PR TITLE
Fix missing serial number on SAS drive

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.32.018";
+const char* version_string = "0.32.019";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.32.018";
+const char* banner = "nwipe 0.32.019";


### PR DESCRIPTION
This was caused by inconsistent labeling of the
serial number by smartctl. In a majority of cases
smartctl would output serial number data using
the label "Serial Number:" however on a SAS
drive we found that smartctl output the label
as "Serial number:" i.e. differs with a lower
case 'n'. Unfortunately we were doing a case
sensitive search for "Serial Number" so the result
being the serial number was not found.

This patch converts both strings in the search
to lower case before searching.

In addition a new field was added to the
anonymize list, "logical unit id:" so when the
-q option is used "serial number", "lu wwn device id:"
and "logical unit id:" are all now anonymized in the
smartctl debug data.

Fixes #384 