### PR TITLE
Added ISAAC-64 PRNG for 64-bit systems.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,5 +6,5 @@ AM_LDFLAGS =
 # this lists the binaries to produce, the (non-PHONY, binary) targets in
 # the previous manual Makefile
 bin_PROGRAMS = nwipe
-nwipe_SOURCES = context.h isaac_rand/isaac_rand.c logging.h options.h prng.h version.h temperature.h nwipe.c gui.c isaac_rand/isaac_rand.h method.h pass.c device.c gui.h isaac_rand/isaac_standard.h mt19937ar-cok/mt19937ar-cok.c nwipe.h mt19937ar-cok/mt19937ar-cok.h pass.h device.h logging.c method.c options.c prng.c version.c temperature.c
+nwipe_SOURCES = context.h logging.h options.h prng.h version.h temperature.h nwipe.c gui.c method.h pass.c device.c gui.h isaac_rand/isaac_standard.h isaac_rand/isaac_rand.h isaac_rand/isaac_rand.c isaac_rand/isaac64.h isaac_rand/isaac64.c mt19937ar-cok/mt19937ar-cok.c nwipe.h mt19937ar-cok/mt19937ar-cok.h pass.h device.h logging.c method.c options.c prng.c version.c temperature.c
 nwipe_LDADD = $(PARTED_LIBS)

--- a/src/gui.c
+++ b/src/gui.c
@@ -1464,10 +1464,11 @@ void nwipe_gui_prng( void )
 
     extern nwipe_prng_t nwipe_twister;
     extern nwipe_prng_t nwipe_isaac;
+    extern nwipe_prng_t nwipe_isaac64;
     extern int terminate_signal;
 
     /* The number of implemented PRNGs. */
-    const int count = 2;
+    const int count = 3;
 
     /* The first tabstop. */
     const int tab1 = 2;
@@ -1497,6 +1498,10 @@ void nwipe_gui_prng( void )
     {
         focus = 1;
     }
+    if( nwipe_options.prng == &nwipe_isaac64 )
+    {
+        focus = 2;
+    }
 
     do
     {
@@ -1506,15 +1511,16 @@ void nwipe_gui_prng( void )
         nwipe_gui_create_all_windows_on_terminal_resize( 0, selection_footer );
 
         /* Initialize the working row. */
-        yy = 2;
+        yy = 3;
 
         /* Print the options. */
         mvwprintw( main_window, yy++, tab1, "  %s", nwipe_twister.label );
         mvwprintw( main_window, yy++, tab1, "  %s", nwipe_isaac.label );
+        mvwprintw( main_window, yy++, tab1, "  %s", nwipe_isaac64.label );
         mvwprintw( main_window, yy++, tab1, "" );
 
         /* Print the cursor. */
-        mvwaddch( main_window, 2 + focus, tab1, ACS_RARROW );
+        mvwaddch( main_window, 3 + focus, tab1, ACS_RARROW );
 
         switch( focus )
         {
@@ -1564,6 +1570,34 @@ void nwipe_gui_prng( void )
                            yy++,
                            tab1,
                            "                                                                            " );
+                mvwprintw( main_window,
+                           yy++,
+                           tab1,
+                           "Performs best on a 32-bit CPU. Use ISAAC-64 if this system has a 64-bit CPU." );
+                break;
+
+            case 2:
+
+                mvwprintw( main_window,
+                           yy++,
+                           tab1,
+                           "ISAAC-64, by Bob Jenkins, is like 32-bit ISAAC, but with a minimum period of" );
+                mvwprintw( main_window,
+                           yy++,
+                           tab1,
+                           "2^77 and an expected period of 2^16583. It is difficult to recover the      " );
+                mvwprintw( main_window,
+                           yy++,
+                           tab1,
+                           "initial PRNG state by cryptanalysis of the ISAAC-64 stream.                 " );
+                mvwprintw( main_window,
+                           yy++,
+                           tab1,
+                           "                                                                            " );
+                mvwprintw( main_window,
+                           yy++,
+                           tab1,
+                           "Performs best on a 64-bit CPU. Use ISAAC if this system has a 32-bit CPU.   " );
                 break;
 
         } /* switch */
@@ -1621,6 +1655,10 @@ void nwipe_gui_prng( void )
                 if( focus == 1 )
                 {
                     nwipe_options.prng = &nwipe_isaac;
+                }
+                if( focus == 2 )
+                {
+                    nwipe_options.prng = &nwipe_isaac64;
                 }
                 return;
 

--- a/src/isaac_rand/isaac64.c
+++ b/src/isaac_rand/isaac64.c
@@ -1,0 +1,122 @@
+/*
+------------------------------------------------------------------------------
+isaac64.c: My random number generator for 64-bit machines.
+By Bob Jenkins, 1996.  Public Domain.
+------------------------------------------------------------------------------
+*/
+#ifndef STANDARD
+#include "isaac_standard.h"
+#endif
+#ifndef ISAAC64
+#include "isaac64.h"
+#endif
+
+
+#define ind(mm,x)  (*(ub8 *)((ub1 *)(mm) + ((x) & ((RANDSIZ-1)<<3))))
+#define rngstep(mix,a,b,mm,m,m2,r,x) \
+{ \
+  x = *m;  \
+  a = (mix) + *(m2++); \
+  *(m++) = y = ind(mm,x) + a + b; \
+  *(r++) = b = ind(mm,y>>RANDSIZL) + x; \
+}
+
+void isaac64(ctx)
+rand64ctx *ctx;
+{
+  register ub8 a,b,x,y,*m,*mm,*m2,*r,*mend;
+  mm=ctx->mm; r=ctx->randrsl;
+  a = ctx->aa; b = ctx->bb + (++ctx->cc);
+  for (m = mm, mend = m2 = m+(RANDSIZ/2); m<mend; )
+  {
+    rngstep(~(a^(a<<21)), a, b, mm, m, m2, r, x);
+    rngstep(  a^(a>>5)  , a, b, mm, m, m2, r, x);
+    rngstep(  a^(a<<12) , a, b, mm, m, m2, r, x);
+    rngstep(  a^(a>>33) , a, b, mm, m, m2, r, x);
+  }
+  for (m2 = mm; m2<mend; )
+  {
+    rngstep(~(a^(a<<21)), a, b, mm, m, m2, r, x);
+    rngstep(  a^(a>>5)  , a, b, mm, m, m2, r, x);
+    rngstep(  a^(a<<12) , a, b, mm, m, m2, r, x);
+    rngstep(  a^(a>>33) , a, b, mm, m, m2, r, x);
+  }
+  ctx->bb = b; ctx->aa = a;
+}
+
+#define mix(a,b,c,d,e,f,g,h) \
+{ \
+   a-=e; f^=h>>9;  h+=a; \
+   b-=f; g^=a<<9;  a+=b; \
+   c-=g; h^=b>>23; b+=c; \
+   d-=h; a^=c<<15; c+=d; \
+   e-=a; b^=d>>14; d+=e; \
+   f-=b; c^=e<<20; e+=f; \
+   g-=c; d^=f>>17; f+=g; \
+   h-=d; e^=g<<14; g+=h; \
+}
+
+void rand64init(ctx, flag)
+rand64ctx *ctx;
+word       flag;
+{
+   word i;
+   ub8 a,b,c,d,e,f,g,h;
+   ub8 *mm, *randrsl;
+   ctx->aa = ctx->bb = ctx->cc = (ub8)0;
+   mm=ctx->mm;
+   randrsl=ctx->randrsl;
+   a=b=c=d=e=f=g=h=0x9e3779b97f4a7c13LL;  /* the golden ratio */
+
+   for (i=0; i<4; ++i)                    /* scramble it */
+   {
+     mix(a,b,c,d,e,f,g,h);
+   }
+
+   for (i=0; i<RANDSIZ; i+=8)   /* fill in mm[] with messy stuff */
+   {
+     if (flag)                  /* use all the information in the seed */
+     {
+       a+=randrsl[i  ]; b+=randrsl[i+1]; c+=randrsl[i+2]; d+=randrsl[i+3];
+       e+=randrsl[i+4]; f+=randrsl[i+5]; g+=randrsl[i+6]; h+=randrsl[i+7];
+     }
+     mix(a,b,c,d,e,f,g,h);
+     mm[i  ]=a; mm[i+1]=b; mm[i+2]=c; mm[i+3]=d;
+     mm[i+4]=e; mm[i+5]=f; mm[i+6]=g; mm[i+7]=h;
+   }
+
+   if (flag) 
+   {        /* do a second pass to make all of the seed affect all of mm */
+     for (i=0; i<RANDSIZ; i+=8)
+     {
+       a+=mm[i  ]; b+=mm[i+1]; c+=mm[i+2]; d+=mm[i+3];
+       e+=mm[i+4]; f+=mm[i+5]; g+=mm[i+6]; h+=mm[i+7];
+       mix(a,b,c,d,e,f,g,h);
+       mm[i  ]=a; mm[i+1]=b; mm[i+2]=c; mm[i+3]=d;
+       mm[i+4]=e; mm[i+5]=f; mm[i+6]=g; mm[i+7]=h;
+     }
+   }
+
+   isaac64();             /* fill in the first set of results */
+   ctx->randcnt=RANDSIZ;  /* prepare to use the first set of results */
+}
+
+#ifdef NEVER
+int main()
+{
+  ub8 i,j;
+  rand64ctx ctx;
+  ctx.aa=ctx.bb=ctx.cc=(ub8)0;
+  for (i=0; i<RANDSIZ; ++i) ctx.mm[i]=(ub8)0;
+  rand64init(&ctx, TRUE);
+  for (i=0; i<2; ++i)
+  {
+    isaac64(&ctx);
+    for (j=0; j<RANDSIZ; ++j)
+    {
+      printf("%.8lx%.8lx",(ub4)(ctx.randrsl[j]>>32),(ub4)ctx.randrsl[j]);
+      if ((j&3)==3) printf("\n");
+    }
+  }
+}
+#endif

--- a/src/isaac_rand/isaac64.h
+++ b/src/isaac_rand/isaac64.h
@@ -1,0 +1,41 @@
+/*
+------------------------------------------------------------------------------
+isaac64.h: definitions for a random number generator
+Bob Jenkins, 1996, Public Domain
+------------------------------------------------------------------------------
+*/
+#ifndef ISAAC64
+#define ISAAC64
+
+#include "isaac_standard.h"
+
+struct rand64ctx
+{
+ ub8 randrsl[RANDSIZ], randcnt;
+ ub8 mm[RANDSIZ];
+ ub8 aa, bb, cc;
+};
+typedef struct rand64ctx rand64ctx;
+
+/*
+------------------------------------------------------------------------------
+ If (flag==TRUE), then use the contents of randrsl[0..255] as the seed.
+------------------------------------------------------------------------------
+*/
+void randinit64(/*_ rand64ctx *r, word flag _*/);
+
+void isaac64();
+
+
+/*
+------------------------------------------------------------------------------
+ Call rand64() to retrieve a single 64-bit random value
+------------------------------------------------------------------------------
+*/
+#define isaac64_rand() \
+   (!(r)->randcnt-- ? \
+     (isaac64(r), (r)->randcnt=RANDSIZ-1, (r)->randrsl[(r)->>randcnt]) : \
+     (r)->randrsl[(r)->randcnt])
+
+#endif  /* ISAAC64 */
+

--- a/src/isaac_rand/isaac_rand.h
+++ b/src/isaac_rand/isaac_rand.h
@@ -10,14 +10,10 @@ MODIFIED:
   010626: note this is public domain
 ------------------------------------------------------------------------------
 */
-#ifndef STANDARD
-#include "isaac_standard.h"
-#endif
-
 #ifndef RAND
 #define RAND
-#define RANDSIZL   (4)  /* I recommend 8 for crypto, 4 for simulations */
-#define RANDSIZ    (1<<RANDSIZL)
+
+#include "isaac_standard.h"
 
 /* context of random number generator */
 struct randctx

--- a/src/isaac_rand/isaac_standard.h
+++ b/src/isaac_rand/isaac_standard.h
@@ -54,4 +54,7 @@ typedef                 int  word;  /* fastest type available */
 #define FALSE 0
 #define SUCCESS 0  /* 1 on VAX */
 
+#define RANDSIZL   (8)  /* I recommend 8 for crypto, 4 for simulations */
+#define RANDSIZ    (1<<RANDSIZL)
+
 #endif /* STANDARD */

--- a/src/prng.h
+++ b/src/prng.h
@@ -52,11 +52,14 @@ int nwipe_twister_read( NWIPE_PRNG_READ_SIGNATURE );
 /* ISAAC prototypes. */
 int nwipe_isaac_init( NWIPE_PRNG_INIT_SIGNATURE );
 int nwipe_isaac_read( NWIPE_PRNG_READ_SIGNATURE );
+int nwipe_isaac64_init( NWIPE_PRNG_INIT_SIGNATURE );
+int nwipe_isaac64_read( NWIPE_PRNG_READ_SIGNATURE );
 
 /* Size of the twister is not derived from the architecture, but it is strictly 4 bytes */
 #define SIZE_OF_TWISTER 4
 
-/* Size of the isaac is not derived from the architecture, but it is strictly 4 bytes */
+/* Size of the isaac/isaac64 is not derived from the architecture, but it is strictly 4 or 8 bytes */
 #define SIZE_OF_ISAAC 4
+#define SIZE_OF_ISAAC64 8
 
 #endif /* PRNG_H_ */


### PR DESCRIPTION
Use RANDIZL=8 as recommended by ISAAC author.
Fixed possible buffer overflow in nwipe_isaac_read().
Slight performance improvement.