### PR TITLE
Added max, min drive temperatures to log

### DIFF
--- a/src/temperature.c
+++ b/src/temperature.c
@@ -300,6 +300,17 @@ void nwipe_log_drives_temperature_limits( nwipe_context_t* c )
 
     idx = strlen( temperature_limits_txt );
 
+    if( c->temp1_max != 1000000 )
+    {
+        snprintf( &temperature_limits_txt[idx], ( sizeof( temperature_limits_txt ) - idx ), "max=%ic, ", c->temp1_max );
+    }
+    else
+    {
+        snprintf( &temperature_limits_txt[idx], ( sizeof( temperature_limits_txt ) - idx ), "max=N/A, " );
+    }
+
+    idx = strlen( temperature_limits_txt );
+
     if( c->temp1_highest != 1000000 )
     {
         snprintf( &temperature_limits_txt[idx],
@@ -322,6 +333,17 @@ void nwipe_log_drives_temperature_limits( nwipe_context_t* c )
     else
     {
         snprintf( &temperature_limits_txt[idx], ( sizeof( temperature_limits_txt ) - idx ), "lowest=N/A, " );
+    }
+
+    idx = strlen( temperature_limits_txt );
+
+    if( c->temp1_min != 1000000 )
+    {
+        snprintf( &temperature_limits_txt[idx], ( sizeof( temperature_limits_txt ) - idx ), "min=%ic, ", c->temp1_min );
+    }
+    else
+    {
+        snprintf( &temperature_limits_txt[idx], ( sizeof( temperature_limits_txt ) - idx ), "min=N/A, " );
     }
 
     idx = strlen( temperature_limits_txt );

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.34.6 Development code, not for production use!";
+const char* version_string = "0.34.7 Development code, not for production use!";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.34.6 Development code, not for production use!";
+const char* banner = "nwipe 0.34.7 Development code, not for production use!";


### PR DESCRIPTION
Added the max and min drive temperatures to the nwipe log. We now have upto six temperatures that may be reported for each drive. Whether all these fields are populated is down to each drive manufacturer.