### PR TITLE
PDFGen14 - further work on PDF certificate

### DIFF
--- a/src/hpa_dco.h
+++ b/src/hpa_dco.h
@@ -25,6 +25,7 @@
 #define HPA_ENABLED 1
 #define HPA_UNKNOWN 2
 #define HPA_NOT_APPLICABLE 3
+#define HPA_NOT_SUPPORTED_BY_DRIVE 4
 
 int hpa_dco_status( nwipe_context_t* );
 


### PR DESCRIPTION
1. Changes to colour on some items under certain conditions.

2. Changed the HPA labels to include DCO, and changed the text from HPA enabled/disabled to something more meaningful to a user, i.e Hidden area found, no hidden area.

3. Added a new define "HPA_NOT_SUPPORTED_BY_DRIVE" for recent SATA drives that no longer support HPA/DCO. Further work needs to be done determining whether a drive supports HPA/DCO or not in the hpa_dco.c functions.

more code to follow ..

Snapshot of part of the certificate showing a wipe that was started then aborted on a drive that has one sector (512bytes) hidden by the disk configuration overlay, the user having not chosen to restore the DCO, in order to expose the hidden area to the OS. Bytes erased shows the number of bytes erased before the user aborted the wipe 7 seconds after it had started. The real size of the disc is in green as that is the genuine size of the disc, the apparent size is what the O.S. would see. There is a difference of 1 sector (512 bytes). This is also indicated in red for the HAP/DCO Size of 1 sector.  For a totally wiped drive you don't want to see any red, just green. However sometimes you may want to keep to hidden area, this will still be noted in red on the certificate.

![Screenshot_20230305_234032](https://user-images.githubusercontent.com/22084881/222992761-661fc900-6bd0-4d7f-aebf-10de0bc00cd0.png)


