### PR TITLE
PDFGen29 Fix incorrect customer deletion/selection

### DIFF
--- a/src/customers.c
+++ b/src/customers.c
@@ -198,7 +198,10 @@ void delete_customer( int count, char** customer_list_array )
 
     nwipe_gui_list( count, window_title, customer_list_array, &selected_entry );
 
-    delete_customer_csv_entry( &selected_entry );
+    if( selected_entry != 0 )
+    {
+        delete_customer_csv_entry( &selected_entry );
+    }
 }
 
 void write_customer_csv_entry( char* customer_name,

--- a/src/gui.c
+++ b/src/gui.c
@@ -3885,7 +3885,7 @@ void nwipe_gui_list( int count, char* window_title, char** list, int* selected_e
                 case KEY_BACKSPACE:
                 case KEY_LEFT:
                 case 127:
-                    *selected_entry = 1;
+                    *selected_entry = 0;
                     return;
                     break;
 


### PR DESCRIPTION
When using backspace or esc to abort customer deletion, the first customer in the list would be incorrectly deleted. Corrected by this fix.

Also when aborting customer selection, the first customer in the list would be automatically selected. Also corrected by this fix.