### PR TITLE
PDFGen7 - further work on PDF certificate

### DIFF
--- a/src/create_pdf.h
+++ b/src/create_pdf.h
@@ -38,4 +38,17 @@
  */
 int create_pdf( nwipe_context_t* ptr );
 
+/**
+ * Scan a string and replace any characters that are not alpha-numeric with
+ * the character_char.
+ * Example:
+ * char str[] = 18:21:56;
+ * calling the function replace_non_alphanumeric( &str, '_' )
+ * would result in str changing from 18:21:56 to 18_21_56
+ * @param character pointer to the string to be processed
+ * @param replacement_char the character used to replace non alpha-numeric characters
+ * @return void
+ */
+void replace_non_alphanumeric( char* str, char replacement_char );
+
 #endif /* CREATE_PDF_H_ */


### PR DESCRIPTION
1. Change model/serial number in header to bold and move left slightly.
2. Create a filename for the report that identifies the wipe uniquely i.e:
nwipe_report_YY-MM-DD_HH-MM-SS_Model_XXXX_Serial_XXXX.pdf
3. Move size data 2 characters right to allow for up to two space prefix on size string. So data doesn't get written over the end of the 'Size:' label.