### PR TITLE
Fix intermittent segfault when --logfile specified without insufficient permissions to write to directory

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -401,7 +401,6 @@ void nwipe_log( nwipe_log_t level, const char* format, ... )
             }
             user_abort = 1;
             terminate_signal = 1;
-            return;
         }
     }
 

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -185,8 +185,10 @@ int main( int argc, char** argv )
         nwipe_enumerated = nwipe_device_get( &c1, argv, argc );
         if( nwipe_enumerated == 0 )
         {
-            nwipe_log( NWIPE_LOG_ERROR, "Devices not found. Check you're not excluding drives unnecessarily." );
-            printf( "No drives found\n" );
+            nwipe_log( NWIPE_LOG_ERROR, "Devices not found. Check you're not excluding drives unnecessarily," );
+            nwipe_log( NWIPE_LOG_ERROR, "and you are running nwipe as sudo or as root." );
+            printf( "Devices not found, check you're not excluding drives unnecessarily \n and you are running nwipe "
+                    "as sudo or as root." );
             cleanup();
             exit( 1 );
         }


### PR DESCRIPTION
Under the following conditions a segfault will occur upon starting nwipe.

Run nwipe with --logfile option AND run nwipe in a directory that does not have write permissions so the logfile can't be created AND run nwipe without sudo or root or as as a user without sufficient privileges so you don't have permissions to write to the directory.