### PR TITLE
HPA_DCO_008 continuation of HPA/DCO integration.

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -164,9 +164,12 @@ typedef struct nwipe_context_t_
     int DCO_status;  // 0 = No DCO found, 1 = DCO detected, 2 = Unknown, unable to checked
     u64 DCO_reported_real_max_sectors;  // real max sectors as reported by hdparm --dco-identify
     u64 DCO_reported_real_max_size;  // real max sectors in bytes
+    u64 Calculated_real_max_size_in_bytes;  // This value is determined from all the possible variations for drives that
+                                            // don't support DCO/HPA and those that do. Also drives that can't provide
+                                            // HPA/DCO due to the chips they use (USB adapters)
     char DCO_reported_real_max_size_text[NWIPE_DEVICE_SIZE_TXT_LENGTH];  // real max size in human readable form i.e 1TB
                                                                          // etc
-    u64 HPA_size;  // The size of the host protected area in sectors
+    u64 HPA_sectors;  // The size of the host protected area in sectors
     char HPA_size_text[NWIPE_DEVICE_SIZE_TXT_LENGTH];  // Human readable size bytes, KB, MB, GB ..
     int HPA_display_toggle_state;  // 0 or 1 Used to toggle between "[1TB] [ 33C]" and [HDA STATUS]
     time_t HPA_toggle_time;  // records a time, then if for instance 3 seconds has elapsed the display changes

--- a/src/device.c
+++ b/src/device.c
@@ -219,6 +219,7 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
     }
 
     next_device->device_size = dev->length * dev->sector_size;
+    next_device->device_sector_size = dev->sector_size;
     Determine_C_B_nomenclature( next_device->device_size, next_device->device_size_txt, NWIPE_DEVICE_SIZE_TXT_LENGTH );
     next_device->device_size_text = next_device->device_size_txt;
     next_device->result = -2;
@@ -293,6 +294,9 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
      * We also set a switch for certain devices to check for the host protected area (HPA)
      */
     check_HPA = 0;
+
+    // WARNING TEMP LINE WARNING
+    // next_device->device_type = NWIPE_DEVICE_ATA;
 
     switch( next_device->device_type )
     {

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.34.81 Development code, not for production use!";
+const char* version_string = "0.34.82 Development code, not for production use!";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.34.81 Development code, not for production use!";
+const char* banner = "nwipe 0.34.82 Development code, not for production use!";


### PR DESCRIPTION
Many changes related to DCO real max sectors and HPA set and real sectors and how they are processed and used in the PDF creation function. More testing is required until I'm happy this works correctly with lots of different hardware including USB adapters that don't support DCO/HPA and also drives that don't support DCO/HPA such as the Seagate Enterprise EXOS drives.