### PR TITLE
Fixes a compiler warning -Wformat-zero-length string

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -1433,7 +1433,7 @@ void nwipe_gui_rounds( void )
         yy = 4;
 
         mvwprintw( main_window, yy++, tab1, "This is the number of times to run the wipe method on each device." );
-        mvwprintw( main_window, yy++, tab1, "" );
+        yy++;
 
         if( focus > 0 )
         {
@@ -1582,7 +1582,7 @@ void nwipe_gui_prng( void )
         mvwprintw( main_window, yy++, tab1, "  %s", nwipe_twister.label );
         mvwprintw( main_window, yy++, tab1, "  %s", nwipe_isaac.label );
         mvwprintw( main_window, yy++, tab1, "  %s", nwipe_isaac64.label );
-        mvwprintw( main_window, yy++, tab1, "" );
+        yy++;
 
         /* Print the cursor. */
         mvwaddch( main_window, 3 + focus, tab1, ACS_RARROW );


### PR DESCRIPTION
Replaced the mvwprintw command that contained an empty string with a simple increment to the line position which maintains the display as it was but gets rid of the -Wformat-zero-length string compiler warning.