### PR TITLE
HPA_DCO_007 - Add HPA/DCO capability

### DIFF
--- a/src/create_pdf.c
+++ b/src/create_pdf.c
@@ -205,7 +205,7 @@ int create_pdf( nwipe_context_t* ptr )
     if( !strcmp( c->device_type_str, "NVME" ) || !strcmp( c->device_type_str, "VIRT" )
         || c->HPA_status == HPA_NOT_APPLICABLE )
     {
-        snprintf( device_size, sizeof( device_size ), "Not applicable to %s", c->device_type_str );
+        snprintf( device_size, sizeof( device_size ), "%s, %lli bytes", c->device_size_text, c->device_size );
         pdf_add_text( pdf, NULL, device_size, text_size_data, 125, 370, PDF_DARK_GREEN );
     }
     else
@@ -213,7 +213,7 @@ int create_pdf( nwipe_context_t* ptr )
         /* If there is a real max size always show in green, if the drive doesn't
          * support HPA show device size as that is the real size.
          */
-        if( c->DCO_reported_real_max_size > 1 || c->HPA_status == HPA_NOT_APPLICABLE )
+        if( c->DCO_reported_real_max_size > 1 )
         {
             /* displays the real max size of the disc from the DCO displayed in Green */
             snprintf( device_size,

--- a/src/gui.c
+++ b/src/gui.c
@@ -824,19 +824,19 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
                             case HPA_ENABLED:
                                 wprintw( main_window, " " );
                                 wattron( main_window, COLOR_PAIR( 9 ) );
-                                wprintw( main_window, " HPA/DCO Hidden area detected !!   " );
+                                wprintw( main_window, " HPA/DCO Hidden sectors detected !!" );
                                 wattroff( main_window, COLOR_PAIR( 9 ) );
                                 break;
 
                             case HPA_DISABLED:
                                 wprintw( main_window, " " );
-                                wprintw( main_window, " HPA/DCO No hidden areas detected " );
+                                wprintw( main_window, "HPA/DCO No hidden sectors detected " );
                                 break;
 
                             case HPA_UNKNOWN:
                                 wprintw( main_window, " " );
                                 wattron( main_window, COLOR_PAIR( 9 ) );
-                                wprintw( main_window, " HPA/DCO hidden area indeterminate " );
+                                wprintw( main_window, " HPA/DCO hidden sectors indeterminate " );
                                 wattroff( main_window, COLOR_PAIR( 9 ) );
                                 break;
 

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -84,32 +84,6 @@ int main( int argc, char** argv )
     /* The generic result buffer. */
     int r;
 
-    /* Log nwipes version */
-    nwipe_log( NWIPE_LOG_INFO, "%s", banner );
-
-    /* Check that hdparm exists, we use hdparm for HPA/DCO detection etc, if not exit nwipe
-     * required if the PATH environment is not setup ! (Debian sid 'su' as
-     * opposed to 'su -'
-     */
-    if( system( "which hdparm > /dev/null 2>&1" ) )
-    {
-        if( system( "which /sbin/hdparm > /dev/null 2>&1" ) )
-        {
-            if( system( "which /usr/bin/hdparm > /dev/null 2>&1" ) )
-            {
-                nwipe_log( NWIPE_LOG_WARNING, "hdparm command not found." );
-                nwipe_log( NWIPE_LOG_WARNING,
-                           "Required by nwipe for HPA/DCO detection & correction and ATA secure erase." );
-                nwipe_log( NWIPE_LOG_WARNING, "** Please install hdparm **\n" );
-                cleanup();
-                exit( 1 );
-            }
-        }
-    }
-
-    /* Log OS info */
-    nwipe_log_OSinfo();
-
     /* Initialise the termintaion signal, 1=terminate nwipe */
     terminate_signal = 0;
 
@@ -136,8 +110,43 @@ int main( int argc, char** argv )
 
     int wipe_threads_started = 0;
 
-    /* Parse command line options. */
+    /** NOTE ** NOTE ** NOTE ** NOTE ** NOTE ** NOTE ** NOTE ** NOTE ** NOTE **
+     * Important Note: if you want nwipe_log messages to go into the logfile
+     * they must after after the options are parsed here, else they will
+     * appear in the console but not in the logfile, that is, assuming you
+     * specified a log file on the command line as an nwipe option.
+     */
+
+    /*****************************
+     * Parse command line options.
+     */
     nwipe_optind = nwipe_options_parse( argc, argv );
+
+    /* Log nwipes version */
+    nwipe_log( NWIPE_LOG_INFO, "%s", banner );
+
+    /* Log OS info */
+    nwipe_log_OSinfo();
+
+    /* Check that hdparm exists, we use hdparm for HPA/DCO detection etc, if not exit nwipe
+     * required if the PATH environment is not setup ! (Debian sid 'su' as
+     * opposed to 'su -'
+     */
+    if( system( "which hdparm > /dev/null 2>&1" ) )
+    {
+        if( system( "which /sbin/hdparm > /dev/null 2>&1" ) )
+        {
+            if( system( "which /usr/bin/hdparm > /dev/null 2>&1" ) )
+            {
+                nwipe_log( NWIPE_LOG_WARNING, "hdparm command not found." );
+                nwipe_log( NWIPE_LOG_WARNING,
+                           "Required by nwipe for HPA/DCO detection & correction and ATA secure erase." );
+                nwipe_log( NWIPE_LOG_WARNING, "** Please install hdparm **\n" );
+                cleanup();
+                exit( 1 );
+            }
+        }
+    }
 
     if( nwipe_optind == argc )
     {
@@ -973,7 +982,7 @@ int cleanup()
     extern int log_elements_allocated;  // initialised and found in logging.c
     extern char** log_lines;
 
-    /* Print the logs held in memory. */
+    /* Print the logs held in memory to the console */
     for( i = log_elements_displayed; i < log_elements_allocated; i++ )
     {
         printf( "%s\n", log_lines[i] );

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.34.8 Development code, not for production use!";
+const char* version_string = "0.34.81 Development code, not for production use!";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.34.8 Development code, not for production use!";
+const char* banner = "nwipe 0.34.81 Development code, not for production use!";


### PR DESCRIPTION
1. Fix issue in PDF certificate where a drive that doesn't support device configuration overlay, shows 512 bytes as the disc size in the "Size(Real)" area on the certificate.

2. Fix a comment in the log that suggests you might be using a USB adapter or memory stick and those device can cause an indeterminate HPA/DCO status. This is now corrected so that we check the bus is USB before we issue that message.

3. Changes to some GUI text, replaced 'area' with 'sectors'.

4. Aligned "HPA/DCO No hidden sectors detected" to the drive model/serial text that it alternates with. One character left.

5. Nwipe's version and operating system information that is always printed to the console on exit, was not appearing in the optional log file, as optionally specified on the command line. This was caused because those nwipe_log() calls were happening before the command line options had been parsed. Essentially there was no ~spoon~ log file. Comments were made in the nwipe.c as a reminder to use nwipe_log() calls with caution, prior to the options parser.

6. Made changes to the logic in the HPA_dco functions such that a device that does not appear to support device configuration overlay and host protected area is classified as HPA_NOT APPLICABLE in regards to the hpa_status which is important for the PDF certificate code so that the fields in the certificate are updated appropriately.