### PR TITLE
HPA_DCO_011 Continuation of HPA/DCO integration.

### DIFF
--- a/src/hpa_dco.c
+++ b/src/hpa_dco.c
@@ -533,38 +533,54 @@ int hpa_dco_status( nwipe_context_t* ptr )
         }
         else
         {
-            if( c->HPA_reported_set == c->HPA_reported_real && c->DCO_reported_real_max_sectors == 0 )
+            if( c->DCO_reported_real_max_sectors > 0 && c->DCO_reported_real_max_sectors == ( c->device_size / 512 ) )
             {
-                c->HPA_status = HPA_NOT_APPLICABLE;
+                c->HPA_status = HPA_DISABLED;
             }
             else
             {
-                if( c->HPA_reported_set != c->DCO_reported_real_max_sectors && c->HPA_reported_set != 0 )
+                if( c->DCO_reported_real_max_sectors > 0
+                    && c->DCO_reported_real_max_sectors != ( c->device_size / 512 ) )
                 {
                     c->HPA_status = HPA_ENABLED;
                 }
                 else
                 {
-                    /* This occurs when a SG_IO error occurs with USB devices that don't support ATA pass through */
-                    if( c->HPA_reported_set == 0 && c->HPA_reported_real == 1 )
+                    if( c->HPA_reported_set == c->HPA_reported_real && c->DCO_reported_real_max_sectors == 0 )
                     {
-                        c->HPA_status = HPA_UNKNOWN;
+                        c->HPA_status = HPA_NOT_APPLICABLE;
                     }
                     else
                     {
-                        /* NVMe drives don't support HPA/DCO */
-                        if( c->device_type == NWIPE_DEVICE_NVME || c->device_type == NWIPE_DEVICE_VIRT
-                            || ( c->HPA_reported_set > 1 && c->DCO_reported_real_max_sectors < 2 ) )
+                        if( c->HPA_reported_set != c->DCO_reported_real_max_sectors && c->HPA_reported_set != 0 )
                         {
-                            c->HPA_status = HPA_NOT_APPLICABLE;
+                            c->HPA_status = HPA_ENABLED;
                         }
                         else
                         {
-                            /* For recent enterprise and new drives that don't provide HPA/DCO anymore */
-                            if( c->HPA_reported_set > 0 && c->HPA_reported_real == 1
-                                && c->DCO_reported_real_max_sectors < 2 )
+                            /* This occurs when a SG_IO error occurs with USB devices that don't support ATA pass
+                             * through */
+                            if( c->HPA_reported_set == 0 && c->HPA_reported_real == 1 )
                             {
-                                c->HPA_status = HPA_NOT_APPLICABLE;
+                                c->HPA_status = HPA_UNKNOWN;
+                            }
+                            else
+                            {
+                                /* NVMe drives don't support HPA/DCO */
+                                if( c->device_type == NWIPE_DEVICE_NVME || c->device_type == NWIPE_DEVICE_VIRT
+                                    || ( c->HPA_reported_set > 1 && c->DCO_reported_real_max_sectors < 2 ) )
+                                {
+                                    c->HPA_status = HPA_NOT_APPLICABLE;
+                                }
+                                else
+                                {
+                                    /* For recent enterprise and new drives that don't provide HPA/DCO anymore */
+                                    if( c->HPA_reported_set > 0 && c->HPA_reported_real == 1
+                                        && c->DCO_reported_real_max_sectors < 2 )
+                                    {
+                                        c->HPA_status = HPA_NOT_APPLICABLE;
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.34.83 Development code, not for production use!";
+const char* version_string = "0.34.84 Development code, not for production use!";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.34.83 Development code, not for production use!";
+const char* banner = "nwipe 0.34.84 Development code, not for production use!";


### PR DESCRIPTION
Fixed a issue that occurs when a drive is attached via a USB adapter that doesn't correctly pass the ATA commands for HPA/DCO determination.

It incorrectly set the HPA_status as enabled when in fact it should have determined that DCO was accessible and a comparison against the size as returned by libata and the real max sectors which in this particular adapters case worked, was sufficient to correctly determine whether there were hidden sectors or not.

Now fixed, so HPA status is now determined correctly even on some less than ideal USB adapters.