### PR TITLE
Fix temperature update in drive selection window

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -637,6 +637,8 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
     stdscr_lines_previous = stdscr_lines;
     stdscr_cols_previous = stdscr_cols;
 
+    time_t temperature_check_time = time( NULL );
+
     do
     {
 
@@ -797,6 +799,9 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
                         break;
 
                 } /* switch select */
+
+                /* Read the drive temperature values */
+                nwipe_update_temperature( c[i + offset] );
 
                 /* print the temperature */
                 wprintw_temperature( c[i + offset] );
@@ -1230,6 +1235,13 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
             /* Check the terminal size, if the user has changed it the while loop checks for
              * this change and exits the valid key hit loop so the windows can be updated */
             getmaxyx( stdscr, stdscr_lines, stdscr_cols );
+
+            /* Update the selection window every 60 seconds specifically so that the drive temperatures are updated */
+            if( time( NULL ) > ( temperature_check_time + 60 ) )
+            {
+                temperature_check_time = time( NULL );
+                validkeyhit = 1;
+            }
 
         } /* key hit loop */
         while( validkeyhit == 0 && terminate_signal != 1 && stdscr_cols_previous == stdscr_cols

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.32.024";
+const char* version_string = "0.32.025";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.32.024";
+const char* banner = "nwipe 0.32.025";


### PR DESCRIPTION
This fixes a problem where the drive temperature is not updated
automatically in the drive selection window only. The temperature
is however updated every correctly every 60 seconds during a wipe in
the wipe status window.

This bug would probably never be noticed by most people as usually the
drive temperature changes slowly and only rises once a wipe has started.

The only time I imagine it would have been noticed would have been if
the drive temperature was already high and you were trying to reduce the
temperature by cooling before starting a wipe.

This has now been corrected so that the temperature in the drive
selection window is updated every 60 seconds.