### PR TITLE
Add grml to distros that ship nwipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ And in addition checkout the following distros that all include nwipe:
 - [partedmagic](https://partedmagic.com)
 - [SystemRescueCD](https://www.system-rescue.org)
 - [gparted live](https://sourceforge.net/projects/gparted/files/gparted-live-testing/1.2.0-2/)
+- [grml](https://grml.org/)
 
 Know of other distros that include nwipe? Then please let us know or issue a PR on this README.md. Thanks.
 


### PR DESCRIPTION
I was searching for a DBAN alternative that runs in a normal Linux distro so I can hot-swap drives and not have to reboot the system. When I found nwipe, I went to install it in a grml live system. Turns out, nwipe ships with grml by default as you can see in [grml's dpkg.list](https://packages.grml.org/files/grml64-small_2021.07/dpkg.list).

It's not exactly the most up-to-date version (0.30-1+b2 for amd64) because grml is close to Debian stable. It even comes with the the small live system image.