### PR TITLE
HPA_DCO_004 - Add HPA/DCO Capability

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -795,47 +795,51 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
 
                 } /* switch select */
 
-                /* Toggle the [size][temp C] with [HDA Status]
+                wprintw( main_window, "[%s] ", c[i + offset]->device_size_text );
+
+                /* Read the drive temperature values */
+                nwipe_update_temperature( c[i + offset] );
+
+                /* print the temperature */
+                wprintw_temperature( c[i + offset] );
+
+                /* Toggle the drive/serial with [HDA/DCO Status]
                  */
                 switch( c[i + offset]->HPA_display_toggle_state )
                 {
                     case 0:
-                        wprintw( main_window, "[%s] ", c[i + offset]->device_size_text );
-
-                        /* Read the drive temperature values */
-                        nwipe_update_temperature( c[i + offset] );
-
-                        /* print the temperature */
-                        wprintw_temperature( c[i + offset] );
+                        /* print the drive model and serial number */
+                        wprintw( main_window, " %s/%s", c[i + offset]->device_model, c[i + offset]->device_serial_no );
                         break;
 
                     case 1:
                         switch( c[i + offset]->HPA_status )
                         {
                             case HPA_ENABLED:
+                                wprintw( main_window, " " );
                                 wattron( main_window, COLOR_PAIR( 9 ) );
-                                wprintw( main_window, "[HPA ENABLED!]" );
+                                wprintw( main_window, " HPA/DCO Warning, hidden area detected " );
                                 wattroff( main_window, COLOR_PAIR( 9 ) );
                                 break;
 
                             case HPA_DISABLED:
-                                wprintw( main_window, "[HPA disabled]" );
+                                wprintw( main_window, " " );
+                                wprintw( main_window, " HPA/DCO GOOD, no hidden areas " );
                                 break;
 
                             case HPA_UNKNOWN:
+                                wprintw( main_window, " " );
                                 wattron( main_window, COLOR_PAIR( 9 ) );
-                                wprintw( main_window, "[HPA unknown ]" );
+                                wprintw( main_window, " HPA/DCO hidden area indeterminate " );
                                 wattroff( main_window, COLOR_PAIR( 9 ) );
                                 break;
 
                             case HPA_NOT_APPLICABLE:
-                                wprintw( main_window, "[%s] ", c[i + offset]->device_size_text );
-
-                                /* Read the drive temperature values */
-                                nwipe_update_temperature( c[i + offset] );
-
-                                /* print the temperature */
-                                wprintw_temperature( c[i + offset] );
+                                /* print the drive model and serial number */
+                                wprintw( main_window,
+                                         " %s/%s",
+                                         c[i + offset]->device_model,
+                                         c[i + offset]->device_serial_no );
                                 break;
 
                             default:
@@ -858,9 +862,6 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
                     }
                     c[i + offset]->HPA_toggle_time = time( NULL );
                 }
-
-                /* print the drive model and serial number */
-                wprintw( main_window, " %s/%s", c[i + offset]->device_model, c[i + offset]->device_serial_no );
             }
             else
             {

--- a/src/hpa_dco.h
+++ b/src/hpa_dco.h
@@ -29,4 +29,13 @@
 
 int hpa_dco_status( nwipe_context_t* );
 
+typedef struct nwipe_sense_dco_identify_t_t_
+{
+    /* This struct contains some of the decoded fields from the sense data after a
+     * ATA 0xB1 device configuration overlay command has been issued. We mainly
+     * use it to decode the real max sectors
+     */
+    u64 dco_real_max_sectors;
+} nwipe_sense_dco_identify_t_t_;
+
 #endif /* HPA_DCO_H_ */


### PR DESCRIPTION
1. In the GUI I switched the HPA/DCO status position from overlaying the [drive size][temp] and instead positioning the HPA/DCO status over the drive model and serial number. HPA/DCO information and drive details alternating every couple of seconds. This allowed me to extend the length of the HPA message and make it more meaningful to somebody that doesn't know the HPA/DCO terminology. Therefore "HPA Enabled" is replaced with "HPA/DCO Warning, hidden area detected"

2. Started adding bad/missing sense data detection ..

more code to follow ..