### PR TITLE
PDFGen9 - further work on PDF certificate

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -118,7 +118,7 @@ typedef struct nwipe_context_t_
     nwipe_entropy_t prng_seed;  // The random data that is used to seed the PRNG.
     void* prng_state;  // The private internal state of the PRNG.
     int result;  // The process return value.
-    int round_count;  // The number of rounds performed by the working wipe method.
+    int round_count;  // The number of rounds requested by the user for the working wipe method.
     u64 round_done;  // The number of bytes that have already been i/o'd.
     u64 round_errors;  // The number of errors across all rounds.
     u64 round_size;  // The total number of i/o bytes across all rounds.
@@ -156,6 +156,7 @@ typedef struct nwipe_context_t_
     time_t start_time;  // Start time of wipe
     time_t end_time;  // End time of wipe
     u64 fsyncdata_errors;  // The number of fsyncdata errors across all passes.
+    char PDF_filename[256];  // The filename of the PDF certificate/report.
     /*
      * Identity contains the raw serial number of the drive
      * (where applicable), however, for use within nwipe use the

--- a/src/logging.c
+++ b/src/logging.c
@@ -786,7 +786,7 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
         }
         else
         {
-            if( c[i]->wipe_status == 0 )
+            if( c[i]->wipe_status == 0 && user_abort != 1 )
             {
                 strncpy( exclamation_flag, " ", 1 );
                 exclamation_flag[1] = 0;
@@ -842,8 +842,13 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
         {
             if( c[i]->start_time != 0 && c[i]->end_time == 0 )
             {
-                /* For a summary in the event of a system shutdown */
+                /* For a summary in the event of a system shutdown, user abort */
                 c[i]->duration = difftime( t, c[i]->start_time );
+
+                /* If end_time is zero, which may occur if the wipe is aborted, then set
+                 * end_time to current time. Important to do as endtime is used by
+                 * the PDF report function */
+                c[i]->end_time = time( &t );
             }
         }
 

--- a/src/method.c
+++ b/src/method.c
@@ -172,7 +172,7 @@ void* nwipe_one( void* ptr )
     /* set wipe in progress flag for GUI */
     c->wipe_status = 1;
 
-    /* setup for a zero-fill. */
+    /* setup for a one-fill. */
 
     char onefill[1] = { '\xFF' };
     nwipe_pattern_t patterns[] = { { 1, &onefill[0] },  // pass 1: 1s


### PR DESCRIPTION
1. Added rounds requested & completed. Coloured green if equal and red if not.
2. Fixed endtime sometimes not being recorded when a wipe is aborted. This affected the creation of the PDF filename. Now ok.
3. Added throughput using the appropriate nomenclature such as KB/sec MB/sec, GB/sec etc

This is the current status of the certificate, more code to follow shortly for HPA/DCO, organisation, customer and a /etc/nwipe.conf file where you can set nwipe's configuration including organisation and customers. 

![Screenshot_20230221_120429](https://user-images.githubusercontent.com/22084881/220340230-8eca9874-b2c6-4fff-8c37-5132f625756c.png)

And here's how the certificate looks for a aborted wipe.

![Screenshot_20230221_120708](https://user-images.githubusercontent.com/22084881/220340683-caf66fb4-2325-4fdc-866f-9adad29507e0.png)

