### PR TITLE
HPA_DCO_012 Continuation of HPA/DCO integration

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -94,6 +94,7 @@ typedef struct nwipe_context_t_
     char device_name_without_path[100];
     char gui_device_name[100];
     unsigned long long device_size;  // The device size in bytes.
+    u64 device_size_in_sectors;  // The device size in sectors
     unsigned long long bytes_erased;  // Irrespective of pass, this how much of the drive has been erased, CANNOT be
                                       // greater than device_size.
     char* device_size_text;  // The device size in a more (human)readable format.

--- a/src/create_pdf.c
+++ b/src/create_pdf.c
@@ -567,7 +567,7 @@ int create_pdf( nwipe_context_t* ptr )
     {
         if( c->HPA_status == HPA_ENABLED )
         {
-            snprintf( HPA_status_text, sizeof( HPA_status_text ), "HIDDEN AREA FOUND!" );
+            snprintf( HPA_status_text, sizeof( HPA_status_text ), "Hidden sectors found!" );
             pdf_set_font( pdf, "Helvetica-Bold" );
             pdf_add_text( pdf, NULL, HPA_status_text, text_size_data, 130, 210, PDF_RED );
             pdf_set_font( pdf, "Helvetica" );
@@ -576,7 +576,7 @@ int create_pdf( nwipe_context_t* ptr )
         {
             if( c->HPA_status == HPA_DISABLED )
             {
-                snprintf( HPA_status_text, sizeof( HPA_status_text ), "NO HIDDEN AREA" );
+                snprintf( HPA_status_text, sizeof( HPA_status_text ), "No hidden sectors" );
                 pdf_set_font( pdf, "Helvetica-Bold" );
                 pdf_add_text( pdf, NULL, HPA_status_text, text_size_data, 130, 210, PDF_DARK_GREEN );
                 pdf_set_font( pdf, "Helvetica" );
@@ -585,7 +585,7 @@ int create_pdf( nwipe_context_t* ptr )
             {
                 if( c->HPA_status == HPA_UNKNOWN )
                 {
-                    snprintf( HPA_status_text, sizeof( HPA_status_text ), "STATUS UNKNOWN" );
+                    snprintf( HPA_status_text, sizeof( HPA_status_text ), "Status unknown" );
                     pdf_set_font( pdf, "Helvetica-Bold" );
                     pdf_add_text( pdf, NULL, HPA_status_text, text_size_data, 130, 210, PDF_RED );
                     pdf_set_font( pdf, "Helvetica" );
@@ -594,7 +594,7 @@ int create_pdf( nwipe_context_t* ptr )
                 {
                     if( c->HPA_status == HPA_NOT_SUPPORTED_BY_DRIVE )
                     {
-                        snprintf( HPA_status_text, sizeof( HPA_status_text ), "NO HIDDEN AREA **DDNSHDA" );
+                        snprintf( HPA_status_text, sizeof( HPA_status_text ), "No hidden sectors **DDNSHDA" );
                         pdf_set_font( pdf, "Helvetica-Bold" );
                         pdf_add_text( pdf, NULL, HPA_status_text, text_size_data, 130, 210, PDF_DARK_GREEN );
                         pdf_set_font( pdf, "Helvetica" );

--- a/src/device.c
+++ b/src/device.c
@@ -220,6 +220,7 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
 
     next_device->device_size = dev->length * dev->sector_size;
     next_device->device_sector_size = dev->sector_size;
+    next_device->device_size_in_sectors = next_device->device_size / next_device->device_sector_size;
     Determine_C_B_nomenclature( next_device->device_size, next_device->device_size_txt, NWIPE_DEVICE_SIZE_TXT_LENGTH );
     next_device->device_size_text = next_device->device_size_txt;
     next_device->result = -2;

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.34.84 Development code, not for production use!";
+const char* version_string = "0.34.85 Development code, not for production use!";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.34.84 Development code, not for production use!";
+const char* banner = "nwipe 0.34.85 Development code, not for production use!";


### PR DESCRIPTION
Simplified the code that determines whether a HPA/DCO is present and in the process fixed some related bugs to do with the HPA/DCO fields in the PDF document
displaying incorrect information in some drive specific cases.