### PR TITLE
PDFGen27 Cleaned up customer selection list

### DIFF
--- a/src/customers.c
+++ b/src/customers.c
@@ -92,8 +92,9 @@ void customer_processes( int mode )
     idx2 = 0;
     while( idx < size )
     {
-        if( ( raw_buffer[idx] > 0x20 && raw_buffer[idx] < 0x7F ) || raw_buffer[idx] == 0x0A )
+        if( ( raw_buffer[idx] > 0x1F && raw_buffer[idx] < 0x7F ) || raw_buffer[idx] == 0x0A )
         {
+            /* copy printable characters and line feeds but not double quotes. */
             buffer[idx2++] = raw_buffer[idx];
         }
         idx++;

--- a/src/gui.c
+++ b/src/gui.c
@@ -3591,6 +3591,9 @@ void nwipe_gui_list( int count, char* window_title, char** list, int* selected_e
     /* Flag, Valid key hit = 1, anything else = 0 */
     int validkeyhit;
 
+    /* Processed customer entry as displayed in selection dialog */
+    char* display_line;
+
     /* Get the terminal size */
     getmaxyx( stdscr, stdscr_lines, stdscr_cols );
 
@@ -3608,6 +3611,9 @@ void nwipe_gui_list( int count, char* window_title, char** list, int* selected_e
     /* Used in the selection loop to trap a failure of the timeout(), getch() mechanism to block for the designated
      * period */
     int expected_iterations;
+
+    /* General Indexes */
+    int idx, idx2;
 
     time_t previous_iteration_timestamp;
 
@@ -3699,8 +3705,28 @@ void nwipe_gui_list( int count, char* window_title, char** list, int* selected_e
              * and the else part will log the out of bounds values for debugging */
             if( i + offset >= 0 && i + offset < count )
             {
-                /* print a entry from the list */
-                wprintw( main_window, "%s ", list[i + offset] );
+                /* print a entry from the list, we need to process the string before display,
+                 * removing the double quotes that are used in csv for identifying the start & end of a field.
+                 */
+                if( ( display_line = calloc( sizeof( char ), strlen( list[i + offset] ) ) ) )
+                {
+                    idx = 0;
+                    idx2 = 0;
+                    while( list[i + offset][idx] != 0 )
+                    {
+                        if( list[i + offset][idx] == '"' )
+                        {
+                            idx++;
+                        }
+                        else
+                        {
+                            display_line[idx2++] = list[i + offset][idx++];
+                        }
+                    }
+                    display_line[idx2] = 0;
+                    wprintw( main_window, "%s ", display_line );
+                    free( display_line );
+                }
             }
             else
             {


### PR DESCRIPTION
Removed the csv field double quotes from the customer selection list as displayed on screen. The double quotes will still obviously exist in the csv file and are required for the code to work correctly in various places. However, for human readable text they are removed before displaying the customer details line on the selection screen as it makes the list look less 'busy' on screen hopefully.

I also fixed a issue where spaces were incorrectly being removed from the customer details when filtering for printable characters only.