### PR TITLE
Add temperature limits to nwipe log

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -818,13 +818,13 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
                             case HPA_ENABLED:
                                 wprintw( main_window, " " );
                                 wattron( main_window, COLOR_PAIR( 9 ) );
-                                wprintw( main_window, " HPA/DCO hidden area detected !!   " );
+                                wprintw( main_window, " HPA/DCO Hidden area detected !!   " );
                                 wattroff( main_window, COLOR_PAIR( 9 ) );
                                 break;
 
                             case HPA_DISABLED:
                                 wprintw( main_window, " " );
-                                wprintw( main_window, " HPA/DCO Excellent NO hidden areas " );
+                                wprintw( main_window, " HPA/DCO No hidden areas detected " );
                                 break;
 
                             case HPA_UNKNOWN:

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -317,6 +317,12 @@ int main( int argc, char** argv )
         }
 
         nwipe_update_temperature( c1[i] );
+
+        /* Log the temperature crtical, highest, lowest and lowest critical temperature
+         * limits to nwipes log file using the INFO catagory
+         */
+
+        nwipe_log_drives_temperature_limits( c1[i] );
     }
 
     /* Check for initialization errors. */

--- a/src/temperature.c
+++ b/src/temperature.c
@@ -40,11 +40,7 @@
 
 int nwipe_init_temperature( nwipe_context_t* c )
 {
-    /* This function is called after each nwipe_context_t has been created.
-     * It initialises the temperature variables in each context and then
-     * constructs a path that is placed in the context that points to the
-     * appropriate /sys/class/hwmon/hwmonX directory that corresponds with
-     * the particular drive represented in the context structure.
+    /* See header definition for description of function
      */
     DIR* dir;
     DIR* dir2;
@@ -266,6 +262,83 @@ void nwipe_update_temperature( nwipe_context_t* c )
      * this is used by the GUI to check temperatures periodically, typically
      * every 60 seconds */
     c->temp1_time = time( NULL );
+
+    return;
+}
+
+void nwipe_log_drives_temperature_limits( nwipe_context_t* c )
+{
+    /* See header for description of function
+     */
+
+    char temperature_limits_txt[500];
+
+    int idx = 0;
+
+    /*
+     * Initialise the character string, as we are building it a few
+     * characters at a time and it's important there it is populated
+     * with all zeros as we are using strlen() as we build the line up.
+     */
+    memset( &temperature_limits_txt, 0, sizeof( temperature_limits_txt ) );
+
+    if( c->temp1_crit != 1000000 )
+    {
+        snprintf( temperature_limits_txt,
+                  sizeof( temperature_limits_txt ),
+                  "Temperature limits for %s, critical=%ic, ",
+                  c->device_name,
+                  c->temp1_crit );
+    }
+    else
+    {
+        snprintf( temperature_limits_txt,
+                  sizeof( temperature_limits_txt ),
+                  "Temperature limits for %s, critical=N/A, ",
+                  c->device_name );
+    }
+
+    idx = strlen( temperature_limits_txt );
+
+    if( c->temp1_highest != 1000000 )
+    {
+        snprintf( &temperature_limits_txt[idx],
+                  ( sizeof( temperature_limits_txt ) - idx ),
+                  "highest=%ic, ",
+                  c->temp1_highest );
+    }
+    else
+    {
+        snprintf( &temperature_limits_txt[idx], ( sizeof( temperature_limits_txt ) - idx ), "highest=N/A, " );
+    }
+
+    idx = strlen( temperature_limits_txt );
+
+    if( c->temp1_lowest != 1000000 )
+    {
+        snprintf(
+            &temperature_limits_txt[idx], ( sizeof( temperature_limits_txt ) - idx ), "lowest=%ic, ", c->temp1_lowest );
+    }
+    else
+    {
+        snprintf( &temperature_limits_txt[idx], ( sizeof( temperature_limits_txt ) - idx ), "lowest=N/A, " );
+    }
+
+    idx = strlen( temperature_limits_txt );
+
+    if( c->temp1_lcrit != 1000000 )
+    {
+        snprintf( &temperature_limits_txt[idx],
+                  ( sizeof( temperature_limits_txt ) - idx ),
+                  "low critical=%ic.",
+                  c->temp1_lcrit );
+    }
+    else
+    {
+        snprintf( &temperature_limits_txt[idx], ( sizeof( temperature_limits_txt ) - idx ), "low critical=N/A. " );
+    }
+
+    nwipe_log( NWIPE_LOG_INFO, "%s", temperature_limits_txt );
 
     return;
 }

--- a/src/temperature.h
+++ b/src/temperature.h
@@ -1,4 +1,4 @@
-/*.
+/*
  *  temperature.h: The header file for disk drive temperature sensing
  *
  *  This program is free software; you can redistribute it and/or modify it under
@@ -22,8 +22,27 @@
 #include <sys/types.h>
 #include "context.h"
 
+/**
+ * This function is called after each nwipe_context_t has been created.
+ * It initialises the temperature variables in each context and then
+ * constructs a path that is placed in the context that points to the
+ * appropriate /sys/class/hwmon/hwmonX directory that corresponds with
+ * the particular drive represented in the context structure.
+ * @param pointer to a drive context
+ * @return returns 0 on success < 1 on error
+ */
 int nwipe_init_temperature( nwipe_context_t* );
+
 void nwipe_update_temperature( nwipe_context_t* );
+
+/**
+ * This function is normally called only once. It's called after both the
+ * nwipe_init_temperature() function and nwipe_update_temperature()
+ * functions have been called. It logs the drives critical, highest, lowest
+ * and lowest critical temperatures. Not all drives report four temperatures.
+ * @param pointer to a drive context
+ */
+void nwipe_log_drives_temperature_limits( nwipe_context_t* );
 
 #define NUMBER_OF_FILES 7
 


### PR DESCRIPTION
1. For each drive we now show the following temperature limits that are obtained directly from the drive. These are shown in the log under the INFO category. For a given drive all it's limits are shown on a single line near the start of the log. Whether all these values contain data will vary between manufacturer, for instance the Seagate SN570 only shows the high critical value of 84 deg.C

High critical - Exceeding this value can damage and/or reduce the life of the drive.
Highest - This is the maximum continuous running temperature allowed.
Lowest - This is the minimum continuous running temperature allowed.
Low critical - Dropping below this temperature may cause failure.

2. Changed some wording in the GUI for a on screen message to do with HPA/DCO.

#### Example of the drive temperature limits that now appear in the log.

![Screenshot_20230314_203250](https://user-images.githubusercontent.com/22084881/225129745-c3d13861-ef95-4913-a5bb-74a4a5769389.png)
