### PR TITLE
PDFGen5 - further work on PDF certificate

### DIFF
--- a/src/PDFGen/pdfgen.h
+++ b/src/PDFGen/pdfgen.h
@@ -264,9 +264,6 @@ struct pdf_path_operation {
 /*! Utility macro to provide white */
 #define PDF_WHITE PDF_RGB(0xff, 0xff, 0xff)
 
-/*! Utility macro to provide gray */
-#define PDF_GRAY PDF_RGB(0x5A, 0x5A, 0x5A)
-
 /*!
  * Utility macro to provide a transparent colour
  * This is used in some places for 'fill' colours, where no fill is required

--- a/src/context.h
+++ b/src/context.h
@@ -145,6 +145,7 @@ typedef struct nwipe_context_t_
     int temp1_flash_rate_status;  // 0=blank 1=visible
     time_t temp1_time;  // The time when temperature was last checked, seconds since epoch
     int wipe_status;  // Wipe finished = 0, wipe in progress = 1, wipe yet to start = -1.
+    char wipe_status_txt[10];  // ERASED, FAILED, ABORTED, INSANITY
     int spinner_idx;  // Index into the spinner character array
     char spinner_character[1];  // The current spinner character
     double duration;  // Duration of the wipe in seconds

--- a/src/create_pdf.c
+++ b/src/create_pdf.c
@@ -44,14 +44,17 @@ int create_pdf( nwipe_context_t* ptr )
     char pdf_footer[MAX_PDF_FOOTER_TEXT_LENGTH];
     nwipe_context_t* c;
     c = ptr;
-    char model_header[50]; /* Model text in the header */
-    char serial_header[30]; /* Serial number text in the header */
-    char barcode[80]; /* Contents of the barcode, i.e model:serial */
-    char dimm[50]; /* Disk Information: Model */
-    char verify[20]; /* Verify option text */
-    char blank[10]; /* blanking pass, none, zeros, ones */
-    char rounds[10]; /* rounds ASCII numeric */
-    char prng_type[20]; /* type of prng, twister, isaac, isaac64 */
+    char model_header[50] = ""; /* Model text in the header */
+    char serial_header[30] = ""; /* Serial number text in the header */
+    char barcode[100] = ""; /* Contents of the barcode, i.e model:serial */
+    char dimm[50] = ""; /* Disk Information: Model */
+    char verify[20] = ""; /* Verify option text */
+    char blank[10] = ""; /* blanking pass, none, zeros, ones */
+    char rounds[10] = ""; /* rounds ASCII numeric */
+    char prng_type[20] = ""; /* type of prng, twister, isaac, isaac64 */
+    char wipe_status[8] = ""; /* Erased or Failed */
+    char start_time_text[50] = "";
+    char end_time_text[50] = "";
 
     struct pdf_info info = { .creator = "https://github.com/PartialVolume/shredos.x86_64",
                              .producer = "https://github.com/martijnvanbrummelen/nwipe",
@@ -59,6 +62,12 @@ int create_pdf( nwipe_context_t* ptr )
                              .author = "Nwipe",
                              .subject = "Disk Erase Certificate",
                              .date = "Today" };
+
+    /* A pointer to the system time struct. */
+    struct tm* p;
+
+    /* ------------------ */
+    /* Initialise Various */
 
     // nwipe_log( NWIPE_LOG_NOTICE, "Create the PDF disk erasure certificate" );
     struct pdf_doc* pdf = pdf_create( PDF_A4_WIDTH, PDF_A4_HEIGHT, &info );
@@ -75,15 +84,15 @@ int create_pdf( nwipe_context_t* ptr )
     pdf_add_text( pdf, NULL, pdf_footer, 12, 200, 30, PDF_BLACK );
     pdf_add_line( pdf, NULL, 50, 50, 550, 50, 3, PDF_BLACK );
     pdf_add_line( pdf, NULL, 50, 650, 550, 650, 3, PDF_BLACK );
-    pdf_add_image_data( pdf, NULL, 45, 670, 128, 128, bin2c_shred_db_jpg, 27063 );
-    pdf_add_image_data( pdf, NULL, 430, 670, 128, 128, bin2c_te_jpg, 54896 );
-    snprintf( model_header, sizeof( model_header ), " %s:%s ", "Model", c->device_model );
-    pdf_add_text( pdf, NULL, model_header, 14, 215, 720, PDF_BLACK );
-    snprintf( serial_header, sizeof( serial_header ), " %s:%s ", "S/N", c->device_serial_no );
-    pdf_add_text( pdf, NULL, serial_header, 14, 212, 700, PDF_BLACK );
-    pdf_add_text( pdf, NULL, "Disk Erasure Report", 24, 195, 670, PDF_BLACK );
-    snprintf( barcode, sizeof( barcode ), " %s:%s ", c->device_model, c->device_serial_no );
-    pdf_add_barcode( pdf, NULL, PDF_BARCODE_128A, 195, 748, 200, 50, barcode, PDF_BLACK );
+    pdf_add_image_data( pdf, NULL, 45, 665, 100, 100, bin2c_shred_db_jpg, 27063 );
+    pdf_add_image_data( pdf, NULL, 450, 665, 100, 100, bin2c_te_jpg, 54896 );
+    snprintf( model_header, sizeof( model_header ), " %s: %s ", "Model", c->device_model );
+    pdf_add_text( pdf, NULL, model_header, 14, 215, 755, PDF_BLACK );
+    snprintf( serial_header, sizeof( serial_header ), " %s: %s ", "S/N", c->device_serial_no );
+    pdf_add_text( pdf, NULL, serial_header, 14, 215, 735, PDF_BLACK );
+    pdf_add_text( pdf, NULL, "Disk Erasure Report", 24, 190, 690, PDF_BLACK );
+    snprintf( barcode, sizeof( barcode ), "%s:%s", c->device_model, c->device_serial_no );
+    pdf_add_barcode( pdf, NULL, PDF_BARCODE_128A, 100, 790, 400, 25, barcode, PDF_BLACK );
 
     /* ------------------------ */
     /* Organisation Information */
@@ -103,52 +112,102 @@ int create_pdf( nwipe_context_t* ptr )
     pdf_add_text( pdf, NULL, "Contact Name:", 12, 60, 470, PDF_GRAY );
     pdf_add_text( pdf, NULL, "Contact Phone:", 12, 300, 470, PDF_GRAY );
 
-    /* ---------------------- */
-    /* Technician/Operator ID */
-    pdf_add_line( pdf, NULL, 50, 390, 550, 390, 1, PDF_GRAY );
-    pdf_add_text( pdf, NULL, "Technician/Operator ID", 12, 50, 430, PDF_BLUE );
-    pdf_add_text( pdf, NULL, "Name:", 12, 60, 410, PDF_GRAY );
-    pdf_add_text( pdf, NULL, "ID:", 12, 300, 410, PDF_GRAY );
-
     /* ---------------- */
     /* Disk Information */
-    pdf_add_line( pdf, NULL, 50, 270, 550, 270, 1, PDF_GRAY );
-    pdf_add_text( pdf, NULL, "Disk Information", 12, 50, 370, PDF_BLUE );
+    pdf_add_line( pdf, NULL, 50, 330, 550, 330, 1, PDF_GRAY );
+    pdf_add_text( pdf, NULL, "Disk Information", 12, 50, 430, PDF_BLUE );
 
-    pdf_add_text( pdf, NULL, "Make/Model:", 12, 60, 350, PDF_GRAY );
-    pdf_add_text( pdf, NULL, c->device_model, 12, 135, 350, PDF_BLACK );
+    pdf_add_text( pdf, NULL, "Make/Model:", 12, 60, 410, PDF_GRAY );
+    pdf_set_font( pdf, "Helvetica-Bold" );
+    pdf_add_text( pdf, NULL, c->device_model, 12, 135, 410, PDF_BLACK );
+    pdf_set_font( pdf, "Helvetica" );
 
-    pdf_add_text( pdf, NULL, "Serial:", 12, 300, 350, PDF_GRAY );
+    pdf_add_text( pdf, NULL, "Serial:", 12, 300, 410, PDF_GRAY );
     if( c->device_serial_no[0] == 0 )
     {
         strcpy( c->device_serial_no, "Unknown" );
     }
-    pdf_add_text( pdf, NULL, c->device_serial_no, 12, 340, 350, PDF_BLACK );
+    pdf_set_font( pdf, "Helvetica-Bold" );
+    pdf_add_text( pdf, NULL, c->device_serial_no, 12, 340, 410, PDF_BLACK );
+    pdf_set_font( pdf, "Helvetica" );
 
-    pdf_add_text( pdf, NULL, "Size:", 12, 60, 330, PDF_GRAY );
-    pdf_add_text( pdf, NULL, c->device_size_text, 12, 85, 330, PDF_BLACK );
+    pdf_add_text( pdf, NULL, "Size:", 12, 60, 390, PDF_GRAY );
+    pdf_set_font( pdf, "Helvetica-Bold" );
+    pdf_add_text( pdf, NULL, c->device_size_text, 12, 85, 390, PDF_BLACK );
+    pdf_set_font( pdf, "Helvetica" );
 
-    pdf_add_text( pdf, NULL, "Bus:", 12, 300, 330, PDF_GRAY );
-    pdf_add_text( pdf, NULL, c->device_type_str, 12, 330, 330, PDF_BLACK );
+    pdf_add_text( pdf, NULL, "Bus:", 12, 300, 390, PDF_GRAY );
+    pdf_set_font( pdf, "Helvetica-Bold" );
+    pdf_add_text( pdf, NULL, c->device_type_str, 12, 330, 390, PDF_BLACK );
+    pdf_set_font( pdf, "Helvetica" );
 
-    pdf_add_text( pdf, NULL, "Health:", 12, 60, 310, PDF_GRAY );
-    pdf_add_text( pdf, NULL, "Remapped Sectors:", 12, 300, 310, PDF_GRAY );
-    pdf_add_text( pdf, NULL, "HPA(pre-erase):", 12, 60, 290, PDF_GRAY );
-    pdf_add_text( pdf, NULL, "DCO(pre-erase):", 12, 300, 290, PDF_GRAY );
+    pdf_add_text( pdf, NULL, "Health:", 12, 60, 370, PDF_GRAY );
+    pdf_add_text( pdf, NULL, "Remapped Sectors:", 12, 300, 370, PDF_GRAY );
+    pdf_add_text( pdf, NULL, "HPA(pre-erase):", 12, 60, 350, PDF_GRAY );
+    pdf_add_text( pdf, NULL, "DCO(pre-erase):", 12, 300, 350, PDF_GRAY );
 
     /* --------------- */
     /* Erasure Details */
-    pdf_add_text( pdf, NULL, "Disk Erasure Details", 12, 50, 250, PDF_BLUE );
-    pdf_add_text( pdf, NULL, "Start/End Time:", 12, 60, 230, PDF_GRAY );
+    pdf_add_text( pdf, NULL, "Disk Erasure Details", 12, 50, 310, PDF_BLUE );
 
-    pdf_add_text( pdf, NULL, "Duration:", 12, 300, 230, PDF_GRAY );
-    pdf_add_text( pdf, NULL, c->duration_str, 12, 355, 230, PDF_BLACK );
+    /* start time */
+    pdf_add_text( pdf, NULL, "Start time:", 12, 60, 290, PDF_GRAY );
+    p = localtime( &c->start_time );
+    snprintf( start_time_text,
+              sizeof( start_time_text ),
+              "%i/%02i/%02i %02i:%02i:%02i",
+              1900 + p->tm_year,
+              1 + p->tm_mon,
+              p->tm_mday,
+              p->tm_hour,
+              p->tm_min,
+              p->tm_sec );
+    pdf_set_font( pdf, "Helvetica-Bold" );
+    pdf_add_text( pdf, NULL, start_time_text, 12, 120, 290, PDF_BLACK );
+    pdf_set_font( pdf, "Helvetica" );
 
-    pdf_add_text( pdf, NULL, "Method:", 12, 60, 210, PDF_GRAY );
-    pdf_add_text( pdf, NULL, nwipe_method_label( nwipe_options.method ), 12, 110, 210, PDF_BLACK );
+    /* end time */
+    pdf_add_text( pdf, NULL, "End time:", 12, 300, 290, PDF_GRAY );
+    p = localtime( &c->end_time );
+    snprintf( end_time_text,
+              sizeof( end_time_text ),
+              "%i/%02i/%02i %02i:%02i:%02i",
+              1900 + p->tm_year,
+              1 + p->tm_mon,
+              p->tm_mday,
+              p->tm_hour,
+              p->tm_min,
+              p->tm_sec );
+    pdf_set_font( pdf, "Helvetica-Bold" );
+    pdf_add_text( pdf, NULL, end_time_text, 12, 360, 290, PDF_BLACK );
+    pdf_set_font( pdf, "Helvetica" );
+
+    /* Duration */
+    pdf_add_text( pdf, NULL, "Duration:", 12, 60, 270, PDF_GRAY );
+    pdf_set_font( pdf, "Helvetica-Bold" );
+    pdf_add_text( pdf, NULL, c->duration_str, 12, 115, 270, PDF_BLACK );
+    pdf_set_font( pdf, "Helvetica" );
+
+    /* Status */
+    pdf_add_text( pdf, NULL, "Status:", 12, 300, 270, PDF_GRAY );
+    pdf_set_font( pdf, "Helvetica-Bold" );
+    if( !strcmp( c->wipe_status_txt, "ERASED" ) )
+    {
+        pdf_add_text( pdf, NULL, c->wipe_status_txt, 12, 345, 270, PDF_DARK_GREEN );
+    }
+    else
+    {
+        pdf_add_text( pdf, NULL, c->wipe_status_txt, 12, 345, 270, PDF_RED );
+    }
+    pdf_set_font( pdf, "Helvetica" );
+
+    pdf_add_text( pdf, NULL, "Method:", 12, 60, 250, PDF_GRAY );
+    pdf_set_font( pdf, "Helvetica-Bold" );
+    pdf_add_text( pdf, NULL, nwipe_method_label( nwipe_options.method ), 12, 110, 250, PDF_BLACK );
+    pdf_set_font( pdf, "Helvetica" );
 
     /* prng type */
-    pdf_add_text( pdf, NULL, "PRNG algorithm:", 12, 300, 210, PDF_GRAY );
+    pdf_add_text( pdf, NULL, "PRNG algorithm:", 12, 300, 250, PDF_GRAY );
     if( nwipe_options.prng == &nwipe_twister )
     {
         strcpy( prng_type, "Twister" );
@@ -171,7 +230,9 @@ int create_pdf( nwipe_context_t* ptr )
             }
         }
     }
-    pdf_add_text( pdf, NULL, prng_type, 12, 395, 210, PDF_BLACK );
+    pdf_set_font( pdf, "Helvetica-Bold" );
+    pdf_add_text( pdf, NULL, prng_type, 12, 395, 250, PDF_BLACK );
+    pdf_set_font( pdf, "Helvetica" );
 
     /* Final blanking pass if selected, none, zeros or ones */
     if( nwipe_options.noblank )
@@ -182,8 +243,10 @@ int create_pdf( nwipe_context_t* ptr )
     {
         strcpy( blank, "Zeros" );
     }
-    pdf_add_text( pdf, NULL, "Final Pass(Zeros/Ones/None):", 12, 60, 190, PDF_GRAY );
-    pdf_add_text( pdf, NULL, blank, 12, 230, 190, PDF_BLACK );
+    pdf_add_text( pdf, NULL, "Final Pass(Zeros/Ones/None):", 12, 60, 230, PDF_GRAY );
+    pdf_set_font( pdf, "Helvetica-Bold" );
+    pdf_add_text( pdf, NULL, blank, 12, 230, 230, PDF_BLACK );
+    pdf_set_font( pdf, "Helvetica" );
 
     /* Create suitable text based on the numeric value of type of verification */
     switch( nwipe_options.verify )
@@ -200,21 +263,28 @@ int create_pdf( nwipe_context_t* ptr )
             strcpy( verify, "Verify All" );
             break;
     }
-    pdf_add_text( pdf, NULL, "Verify Pass(Last/All/None):", 12, 300, 190, PDF_GRAY );
-    pdf_add_text( pdf, NULL, verify, 12, 450, 190, PDF_BLACK );
+    pdf_add_text( pdf, NULL, "Verify Pass(Last/All/None):", 12, 300, 230, PDF_GRAY );
+    pdf_set_font( pdf, "Helvetica-Bold" );
+    pdf_add_text( pdf, NULL, verify, 12, 450, 230, PDF_BLACK );
+    pdf_set_font( pdf, "Helvetica" );
 
-    pdf_add_text( pdf, NULL, "Status:", 12, 60, 170, PDF_GRAY );
-
-    pdf_add_text( pdf, NULL, "Rounds:", 12, 300, 170, PDF_GRAY );
+    pdf_add_text( pdf, NULL, "Rounds:", 12, 300, 210, PDF_GRAY );
     snprintf( rounds, sizeof( rounds ), "%i", nwipe_options.rounds );
-    pdf_add_text( pdf, NULL, rounds, 12, 350, 170, PDF_BLACK );
+    pdf_set_font( pdf, "Helvetica-Bold" );
+    pdf_add_text( pdf, NULL, rounds, 12, 350, 210, PDF_BLACK );
+    pdf_set_font( pdf, "Helvetica" );
 
-    pdf_add_text( pdf, NULL, "HPA(post-erase):", 12, 60, 150, PDF_GRAY );
-    pdf_add_text( pdf, NULL, "DCO(post-erase):", 12, 300, 150, PDF_GRAY );
-    pdf_add_text( pdf, NULL, "Information:", 12, 60, 130, PDF_GRAY );
+    pdf_add_text( pdf, NULL, "HPA(post-erase):", 12, 60, 190, PDF_GRAY );
+    pdf_add_text( pdf, NULL, "DCO(post-erase):", 12, 300, 190, PDF_GRAY );
+    pdf_add_text( pdf, NULL, "Information:", 12, 60, 170, PDF_GRAY );
 
-    /* --------------------- */
-    /* Certificate Date/Time */
+    /* ---------------------- */
+    /* Technician/Operator ID */
+    pdf_add_line( pdf, NULL, 50, 120, 550, 120, 1, PDF_GRAY );
+    pdf_add_text( pdf, NULL, "Technician/Operator ID", 12, 50, 100, PDF_BLUE );
+    pdf_add_text( pdf, NULL, "Name/ID:", 12, 60, 80, PDF_GRAY );
+    pdf_add_text( pdf, NULL, "Signature:", 12, 300, 100, PDF_BLUE );
+    pdf_add_line( pdf, NULL, 360, 65, 550, 66, 1, PDF_GRAY );
 
     pdf_save( pdf, "output.pdf" );
     pdf_destroy( pdf );

--- a/src/create_pdf.h
+++ b/src/create_pdf.h
@@ -23,6 +23,14 @@
 
 #define MAX_PDF_FOOTER_TEXT_LENGTH 50
 
+/* Additional colors that supplement the standard colors in pdfgen.h
+ */
+/*! Utility macro to provide gray */
+#define PDF_DARK_GREEN PDF_RGB( 0, 0x64, 0 )
+
+/*! Utility macro to provide gray */
+#define PDF_GRAY PDF_RGB( 0x5A, 0x5A, 0x5A )
+
 int create_pdf( nwipe_context_t* ptr );
 
 #endif /* CREATE_PDF_H_ */

--- a/src/logging.c
+++ b/src/logging.c
@@ -781,6 +781,8 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
 
             strncpy( status, "-FAILED-", 8 );
             status[8] = 0;
+
+            strcpy( c[i]->wipe_status_txt, "FAILED" );  // copy to context for use by certificate
         }
         else
         {
@@ -791,6 +793,8 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
 
                 strncpy( status, " Erased ", 8 );
                 status[8] = 0;
+
+                strcpy( c[i]->wipe_status_txt, "ERASED" );  // copy to context for use by certificate
             }
             else
             {
@@ -801,6 +805,8 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
 
                     strncpy( status, "UABORTED", 8 );
                     status[8] = 0;
+
+                    strcpy( c[i]->wipe_status_txt, "ABORTED" );  // copy to context for use by certificate
                 }
                 else
                 {
@@ -810,6 +816,8 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
 
                     strncpy( status, "INSANITY", 8 );
                     status[8] = 0;
+
+                    strcpy( c[i]->wipe_status_txt, "INSANITY" );  // copy to context for use by certificate
                 }
             }
         }


### PR DESCRIPTION
1. Rearranged the layout so the Tech/ID signature is at the bottom of the report.
2. Added start date/time
3. Added end date/time
4. Changed data from helvetica to helvetica-bold
5. Created a definition for PDF_DARK_GREEN text in create_pdf.h and moved the previously created PDF_GRAY to create_pdf.h, to keep pdfgen.h vanilla.
6. Added the erasure status, ERASED, FAILED, ABORTED. ERASED in green and FAILED, ABORTED in red.

Further code to follow ..