### PR TITLE
Fix_nwipe_not_exiting_when_using_konsole

### DIFF
--- a/src/gui.h
+++ b/src/gui.h
@@ -50,6 +50,13 @@ void nwipe_update_speedring( nwipe_speedring_t* speedring, u64 speedring_done, t
 
 #define NOMENCLATURE_RESULT_STR_SIZE 8
 
+/* Note Do not change unless you understand how this value affects keyboard response and screen refresh when
+ * the drive selection screen is displayed. (prior to wipe starting). */
 #define GETCH_BLOCK_MS 250 /* millisecond block time for getch() */
+
+/* Note The value of 1 (100ms) is the ideal speed for screen refresh during a wipe, a value of 2 is noticably slower,
+ * don't change unless you understand how this value affects keyboard responsiveness and speed of screen stats/spinner
+ * updating */
+#define GETCH_GUI_STATS_UPDATE_MS 1 /* 1 * 100 = 1/10/sec = millisecond block time for gui stats screen updates */
 
 #endif /* GUI_H_ */

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.32.026";
+const char* version_string = "0.32.027";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.32.026";
+const char* banner = "nwipe 0.32.027";


### PR DESCRIPTION
This fixes a issue related to konsole and terminals based on Konsole,
like cool retro terminal. If you exit the terminal before exiting nwipe,
nwipe will then continue running in the background but detached from any
terminals input/output. This causes a call to halfdelay()/getch() to
return immediately, thus removing the delay and causing the thread to
run at full speed causing 100% CPU in a core. This requires nwipe to
then be killed manually. This patch is related to the last patch in
that both patches do much the same thing but the previous patch fixes
the problem when nwipe is sitting at the drive selection screen, while
this patch fixes the problem during a wipe.

This problem would only be seen in specific KDE konsole related
terminals and only if you do not exit nwipe by using nwipe's control c
to abort or use the space bar on completion of the wipe.

Much like the same check we perform in the nwipe_gui_select() function,
here we check that we are not looping any faster than as defined by the
halfdelay() function, typically this loop runs at 10 times a second.
This check makes sure that if the loop runs faster than double this
value i.e 20 times a second then the program exits. This check is
therefore determining whether the getch() function is returning
immediately rather than blocking for the defined period of 100ms.
Why is this necessary? Some terminals (konsole & deriviatives) that are
exited while nwipe is still running fail to terminate nwipe this causes
the halfdelay()/getch() functions to immediately fail causing the loop
frequency to drastically increase. We detect that speed increase here
and therefore close down nwipe. This doesn't affect the use of the tmux
terminal by which you can detach and reattach to running nwipe
processes. The tmux terminal will still work correctly when a nwipe
session is detached.