### PR TITLE
Fix anomaly with color change of temperature

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -3266,10 +3266,9 @@ void temp1_flash( nwipe_context_t* c )
 
 void wprintw_temperature( nwipe_context_t* c )
 {
-    /* If available, print the current temperature. This function determines
-     * whether the temperature should be printed as white, solid red, flashing red
-     * solid black or flashing black and then prints it to the main_window.
+    /* See header for description of function
      */
+
     if( c->temp1_input != 1000000 )
     {
         /* if drive temperature has exceeded critical continuous running
@@ -3277,73 +3276,26 @@ void wprintw_temperature( nwipe_context_t* c )
          */
         if( c->temp1_input >= c->temp1_crit && c->temp1_crit != 1000000 )
         {
-            temp1_flash( c );
-
-            if( c->temp1_flash_rate_status == 0 )
-            {
-                /* blue on blue */
-                wattron( main_window, COLOR_PAIR( 12 ) );
-                wprintw( main_window, "[%dC]", c->temp1_input );
-                wattroff( main_window, COLOR_PAIR( 12 ) );
-            }
-            else
-            {
-                /* red on blue */
-                wattron( main_window, COLOR_PAIR( 3 ) );
-                wprintw( main_window, "[%dC]", c->temp1_input );
-                wattroff( main_window, COLOR_PAIR( 3 ) );
-            }
+            /* red on blue */
+            wattron( main_window, COLOR_PAIR( 3 ) );
+            wprintw( main_window, "[%dC]", c->temp1_input );
+            wattroff( main_window, COLOR_PAIR( 3 ) );
         }
         else
         {
-            /* if drive temperature has exceeded maximum continuous running
-             * temperature && max value is valid
-             */
-            if( c->temp1_input >= c->temp1_max && c->temp1_max != 1000000 )
+
+            /* if drive temperature is below the critical temperature && critical value is valid */
+            if( c->temp1_input <= c->temp1_lcrit && c->temp1_lcrit != 1000000 )
             {
-                /* red on blue */
-                wattron( main_window, COLOR_PAIR( 3 ) );
+                /* black on blue */
+                wattron( main_window, COLOR_PAIR( 11 ) );
                 wprintw( main_window, "[%dC]", c->temp1_input );
-                wattroff( main_window, COLOR_PAIR( 3 ) );
+                wattroff( main_window, COLOR_PAIR( 11 ) );
             }
             else
             {
-                /* if drive temperature is below the critical temperature && critical value is valid */
-                if( c->temp1_input <= c->temp1_lcrit && c->temp1_lcrit != 1000000 )
-                {
-                    temp1_flash( c );
-                    if( c->temp1_flash_rate_status == 0 )
-                    {
-                        /* blue on blue */
-                        wattron( main_window, COLOR_PAIR( 12 ) );
-                        wprintw( main_window, "[%dC]", c->temp1_input );
-                        wattroff( main_window, COLOR_PAIR( 12 ) );
-                    }
-                    else
-                    {
-                        /* black on blue */
-                        wattron( main_window, COLOR_PAIR( 11 ) );
-                        wprintw( main_window, "[%dC]", c->temp1_input );
-                        wattroff( main_window, COLOR_PAIR( 11 ) );
-                    }
-                }
-                else
-                {
-                    /* if drive temperature is below the minimum continuous running temperature && minimum
-                     * value is valid */
-                    if( c->temp1_input <= c->temp1_min && c->temp1_min != 1000000 )
-                    {
-                        /* black on blue */
-                        wattron( main_window, COLOR_PAIR( 11 ) );
-                        wprintw( main_window, "[%dC]", c->temp1_input );
-                        wattroff( main_window, COLOR_PAIR( 11 ) );
-                    }
-                    else
-                    {
-                        /* Default white on blue */
-                        wprintw( main_window, "[%dC]", c->temp1_input );
-                    }
-                }
+                /* Default white on blue */
+                wprintw( main_window, "[%dC]", c->temp1_input );
             }
         }
     }

--- a/src/gui.h
+++ b/src/gui.h
@@ -55,6 +55,16 @@ void nwipe_gui_verify( void );  // Change the verify option.
 void nwipe_gui_noblank( void );  // Change the noblank option.
 int spinner( nwipe_context_t** ptr, int );  // Return the next spinner character
 void temp1_flash( nwipe_context_t* );  // toggles term1_flash_status, which flashes the temperature
+
+/**
+ * If the current drive temperature is available, print it to the GUI.
+ * This function determines if the drive temperature limits are specified &
+ * if so, whether the temperature should be printed as white text on blue if the
+ * drive is operating within it's temperature specification or red text on
+ * blue if the drive has exceeded the critical high temperature or black on
+ * blue if the drive has dropped below the drives minimum temperature specification.
+ * @param pointer to the drive context
+ */
 void wprintw_temperature( nwipe_context_t* );
 
 int compute_stats( void* ptr );

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.34.5 Development code, not for production use!";
+const char* version_string = "0.34.6 Development code, not for production use!";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.34.5 Development code, not for production use!";
+const char* banner = "nwipe 0.34.6 Development code, not for production use!";


### PR DESCRIPTION
Temperature text now changes red when it's exceeded the high critical temperature and black when it's dropped below the low critical temperature. See nwipes log for what those values actually are as those critical temperature values are obtained from each drive.

When the drive temperature is within the drives specification the temperature text will be white text on blue background.

The temperature text no longer flashes red or black.