### PR TITLE
Validate temperatures.

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -170,6 +170,8 @@ typedef struct nwipe_context_t_
     char HPA_size_text[NWIPE_DEVICE_SIZE_TXT_LENGTH];  // Human readable size bytes, KB, MB, GB ..
     int HPA_display_toggle_state;  // 0 or 1 Used to toggle between "[1TB] [ 33C]" and [HDA STATUS]
     time_t HPA_toggle_time;  // records a time, then if for instance 3 seconds has elapsed the display changes
+    int test_use1;
+    int test_use2;
 
     /*
      * Identity contains the raw serial number of the drive

--- a/src/temperature.c
+++ b/src/temperature.c
@@ -54,21 +54,22 @@ int nwipe_init_temperature( nwipe_context_t* c )
     struct dirent* dp;
     struct dirent* dp2;
 
-    /* Why Initialise with 1000000? Because the GUI needs to know whether data
-     * has been obtained so it can display appropriate information when a
+    /* Why Initialise with 1000000 (defined as NO_TEMPERATURE_DATA)?
+     * Because the GUI needs to know whether data has been obtained
+     * so it can display appropriate information when a
      * device is unable to provide temperature data */
 
-    c->temp1_crit = 1000000;
-    c->temp1_highest = 1000000;
-    c->temp1_input = 1000000;
-    c->temp1_lcrit = 1000000;
-    c->temp1_lowest = 1000000;
-    c->temp1_max = 1000000;
-    c->temp1_min = 1000000;
-    c->temp1_monitored_wipe_max = 1000000;
-    c->temp1_monitored_wipe_min = 1000000;
-    c->temp1_monitored_wipe_avg = 1000000;
-    c->temp1_flash_rate = 2;
+    c->temp1_crit = NO_TEMPERATURE_DATA;
+    c->temp1_highest = NO_TEMPERATURE_DATA;
+    c->temp1_input = NO_TEMPERATURE_DATA;
+    c->temp1_lcrit = NO_TEMPERATURE_DATA;
+    c->temp1_lowest = NO_TEMPERATURE_DATA;
+    c->temp1_max = NO_TEMPERATURE_DATA;
+    c->temp1_min = NO_TEMPERATURE_DATA;
+    c->temp1_monitored_wipe_max = NO_TEMPERATURE_DATA;
+    c->temp1_monitored_wipe_min = NO_TEMPERATURE_DATA;
+    c->temp1_monitored_wipe_avg = NO_TEMPERATURE_DATA;
+    c->temp1_flash_rate = 0;
     c->temp1_flash_rate_counter = 0;
     c->temp1_path[0] = 0;
     c->temp1_time = 0;
@@ -282,7 +283,7 @@ void nwipe_log_drives_temperature_limits( nwipe_context_t* c )
      */
     memset( &temperature_limits_txt, 0, sizeof( temperature_limits_txt ) );
 
-    if( c->temp1_crit != 1000000 )
+    if( c->temp1_crit != NO_TEMPERATURE_DATA )
     {
         snprintf( temperature_limits_txt,
                   sizeof( temperature_limits_txt ),
@@ -300,7 +301,7 @@ void nwipe_log_drives_temperature_limits( nwipe_context_t* c )
 
     idx = strlen( temperature_limits_txt );
 
-    if( c->temp1_max != 1000000 )
+    if( c->temp1_max != NO_TEMPERATURE_DATA )
     {
         snprintf( &temperature_limits_txt[idx], ( sizeof( temperature_limits_txt ) - idx ), "max=%ic, ", c->temp1_max );
     }
@@ -311,7 +312,7 @@ void nwipe_log_drives_temperature_limits( nwipe_context_t* c )
 
     idx = strlen( temperature_limits_txt );
 
-    if( c->temp1_highest != 1000000 )
+    if( c->temp1_highest != NO_TEMPERATURE_DATA )
     {
         snprintf( &temperature_limits_txt[idx],
                   ( sizeof( temperature_limits_txt ) - idx ),
@@ -325,7 +326,7 @@ void nwipe_log_drives_temperature_limits( nwipe_context_t* c )
 
     idx = strlen( temperature_limits_txt );
 
-    if( c->temp1_lowest != 1000000 )
+    if( c->temp1_lowest != NO_TEMPERATURE_DATA )
     {
         snprintf(
             &temperature_limits_txt[idx], ( sizeof( temperature_limits_txt ) - idx ), "lowest=%ic, ", c->temp1_lowest );
@@ -337,7 +338,7 @@ void nwipe_log_drives_temperature_limits( nwipe_context_t* c )
 
     idx = strlen( temperature_limits_txt );
 
-    if( c->temp1_min != 1000000 )
+    if( c->temp1_min != NO_TEMPERATURE_DATA )
     {
         snprintf( &temperature_limits_txt[idx], ( sizeof( temperature_limits_txt ) - idx ), "min=%ic, ", c->temp1_min );
     }
@@ -348,7 +349,7 @@ void nwipe_log_drives_temperature_limits( nwipe_context_t* c )
 
     idx = strlen( temperature_limits_txt );
 
-    if( c->temp1_lcrit != 1000000 )
+    if( c->temp1_lcrit != NO_TEMPERATURE_DATA )
     {
         snprintf( &temperature_limits_txt[idx],
                   ( sizeof( temperature_limits_txt ) - idx ),

--- a/src/temperature.h
+++ b/src/temperature.h
@@ -46,4 +46,6 @@ void nwipe_log_drives_temperature_limits( nwipe_context_t* );
 
 #define NUMBER_OF_FILES 7
 
+#define NO_TEMPERATURE_DATA 1000000
+
 #endif /* TEMPERATURE_H_ */

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.34.7 Development code, not for production use!";
+const char* version_string = "0.34.8 Development code, not for production use!";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.34.7 Development code, not for production use!";
+const char* banner = "nwipe 0.34.8 Development code, not for production use!";


### PR DESCRIPTION
Now validates temperatures rather than assuming the data is valid.

1. Checks for 0 in high critical and max.
2. Copes with missing critical or max min data or partially missing data.
3. Checks the high critical and max are the right way round
4. Checks the low critical and min are the right way round
5. Temperature is displayed in 5 different ways i. white text on blue - temperature with spec. (or no spec available) ii. red text on blue - max temperature reached.
iii. white text on red - critical high temperature reached. iv. black text on blue - minimum temperature reached. v. white text on black - critical low temperature reached.

Test code showing temperature cycling between +10 and -10 with critical at +8 and -8 and min/max at -5 & +5.
The colors of the temperature text and background change when those settings are reached. As this is a test, those values are low for test purposes, on a actual disc they are more like critical +65, max +60, min -2 critical min -5

![showing_new_temperature_style-2023-03-15_23 26 27 mp4](https://user-images.githubusercontent.com/22084881/225480626-97911df4-ac49-4795-86da-53a17bf3e736.gif)
