### PR TITLE
Fix obscure segfault when --logfile option used.

### DIFF
--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -116,10 +116,17 @@ int main( int argc, char** argv )
 
     /* Parse command line options. */
     nwipe_optind = nwipe_options_parse( argc, argv );
+
     if( nwipe_optind == argc )
     {
         /* File names were not given by the user.  Scan for devices. */
         nwipe_enumerated = nwipe_device_scan( &c1 );
+
+        if( terminate_signal == 1 )
+        {
+            cleanup();
+            exit( 1 );
+        }
 
         if( nwipe_enumerated == 0 )
         {

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.32.027";
+const char* version_string = "0.32.028";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.32.027";
+const char* banner = "nwipe 0.32.028";


### PR DESCRIPTION
If you use the --logfile option but specify a filename
that will be created in a directory that is not writable,
for instance, a system directory such as /proc/sys/ or
your current directory happens to be a system directory
that you are running nwipe from while not specifying a
writable path for the log file then nwipe would exit with
a segfault.

This is now fixed. If the logfile cannot be created
or opened, then a appropriate message is displayed and
nwipe is aborted.