### PR TITLE
HPA_DCO_005 - Add HPA/DCO capability

### DIFF
--- a/src/hpa_dco.h
+++ b/src/hpa_dco.h
@@ -29,6 +29,8 @@
 
 int hpa_dco_status( nwipe_context_t* );
 
+u64 nwipe_read_dco_real_max_sectors( char* );
+
 typedef struct nwipe_sense_dco_identify_t_t_
 {
     /* This struct contains some of the decoded fields from the sense data after a

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.34.1 Development code, not for production use!";
+const char* version_string = "0.34.3 Development code, not for production use!";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.34.1 Development code, not for production use!";
+const char* banner = "nwipe 0.34.3 Development code, not for production use!";


### PR DESCRIPTION
1. Created the function nwipe_read_dco_real_max_sectors() which directly accesses the disk drive sending a 0xB1 device configuration overlay identify command to the drive. We read the returned data structure extracting the real max sectors value. We do this if hdparm returns nonsense for the real max sector (as it does in hdparm v9.60) for some larger drives. This value is automatically sent to the nwipe log FYI.

2. Added a stdout & stderr pipe to the hdparm commands as verbose data appears to be sent to stderr, as we are interested in that data this pipe captures stderr as well as stdout.

3. Added headers "scsi/sg.h" and "scsi/scsi_ioctl.h" as we are now sending low level commands to the drives.