### PR TITLE
PDFGen15 - further work on PDF certificate

### DIFF
--- a/src/create_pdf.h
+++ b/src/create_pdf.h
@@ -38,4 +38,6 @@
  */
 int create_pdf( nwipe_context_t* ptr );
 
+int nwipe_get_smart_data( char* );
+
 #endif /* CREATE_PDF_H_ */

--- a/src/device.c
+++ b/src/device.c
@@ -342,10 +342,6 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
             check_HPA = 1;
             break;
     }
-    if( check_HPA == 1 )
-    {
-        hpa_dco_status( next_device );
-    }
 
     if( strlen( (const char*) next_device->device_serial_no ) )
     {
@@ -376,6 +372,17 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
                next_device->device_model,
                next_device->device_size_text,
                next_device->device_serial_no );
+
+    /******************************
+     * Check for hidden sector_size
+     */
+    if( check_HPA == 1 )
+    {
+        hpa_dco_status( next_device );
+    }
+
+    /* print an empty line to separate the drives in the log */
+    nwipe_log( NWIPE_LOG_INFO, " " );
 
     ( *c )[dcount] = next_device;
     return 1;
@@ -736,7 +743,7 @@ int nwipe_get_device_bus_type_and_serialno( char* device, nwipe_device_t* bus, c
                         }
                     }
 
-                    nwipe_log( NWIPE_LOG_DEBUG, "smartctl: %s", result );
+                    nwipe_log( NWIPE_LOG_INFO, "smartctl: %s", result );
                 }
 
                 if( strstr( result, "serial number:" ) != 0 )
@@ -811,21 +818,6 @@ int nwipe_get_device_bus_type_and_serialno( char* device, nwipe_device_t* bus, c
     }
 
     return set_return_value;
-}
-
-void strip_CR_LF( char* str )
-{
-    /* In the specified string, replace any CR or LF with a space */
-    int idx = 0;
-    int len = strlen( str );
-    while( idx < len )
-    {
-        if( str[idx] == 0x0A || str[idx] == 0x0D )
-        {
-            str[idx] = ' ';
-        }
-        idx++;
-    }
 }
 
 void remove_ATA_prefix( char* str )

--- a/src/hpa_dco.c
+++ b/src/hpa_dco.c
@@ -366,6 +366,13 @@ int hpa_dco_status( nwipe_context_t* ptr )
                  */
                 if( c->DCO_reported_real_max_sectors > 0 && c->DCO_reported_real_max_sectors < 429496729600 )
                 {
+                    nwipe_log( NWIPE_LOG_INFO,
+                               "NWipe: DCO Real max sectors reported as %lli on %s",
+                               c->DCO_reported_real_max_sectors,
+                               c->device_name );
+                }
+                else
+                {
                     /* Call nwipe's own low level function to retrieve the drive configuration
                      * overlay and retrieve the real max sectors. We may remove reliance on hdparm
                      * if nwipes own low level drive access code works well.
@@ -376,7 +383,7 @@ int hpa_dco_status( nwipe_context_t* ptr )
                     if( c->DCO_reported_real_max_sectors > 0 && c->DCO_reported_real_max_sectors < 429496729600 )
                     {
                         nwipe_log( NWIPE_LOG_INFO,
-                                   "NWipe:DCO Real max sectors reported as %lli on %s",
+                                   "NWipe: DCO Real max sectors reported as %lli on %s",
                                    c->DCO_reported_real_max_sectors,
                                    c->device_name );
                     }

--- a/src/miscellaneous.c
+++ b/src/miscellaneous.c
@@ -59,6 +59,21 @@ void strlower( char* str )
     }
 }
 
+void strip_CR_LF( char* str )
+{
+    /* In the specified string, replace any CR or LF with a space */
+    int idx = 0;
+    int len = strlen( str );
+    while( idx < len )
+    {
+        if( str[idx] == 0x0A || str[idx] == 0x0D )
+        {
+            str[idx] = ' ';
+        }
+        idx++;
+    }
+}
+
 /* Search a string for a positive number, convert the first
  * number found to binary and return the binary number.
  * returns the number or -1 if number too large or -2 if

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.34.3 Development code, not for production use!";
+const char* version_string = "0.34.4 Development code, not for production use!";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.34.3 Development code, not for production use!";
+const char* banner = "nwipe 0.34.4 Development code, not for production use!";


### PR DESCRIPTION
1. Added page 2 of the report which includes all smart data as displayed by smartctl -a /dev/sdx

2. Did some more work on the logic, i.e. when certain data on the certificate should be green and when it should be red.

3. Made some changes to nwipe's log in regards to the way it displays disc info right at the beginning of the log. Separated the drive information by a blank line to make each drive stand out from the rest.

4. Moved a string function from device.c to miscellaneous.c

[nwipe_report_2023-03-10-22-55-46_Model_ST350031_2CS_Serial_XXXXXXXXXXXXXXX.pdf](https://github.com/martijnvanbrummelen/nwipe/files/10946867/nwipe_report_2023-03-10-22-55-46_Model_ST350031_2CS_Serial_XXXXXXXXXXXXXXX.pdf)


![Screenshot_20230310_225732](https://user-images.githubusercontent.com/22084881/224448431-ac54a47a-c99a-4b6d-b782-fda483281da8.png)


more code to follow ..