### PR TITLE
HPA_DCO_003 - Add HPA,DCO capability

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -157,13 +157,16 @@ typedef struct nwipe_context_t_
     time_t end_time;  // End time of wipe
     u64 fsyncdata_errors;  // The number of fsyncdata errors across all passes.
     char PDF_filename[256];  // The filename of the PDF certificate/report.
-    int HPA_status;  // 0 = No HPA found/disabled, 1 = HPA detected, 2 = Unknown, unable to checked
+    int HPA_status;  // 0 = No HPA found/disabled, 1 = HPA detected, 2 = Unknown, unable to checked,
+                     // 3 = Not applicable to this device
     u64 HPA_reported_set;  // the 'HPA set' value reported hdparm -N, i.e the first value of n/n
     u64 HPA_reported_real;  // the 'HPA real' value reported hdparm -N, i.e the second value of n/n
     int DCO_status;  // 0 = No DCO found, 1 = DCO detected, 2 = Unknown, unable to checked
     u64 DCO_reported_real_max_sectors;  // real max sectors as reported by hdparm --dco-identify
     u64 HPA_size;  // The size of the host protected area in sectors
     char HPA_size_text[NWIPE_DEVICE_SIZE_TXT_LENGTH];  // Human readable size bytes, KB, MB, GB ..
+    int HPA_display_toggle_state;  // 0 or 1 Used to toggle between "[1TB] [ 33C]" and [HDA STATUS]
+    time_t HPA_toggle_time;  // records a time, then if for instance 3 seconds has elapsed the display changes
 
     /*
      * Identity contains the raw serial number of the drive

--- a/src/create_pdf.c
+++ b/src/create_pdf.c
@@ -376,14 +376,15 @@ int create_pdf( nwipe_context_t* ptr )
     pdf_set_font( pdf, "Helvetica" );
 
     /*********************
-     * Populate HPA status
+     * Populate HPA status (and size if not applicable, NVMe and VIRT)
      */
-    if( !strcmp( c->device_type_str, "NVME" ) )
+    if( !strcmp( c->device_type_str, "NVME" ) || !strcmp( c->device_type_str, "VIRT" ) )
     {
-        snprintf( HPA_status_text, sizeof( HPA_status_text ), "Not applicable to NVME" );
-        snprintf( HPA_size_text, sizeof( HPA_size_text ), "Not applicable to NVME" );
+        snprintf( HPA_status_text, sizeof( HPA_status_text ), "Not applicable to %s", c->device_type_str );
         pdf_set_font( pdf, "Helvetica-Bold" );
         pdf_add_text( pdf, NULL, HPA_status_text, 12, 95, 190, PDF_DARK_GREEN );
+        snprintf( HPA_size_text, sizeof( HPA_size_text ), "Not applicable to %s", c->device_type_str );
+        pdf_add_text( pdf, NULL, HPA_size_text, 12, 360, 190, PDF_DARK_GREEN );
         pdf_set_font( pdf, "Helvetica" );
     }
     else

--- a/src/device.c
+++ b/src/device.c
@@ -288,6 +288,18 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
         }
     }
 
+    /* Initialise the variables that toggle the [size][temp c] with [HPA status]
+     */
+    next_device->HPA_toggle_time = time( NULL );
+    next_device->HPA_display_toggle_state = 0;
+
+    /* Initialise the HPA variables for this device
+     */
+    next_device->HPA_reported_set = 0;
+    next_device->HPA_reported_real = 0;
+    next_device->DCO_reported_real_max_sectors = 0;
+    next_device->HPA_status = HPA_NOT_APPLICABLE;
+
     /* All device strings should be 4 characters, prefix with space if under 4 characters
      * We also set a switch for certain devices to check for the host protected area (HPA)
      */

--- a/src/hpa_dco.c
+++ b/src/hpa_dco.c
@@ -371,22 +371,30 @@ int hpa_dco_status( nwipe_context_t* ptr )
      * to reset the HPA.
      */
     /* If all three values match then there is no hidden disc area. HPA is disabled. */
-    if( ( c->HPA_reported_set == c->HPA_reported_real ) && c->DCO_reported_real_max_sectors == c->HPA_reported_set )
+    if( c->HPA_reported_set == c->HPA_reported_real && c->DCO_reported_real_max_sectors == c->HPA_reported_set
+        && c->HPA_reported_set != 0 )
     {
         c->HPA_status = HPA_DISABLED;
     }
     else
     {
         /* If HPA set and DCO max sectors are equal it can also be considered that HPA is disabled */
-        if( c->HPA_reported_set == c->DCO_reported_real_max_sectors )
+        if( ( c->HPA_reported_set == c->DCO_reported_real_max_sectors ) && c->HPA_reported_set != 0 )
         {
             c->HPA_status = HPA_DISABLED;
         }
         else
         {
-            if( c->HPA_reported_set != c->DCO_reported_real_max_sectors )
+            if( c->HPA_reported_set != c->DCO_reported_real_max_sectors && c->HPA_reported_set != 0 )
             {
                 c->HPA_status = HPA_ENABLED;
+            }
+            else
+            {
+                if( !strcmp( c->device_type_str, "NVME" ) )
+                {
+                    c->HPA_status = HPA_NOT_APPLICABLE;
+                }
             }
         }
     }

--- a/src/hpa_dco.h
+++ b/src/hpa_dco.h
@@ -24,6 +24,7 @@
 #define HPA_DISABLED 0
 #define HPA_ENABLED 1
 #define HPA_UNKNOWN 2
+#define HPA_NOT_APPLICABLE 3
 
 int hpa_dco_status( nwipe_context_t* );
 

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -51,6 +51,7 @@
 #include <parted/parted.h>
 #include <parted/debug.h>
 #include "version.h"
+#include "hpa_dco.h"
 
 int terminate_signal;
 int user_abort;
@@ -351,6 +352,8 @@ int main( int argc, char** argv )
         }
     }
 
+    /* Initialise some of the variables in the drive contexts
+     */
     for( i = 0; i < nwipe_enumerated; i++ )
     {
         /* Set the PRNG implementation, which must always come after the function nwipe_gui_select ! */

--- a/src/temperature.c
+++ b/src/temperature.c
@@ -36,6 +36,7 @@
 #include "device.h"
 #include "logging.h"
 #include "temperature.h"
+#include "miscellaneous.h"
 
 int nwipe_init_temperature( nwipe_context_t* c )
 {


### PR DESCRIPTION
1. For devices that support HPA/DCO (not NVMe) nwipe displays the HPA status, it toggles every two seconds the size and the temperature i.e "[  1TB][ 35C]" with the HPA status such as [HPA disabled], [HPA ENABLED!], [HPA unknown]. The HPA ENABLED is highlighted with red text and a white background. HPA_disabled is standard white text on blue background.

More code to follow, a new option to be added, HPA, disable/enable which will disable the HPA and shut down the system. On manually powering back up the HPA should be reported as disabled.

Then lots of testing.