### PR TITLE
HPA_DCO_006 - Add HPA/DCO capability

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -818,13 +818,13 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
                             case HPA_ENABLED:
                                 wprintw( main_window, " " );
                                 wattron( main_window, COLOR_PAIR( 9 ) );
-                                wprintw( main_window, " HPA/DCO Warning, hidden area detected " );
+                                wprintw( main_window, " HPA/DCO hidden area detected !!   " );
                                 wattroff( main_window, COLOR_PAIR( 9 ) );
                                 break;
 
                             case HPA_DISABLED:
                                 wprintw( main_window, " " );
-                                wprintw( main_window, " HPA/DCO GOOD, no hidden areas " );
+                                wprintw( main_window, " HPA/DCO Excellent NO hidden areas " );
                                 break;
 
                             case HPA_UNKNOWN:

--- a/src/logging.c
+++ b/src/logging.c
@@ -86,6 +86,19 @@ void nwipe_log( nwipe_log_t level, const char* format, ... )
     /* initialise characters written */
     chars_written = 0;
 
+    /* Only log messages with the debug label if the command line --verbose
+     * options has been specified, otherwise just return
+     */
+    if( level == NWIPE_LOG_DEBUG && nwipe_options.verbose == 0 )
+    {
+        r = pthread_mutex_unlock( &mutex1 );
+        if( r != 0 )
+        {
+            fprintf( stderr, "nwipe_log: pthread_mutex_unlock failed. Code %i \n", r );
+        }
+        return;
+    }
+
     /* Print the date. The rc script uses the same format. */
     if( level != NWIPE_LOG_NOTIMESTAMP )
     {
@@ -602,16 +615,16 @@ int nwipe_log_sysinfo()
                     if( *( &dmidecode_keywords[keywords_idx][1][0] ) == '0' )
                     {
                         nwipe_log(
-                            NWIPE_LOG_NOTICE, "%s = %s", &dmidecode_keywords[keywords_idx][0][0], "XXXXXXXXXXXXXXX" );
+                            NWIPE_LOG_INFO, "%s = %s", &dmidecode_keywords[keywords_idx][0][0], "XXXXXXXXXXXXXXX" );
                     }
                     else
                     {
-                        nwipe_log( NWIPE_LOG_NOTICE, "%s = %s", &dmidecode_keywords[keywords_idx][0][0], path );
+                        nwipe_log( NWIPE_LOG_INFO, "%s = %s", &dmidecode_keywords[keywords_idx][0][0], path );
                     }
                 }
                 else
                 {
-                    nwipe_log( NWIPE_LOG_NOTICE, "%s = %s", &dmidecode_keywords[keywords_idx][0][0], path );
+                    nwipe_log( NWIPE_LOG_INFO, "%s = %s", &dmidecode_keywords[keywords_idx][0][0], path );
                 }
             }
             /* close */

--- a/src/logging.h
+++ b/src/logging.h
@@ -22,17 +22,18 @@
 #define LOGGING_H_
 
 /* Maximum size of a log message */
-#define MAX_LOG_LINE_CHARS 512
+#define MAX_LOG_LINE_CHARS 1024
 
-#define MAX_SIZE_OS_STRING 512 /* Maximum size of acceptable OS string */
+#define MAX_SIZE_OS_STRING 1024 /* Maximum size of acceptable OS string */
+
 #define OS_info_Line_offset 31 /* OS_info line offset in log */
 #define OS_info_Line_Length 48 /* OS_info line length */
 
 typedef enum nwipe_log_t_ {
     NWIPE_LOG_NONE = 0,
-    NWIPE_LOG_DEBUG,  // TODO:  Very verbose logging.
-    NWIPE_LOG_INFO,  // TODO:  Verbose logging.
-    NWIPE_LOG_NOTICE,  // Most logging happens at this level.
+    NWIPE_LOG_DEBUG,  // Output only when --verbose option used on cmd line.
+    NWIPE_LOG_INFO,  // General Info not specifically relevant to the wipe.
+    NWIPE_LOG_NOTICE,  // Most logging happens at this level related to wiping.
     NWIPE_LOG_WARNING,  // Things that the user should know about.
     NWIPE_LOG_ERROR,  // Non-fatal errors that result in failure.
     NWIPE_LOG_FATAL,  // Errors that cause the program to exit.


### PR DESCRIPTION
1. If nwipe enumerates a USB bridge that does not support ATA pass through or you are wiping a USB memory stick, nwipe will show a message in the GUI that says
"HPA/DCO hidden area indeterminate". If you get this message you know to either get yourself a better quality USB to SATA adapter or in the case of a USB memory stick, i've never come across one that supports HPA/DCO so either don't worry about it and wipe it as normal or physically destroy it.

2. We now check for a nonsense "real max sectors" as produced by the bug in hdparm. We use our own low level function to issue a DCO identify command and retrieve the correct value.

3. Changed the dmidecode info at the start of the log from a 'notice' classification to 'info'.

4. Made changes to the nwipe_log function so that any messages logged that are classified as 'debug' will not be logged unless the --verbose flag has been set on the command line options. I send the hex data structures and hex sense data to the logs as debug information and as they can take up a lot of space and make the log look untidy they will only appear in --verbose mode.

5. I also extended the nwipe's log message length from 512 to 1024 as some of the sense data was being truncated in the log.

Here's an example screenshot of the "HPA/DCO hidden area indeterminate" shown against the /dev/sdb device which is a USB Sandisk memory stick. Also shown is the "HPA/DCO hidden area detected" against the /dev/sda device. This was attached via a Unitek USB to SATA adapter that allows ATA pass through so we can detect hidden areas. The third device is NVME and HPA/DCO is not relevant to that device so no HPA/DCO message is displayed.

![showing_HPA_indeterminate_status-2023-03-10_00 00 17 mp4](https://user-images.githubusercontent.com/22084881/224194418-95cec10f-6377-4464-a505-fbc99232989a.gif)
