### PR TITLE
fix_endian_model_name

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -200,6 +200,9 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
     next_device->device_model = dev->model;
     remove_ATA_prefix( next_device->device_model );
 
+    /* Some USB adapters have drive model endian swapped, pattern match and fix */
+    fix_endian_model_names( next_device->device_model );
+
     /* full device name, i.e. /dev/sda */
     next_device->device_name = dev->path;
 

--- a/src/miscellaneous.c
+++ b/src/miscellaneous.c
@@ -617,3 +617,50 @@ int write_system_datetime( char* year, char* month, char* day, char* hours, char
 
     return 0;
 }
+
+void fix_endian_model_names( char* model )
+{
+    /* Some IDE USB adapters get the endian wrong, we can't determine the endian from the drive
+     * as the drive standard doesn't provide that information, so we have to resort to matching
+     * the model name against known strings with the endian incorrect, then reverse the endian.
+     */
+
+    int idx = 0;
+    int idx2 = 0;
+    unsigned int length = 0;
+    char* tmp_string;
+
+    length = strlen( model );
+
+    tmp_string = calloc( length, 1 );
+
+    /* "ASSMNU G" = "SAMSUNG ", tested against model Samsung HM160HC so that
+     * "ASSMNU G MH61H0 C" becomes "SAMSUNG HM160HC ")
+     */
+    if( !( strncmp( model, "ASSMNU G", 8 ) ) )
+    {
+        while( model[idx] != 0 )
+        {
+            tmp_string[idx2 + 1] = model[idx];
+            if( model[idx + 1] != 0 )
+            {
+                tmp_string[idx2] = model[idx + 1];
+            }
+            else
+            {
+                break;
+            }
+
+            if( tmp_string[idx2 + 1] == ' ' && model[idx + 2] == ' ' )
+            {
+                idx++;
+            }
+
+            idx += 2;
+            idx2 += 2;
+        }
+
+        tmp_string[idx2 + 1] = 0;
+        strcpy( model, tmp_string );
+    }
+}

--- a/src/miscellaneous.h
+++ b/src/miscellaneous.h
@@ -120,4 +120,13 @@ int read_system_datetime( char*, char*, char*, char*, char*, char* );
  */
 int write_system_datetime( char*, char*, char*, char*, char*, char* );
 
+/**
+ * Fixes drive model names that have the incorrect endian. This happens
+ * with some IDE USB adapters.
+ *
+ * @param char* pointer to the drive model names
+ * @return void
+ */
+void fix_endian_model_names( char* model );
+
 #endif /* HPA_DCO_H_ */

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.34.91 Development code, not for production use!";
+const char* version_string = "0.34.92";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.34.91 Development code, not for production use!";
+const char* banner = "nwipe 0.34.92";


### PR DESCRIPTION
Some IDE USB adapter chipsets get the endian wrong for model name This fix identifies a endian swapped model name and corrects it.

The function currently only includes Samsung but I'll add more IDE drive manufacturers as I come across them.

This is peculiar to some USB IDE adapters. I've never seen this issue with SATA, ATA drives connected directly to the motherboard.