### PR TITLE
Fix spurious message on abort before wipe.

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2689,8 +2689,8 @@ void* nwipe_gui_status( void* ptr )
             }
         }
 
-        /* Update screen if not blanked. */
-        if( nwipe_gui_blank == 0 )
+        /* Update data in statistics & main windows only if we're in 'gui' mode and only if a wipe has started */
+        if( nwipe_gui_blank == 0 && global_wipe_status == 1 )
         {
 
             if( terminate_signal != 1 )

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.32.023";
+const char* version_string = "0.32.024";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.32.023";
+const char* banner = "nwipe 0.32.024";


### PR DESCRIPTION
This patch fixes a minor display issue that occurs when
a user aborts a wipe before a wipe has started. It only occurs
if the user had selected one or more drives for wipe and then
aborted before starting the wipe. The spurious message only
occurs in a virtual terminal, i.e. /dev/tty1, /dev/tty2, /dev/console
It does not occur in terminal applications such as konsole, xterm,
terminator etc.

The spurious message that appears in the main window, states that
"/dev/sdxyz 100% complete" along with garbage values in the statistics
window. The message appears for a fraction of a second before being
replaced with the textual log information that correctly states that
the user aborted and no wipe was started.

Basically the gui status information update function tries to update
the data when the wipe hasn't even started. The fix is to only update
the statistics information only if a wipe has started by checking the
'global_wipe_status' value which indicates whether any wipe started. '1'
indicates that a wipe has started, else '0' if no wipe has started.