### PR TITLE
Fix obscure incorrect summary table status

### DIFF
--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -722,10 +722,21 @@ int main( int argc, char** argv )
     {
         for( i = 0; i < nwipe_selected; i++ )
         {
-            /* Check for non-fatal errors. */
+            /* Check for errors. */
             if( c2[i]->result != 0 || c2[i]->pass_errors != 0 || c2[i]->verify_errors != 0
                 || c2[i]->fsyncdata_errors != 0 )
             {
+                /* If the run_method ever returns anything other than zero then makesure there is at least one pass
+                 * error This is so that the log summary tables correctly show a failure when one occurs as it only
+                 * shows pass, verification and fdatasync errors. */
+                if( c2[i]->result != 0 )
+                {
+                    if( c2[i]->pass_errors == 0 )
+                    {
+                        c2[i]->pass_errors = 1;
+                    }
+                }
+
                 nwipe_log( NWIPE_LOG_FATAL,
                            "Nwipe exited with errors on device = %s, see log for specific error\n",
                            c2[i]->device_name );

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.32.021";
+const char* version_string = "0.32.022";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.32.021";
+const char* banner = "nwipe 0.32.022";


### PR DESCRIPTION
If the drive becomes non responsive during the wipe, the MB/s will
slowly drop towards 0MB/s and will display a FAILURE -1 error. The logs
will display errors and nwipe's return status will be non zero, however
the summary table may display erased rather than FAILURE, this is because
the wipe thread exited prematurely without setting the pass error.

This fixes the error by checking the context's result status, i.e non zero
on failure and if pass equals zero it makes pass equal to one. This is
then picked up by the summary table log code which then marks the status
correctly as FAILURE in the summary table.