### PR TITLE
HPA_DCO_013 Continuation of HPA/DCO integration

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -169,7 +169,7 @@ typedef struct nwipe_context_t_
                                             // don't support DCO/HPA and those that do. Also drives that can't provide
                                             // HPA/DCO due to the chips they use (USB adapters)
     char DCO_reported_real_max_size_text[NWIPE_DEVICE_SIZE_TXT_LENGTH];  // real max size in human readable form i.e 1TB
-                                                                         // etc
+    char Calculated_real_max_size_in_bytes_text[NWIPE_DEVICE_SIZE_TXT_LENGTH];  // calculated real max human readable
     u64 HPA_sectors;  // The size of the host protected area in sectors
     char HPA_size_text[NWIPE_DEVICE_SIZE_TXT_LENGTH];  // Human readable size bytes, KB, MB, GB ..
     int HPA_display_toggle_state;  // 0 or 1 Used to toggle between "[1TB] [ 33C]" and [HDA STATUS]

--- a/src/gui.c
+++ b/src/gui.c
@@ -2905,7 +2905,7 @@ void* nwipe_gui_status( void* ptr )
                     else
                     {
                         wattron( main_window, COLOR_PAIR( 9 ) );
-                        mvwprintw( main_window, yy++, 4, "(>>>FAILURE!<<<, code %i) ", c[i]->result );
+                        mvwprintw( main_window, yy++, 4, "(>>> IOERROR! <<<, code %i) ", c[i]->result );
                         wattroff( main_window, COLOR_PAIR( 9 ) );
                     }
 

--- a/src/hpa_dco.c
+++ b/src/hpa_dco.c
@@ -565,7 +565,7 @@ int hpa_dco_status( nwipe_context_t* ptr )
     {
         /* This occurs when a SG_IO error occurs with USB devices that don't support ATA pass
          * through */
-        if( c->HPA_reported_set == 0 && c->HPA_reported_real == 1 && c->DCO_reported_real_max_sectors <= 1 )
+        if( c->HPA_reported_set == 0 && c->HPA_reported_real == 0 && c->DCO_reported_real_max_sectors <= 1 )
         {
             c->HPA_status = HPA_UNKNOWN;
             if( c->device_bus == NWIPE_DEVICE_USB )
@@ -583,14 +583,7 @@ int hpa_dco_status( nwipe_context_t* ptr )
         }
     }
 
-    /* -------------------------------------------------------------------
-     * create two variables for later use  based on real max sectors
-     * DCO_reported_real_max_size = real max sectors * sector size = bytes
-     * DCO_reported_real_max_size_text = human readable string, i.e 1TB etc.
-     */
     c->DCO_reported_real_max_size = c->DCO_reported_real_max_sectors * c->device_sector_size;
-    Determine_C_B_nomenclature(
-        c->DCO_reported_real_max_size, c->DCO_reported_real_max_size_text, NWIPE_DEVICE_SIZE_TXT_LENGTH );
 
     nwipe_dco_real_max_sectors = nwipe_read_dco_real_max_sectors( c->device_name );
 
@@ -636,6 +629,19 @@ int hpa_dco_status( nwipe_context_t* ptr )
             }
         }
     }
+
+    /* -------------------------------------------------------------------
+     * create two variables for later use by the PDF creation function
+     * based on real max sectors and calculated real max size in bytes.
+     *
+     * DCO_reported_real_max_size = real max sectors * sector size = bytes
+     * DCO_reported_real_max_size_text = human readable string, i.e 1TB etc.
+     */
+
+    Determine_C_B_nomenclature(
+        c->DCO_reported_real_max_size, c->DCO_reported_real_max_size_text, NWIPE_DEVICE_SIZE_TXT_LENGTH );
+    Determine_C_B_nomenclature(
+        c->Calculated_real_max_size_in_bytes, c->Calculated_real_max_size_in_bytes_text, NWIPE_DEVICE_SIZE_TXT_LENGTH );
 
     /* ----------------------------------------------------------------------------------
      * Determine the size of the HPA if it's enabled and store the results in the context

--- a/src/logging.c
+++ b/src/logging.c
@@ -797,7 +797,7 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
         }
         else
         {
-            if( c[i]->wipe_status == 0 && user_abort != 1 )
+            if( c[i]->wipe_status == 0 /* && user_abort != 1 */ )
             {
                 strncpy( exclamation_flag, " ", 1 );
                 exclamation_flag[1] = 0;
@@ -809,7 +809,7 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
             }
             else
             {
-                if( user_abort == 1 )
+                if( c[i]->wipe_status == 1 && user_abort == 1 )
                 {
                     strncpy( exclamation_flag, "!", 1 );
                     exclamation_flag[1] = 0;

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.34.85 Development code, not for production use!";
+const char* version_string = "0.34.86 Development code, not for production use!";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.34.85 Development code, not for production use!";
+const char* banner = "nwipe 0.34.86 Development code, not for production use!";


### PR DESCRIPTION
Fixes to apparent and real disc size fields in PDF based on use of c->Calculated_real_max_size_in_bytes.

Minor changes to HPA status messages for consistent messaging.

When HPA and DCO sector information cannot be obtained display the message "HPA/DCO data unavailable, can not determine hidden sector status" in the information field on the PDF.

Determine human readable size for the c->Calculated_real_max_size_in_bytes as used in the PDF real disc size field.

Instead of >>FAILURE!<< -1 when a I/O error occurs display >>IOERROR!<< -1 in the GUI.