### PR TITLE
HPA_DCO_010 Continuation of HPA/DCO integration.

### DIFF
--- a/src/miscellaneous.c
+++ b/src/miscellaneous.c
@@ -251,7 +251,6 @@ void convert_double_to_string( char* output_str, double value )
     char percstr[512] = "";
 
     snprintf( percstr, sizeof( percstr ), "%5.32lf", value );
-    printf( "percstr=%s%%", percstr );
 
     while( percstr[idx] != 0 )
     {

--- a/src/version.c
+++ b/src/version.c
@@ -4,14 +4,14 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.34.82 Development code, not for production use!";
+const char* version_string = "0.34.83 Development code, not for production use!";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
-const char* years = "2022";
+const char* years = "2023";
 const char* copyright = "Copyright Darik Horn <dajhorn-dban@vanadac.com>\n\
 Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.34.82 Development code, not for production use!";
+const char* banner = "nwipe 0.34.83 Development code, not for production use!";


### PR DESCRIPTION
The Seagate EXOS family of drives don't support the ATA drive configuration overlay (DCO) command, however they do support host protected area (HPA). Therefore these drives can have hidden sectors.

The code was changed to accommodate the slightly different way these drives respond to a hdparm -N, that is, the response is accessible max address enabled or
accessible max address disabled. The new code correctly determines a the status of a drive in regards to
whether it has hidden sectors or not and what it's apparent and real size is.