### PR TITLE
PDFGen36_Add_Optional_Org_Customer_Preview_Prior_To_Drive_Selection.

### DIFF
--- a/src/conf.h
+++ b/src/conf.h
@@ -22,6 +22,30 @@ void nwipe_conf_close();
 
 void save_selected_customer( char** );
 
+/**
+ * int nwipe_conf_update_setting( char *, char * );
+ * Use this function to update a setting in nwipe.conf
+ * @param char * this is the group name and setting name separated by a period '.'
+ *               i.e "PDF_Certificate.PDF_Enable"
+ * @param char * this is the setting, i.e ENABLED
+ * @return int 0 = Success
+ *             1 = Unable to update memory copy
+ *             2 = Unable to write new configuration to /etc/nwipe/nwipe.conf
+ */
+int nwipe_conf_update_setting( char*, char* );
+
+/**
+ * int nwipe_conf_read_setting( char *, char *, const char ** )
+ * Use this function to read a setting value in nwipe.conf
+ * @param char * this is the group name
+ * @param char * this is the setting name
+ * @param char ** this is a pointer to the setting value
+ * @return int 0 = Success
+ *             -1 = Unable to find the specified group name
+ *             -2 = Unable to find the specified setting name
+ */
+int nwipe_conf_read_setting( char*, const char** );
+
 #define FIELD_LENGTH 256
 #define NUMBER_OF_FIELDS 4
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -61,6 +61,7 @@
 #include "miscellaneous.h"
 #include "hpa_dco.h"
 #include "customers.h"
+#include "conf.h"
 
 #define NWIPE_GUI_PANE 8
 
@@ -158,6 +159,8 @@ const char* main_window_footer_warning_no_drive_selected =
 /* Oddly enough, placing extra quotes around the footer strings fixes corruption to the right
  * of the footer message when the terminal is resized, a quirk in ncurses? - DO NOT REMOVE THE \" */
 const char* selection_footer = "J=Down K=Up Space=Select Backspace=Cancel Ctrl+C=Quit";
+const char* selection_footer_preview_prior_to_drive_selection =
+    "A=Accept & display drives J=Down K=Up Space=Select Backspace=Cancel Ctrl+C=Quit";
 const char* selection_footer_add_customer = "S=Save J=Down K=Up Space=Select Backspace=Cancel Ctrl+C=Quit";
 const char* selection_footer_add_customer_yes_no = "Save Customer Details Y/N";
 const char* end_wipe_footer = "B=[Toggle between dark\\blank\\blue screen] Ctrl+C=Quit";
@@ -2491,7 +2494,7 @@ void nwipe_gui_config( void )
     extern int terminate_signal;
 
     /* Number of entries in the configuration menu. */
-    const int count = 7;
+    const int count = 8;
 
     /* The first tabstop. */
     const int tab1 = 2;
@@ -2524,11 +2527,13 @@ void nwipe_gui_config( void )
         yy = 2;
 
         /* Print the options. */
+        mvwprintw( main_window, yy++, tab1, "  %s", "PDF Report - Enable/Disable   " );
         mvwprintw( main_window, yy++, tab1, "  %s", "PDF Report - Edit Organisation" );
         mvwprintw( main_window, yy++, tab1, "  %s", "PDF Report - Select Customer  " );
         mvwprintw( main_window, yy++, tab1, "  %s", "PDF Report - Add Customer     " );
         mvwprintw( main_window, yy++, tab1, "  %s", "PDF Report - Delete Customer  " );
         mvwprintw( main_window, yy++, tab1, "  %s", "PDF Report - Preview Details  " );
+        mvwprintw( main_window, yy++, tab1, "  %s", "PDF Report - Preview at Start " );
         yy++;
         mvwprintw( main_window, yy++, tab1, "  %s", "Set System Date & Time        " );
         mvwprintw( main_window, yy++, tab1, "                                      " );
@@ -2540,6 +2545,23 @@ void nwipe_gui_config( void )
         {
             case 0:
 
+                mvwprintw( main_window, 2, tab2, "PDF Report - Enable/Disable" );
+
+                mvwprintw( main_window, 4, tab2, "Enable or Disable creation of the PDF " );
+                mvwprintw( main_window, 5, tab2, "report/certificate                    " );
+
+                if( nwipe_options.PDF_enable )
+                {
+                    mvwprintw( main_window, 7, tab2, "Create PDF Report = ENABLED" );
+                }
+                else
+                {
+                    mvwprintw( main_window, 7, tab2, "Create PDF Report = DISABLED" );
+                }
+                break;
+
+            case 1:
+
                 mvwprintw( main_window, 2, tab2, "PDF Report - Edit Organisation" );
 
                 mvwprintw( main_window, 4, tab2, "This option allows you to edit details" );
@@ -2549,7 +2571,7 @@ void nwipe_gui_config( void )
                 mvwprintw( main_window, 8, tab2, "and contact phone.                    " );
                 break;
 
-            case 1:
+            case 2:
                 mvwprintw( main_window, 2, tab2, "PDF Report - Select Customer" );
 
                 mvwprintw( main_window, 4, tab2, "Allows selection of a customer as     " );
@@ -2562,7 +2584,7 @@ void nwipe_gui_config( void )
                 mvwprintw( main_window, 11, tab2, "/etc/nwipe/nwipe_customers.csv       " );
                 break;
 
-            case 2:
+            case 3:
 
                 mvwprintw( main_window, 2, tab2, "PDF Report - Add Customer     " );
 
@@ -2577,7 +2599,7 @@ void nwipe_gui_config( void )
                 mvwprintw( main_window, 12, tab2, "/etc/nwipe/nwipe_customers.csv        " );
                 break;
 
-            case 3:
+            case 4:
 
                 mvwprintw( main_window, 2, tab2, "PDF Report - Delete Customer  " );
 
@@ -2592,7 +2614,7 @@ void nwipe_gui_config( void )
                 mvwprintw( main_window, 12, tab2, "/etc/nwipe/nwipe_customers.csv        " );
                 break;
 
-            case 4:
+            case 5:
 
                 mvwprintw( main_window, 2, tab2, "PDF Report - Preview Organisation,    " );
                 mvwprintw( main_window, 3, tab2, "Customer and Date/Time details        " );
@@ -2604,6 +2626,28 @@ void nwipe_gui_config( void )
                 break;
 
             case 6:
+
+                mvwprintw( main_window, 2, tab2, "PDF Report - Enable Preview at Start  " );
+
+                mvwprintw( main_window, 4, tab2, "A preview prior to the drive selection" );
+                mvwprintw( main_window, 5, tab2, "of the organisation that is performing" );
+                mvwprintw( main_window, 6, tab2, "the wipe, the customer details and the" );
+                mvwprintw( main_window, 7, tab2, "current date and time in order to     " );
+                mvwprintw( main_window, 8, tab2, "confirm that the information is       " );
+                mvwprintw( main_window, 9, tab2, "correct on the pdf report prior to    " );
+                mvwprintw( main_window, 10, tab2, "drive selection and starting the erase" );
+
+                if( nwipe_options.PDF_preview_details )
+                {
+                    mvwprintw( main_window, 12, tab2, "Preview at start = ENABLED" );
+                }
+                else
+                {
+                    mvwprintw( main_window, 12, tab2, "Preview at start = DISABLED" );
+                }
+                break;
+
+            case 8:
 
                 mvwprintw( main_window, 2, tab2, "Set System Date & Time                " );
 
@@ -2641,7 +2685,7 @@ void nwipe_gui_config( void )
 
                 if( focus < count - 1 )
                 {
-                    if( focus == 4 )
+                    if( focus == 6 )
                     {
                         focus += 2; /* mind the gaps */
                     }
@@ -2658,7 +2702,7 @@ void nwipe_gui_config( void )
 
                 if( focus > 0 )
                 {
-                    if( focus == 6 )
+                    if( focus == 8 )
                     {
                         focus -= 2; /* mind the gaps */
                     }
@@ -2677,35 +2721,75 @@ void nwipe_gui_config( void )
 
         } /* switch */
 
+        if( keystroke == 0x0A )
+        {
+            switch( focus )
+            {
+                case 0:
+                    /* Toggle on pressing ENTER key */
+                    if( nwipe_options.PDF_enable == 0 )
+                    {
+                        nwipe_options.PDF_enable = 1;
+
+                        /* write the setting to nwipe.conf */
+                        nwipe_conf_update_setting( "PDF_Certificate.PDF_Enable", "ENABLED" );
+                    }
+                    else
+                    {
+                        nwipe_options.PDF_enable = 0;
+
+                        /* write the setting to nwipe.conf */
+                        nwipe_conf_update_setting( "PDF_Certificate.PDF_Enable", "DISABLED" );
+                    }
+                    break;
+
+                case 1:
+                    nwipe_gui_edit_organisation();
+                    break;
+
+                case 2:
+                    customer_processes( SELECT_CUSTOMER );
+
+                    break;
+
+                case 3:
+                    nwipe_gui_add_customer();
+                    break;
+
+                case 4:
+                    customer_processes( DELETE_CUSTOMER );
+                    break;
+
+                case 5:
+                    nwipe_gui_preview_org_customer( SHOWING_IN_CONFIG_MENUS );
+                    break;
+
+                case 6:
+                    /* Toggle on pressing ENTER key */
+                    if( nwipe_options.PDF_preview_details == 0 )
+                    {
+                        nwipe_options.PDF_preview_details = 1;
+
+                        /* write the setting to nwipe.conf */
+                        nwipe_conf_update_setting( "PDF_Certificate.PDF_Preview", "ENABLED" );
+                    }
+                    else
+                    {
+                        nwipe_options.PDF_preview_details = 0;
+
+                        /* write the setting to nwipe.conf */
+                        nwipe_conf_update_setting( "PDF_Certificate.PDF_Preview", "DISABLED" );
+                    }
+                    break;
+
+                case 8:
+                    nwipe_gui_set_date_time();
+                    break;
+            }
+            keystroke = -1;
+        }
+
     } while( keystroke != KEY_ENTER && keystroke != ' ' && keystroke != 10 && terminate_signal != 1 );
-
-    switch( focus )
-    {
-        case 0:
-            nwipe_gui_edit_organisation();
-            break;
-
-        case 1:
-            customer_processes( SELECT_CUSTOMER );
-
-            break;
-
-        case 2:
-            nwipe_gui_add_customer();
-            break;
-
-        case 3:
-            customer_processes( DELETE_CUSTOMER );
-            break;
-
-        case 4:
-            nwipe_gui_preview_org_customer();
-            break;
-
-        case 6:
-            nwipe_gui_set_date_time();
-            break;
-    }
 
 } /* end of nwipe_config() */
 
@@ -4620,7 +4704,7 @@ void nwipe_gui_add_customer_contact_phone( char* customer_contact_phone )
 
 } /* End of nwipe_gui_add_customer_contact_phone() */
 
-void nwipe_gui_preview_org_customer( void )
+void nwipe_gui_preview_org_customer( int mode )
 {
     /**
      * Display the organisation and customers details and the current system date and time
@@ -4663,7 +4747,14 @@ void nwipe_gui_preview_org_customer( void )
 
     /* Update the footer window. */
     werase( footer_window );
-    nwipe_gui_title( footer_window, selection_footer );
+    if( mode == SHOWING_IN_CONFIG_MENUS )
+    {
+        nwipe_gui_title( footer_window, selection_footer );
+    }
+    else
+    {
+        nwipe_gui_title( footer_window, selection_footer_preview_prior_to_drive_selection );
+    }
     wrefresh( footer_window );
 
     do
@@ -4673,7 +4764,14 @@ void nwipe_gui_preview_org_customer( void )
             /* Clear the main window. */
             werase( main_window );
 
-            nwipe_gui_create_all_windows_on_terminal_resize( 0, selection_footer );
+            if( mode == SHOWING_IN_CONFIG_MENUS )
+            {
+                nwipe_gui_create_all_windows_on_terminal_resize( 0, selection_footer );
+            }
+            else
+            {
+                nwipe_gui_create_all_windows_on_terminal_resize( 0, selection_footer_preview_prior_to_drive_selection );
+            }
 
             /* Determine size of window */
             getmaxyx( main_window, wlines, wcols );
@@ -4891,6 +4989,14 @@ void nwipe_gui_preview_org_customer( void )
                 case 27: /* ESC */
 
                     return;
+                    break;
+
+                case 'A':
+                case 'a':
+                    if( mode == SHOWING_PRIOR_TO_DRIVE_SELECTION )
+                    {
+                        return;
+                    }
 
             } /* switch */
 
@@ -4937,7 +5043,8 @@ void nwipe_gui_preview_org_customer( void )
             }
         }
 
-    } while( keystroke != KEY_ENTER && keystroke != ' ' && keystroke != 10 && terminate_signal != 1 );
+    } while( keystroke != 'A' && keystroke != 'a' && keystroke != KEY_ENTER && keystroke != ' ' && keystroke != 10
+             && terminate_signal != 1 );
 
 } /* end of nwipe_gui_preview_org_customer( void ) */
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -67,7 +67,17 @@ void nwipe_gui_add_customer_address( char* );  // Add new customer address
 void nwipe_gui_add_customer_contact_name( char* );  // Add new customer contact name
 void nwipe_gui_add_customer_contact_phone( char* );  // Add new customer contact phone
 int nwipe_gui_yes_no_footer( void );  // Change footer to yes no
-void nwipe_gui_preview_org_customer( void );  // Preview window  for wipe organisation and customer
+
+/** nwipe_gui_preview_org_customer( int )
+ * Display a editable preview of organisation, customer and date/time
+ *
+ * @param int mode 0 = use prior to drive selection
+ *                 1 = use in config menus
+ * The different modes simply change the text in the footer menu and in the case
+ * of mode 0 enable the A key which means accept & display drive selection.
+ */
+void nwipe_gui_preview_org_customer( int );  // Preview window  for wipe organisation and customer
+
 void nwipe_gui_set_system_year( void );  // Set the systems current year
 void nwipe_gui_set_system_month( void );  // Set the systems month
 void nwipe_gui_set_system_day( void );  // Set the system day of the month
@@ -128,5 +138,8 @@ void nwipe_update_speedring( nwipe_speedring_t* speedring, u64 speedring_done, t
 
 #define YES 1
 #define NO 0
+
+#define SHOWING_PRIOR_TO_DRIVE_SELECTION 0
+#define SHOWING_IN_CONFIG_MENUS 1
 
 #endif /* GUI_H_ */

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -124,6 +124,10 @@ int main( int argc, char** argv )
     /*****************************
      * Parse command line options.
      */
+
+    /* Initialise the libconfig code that handles nwipe.conf */
+    nwipe_conf_init();
+
     nwipe_optind = nwipe_options_parse( argc, argv );
 
     /* Log nwipes version */
@@ -131,9 +135,6 @@ int main( int argc, char** argv )
 
     /* Log OS info */
     nwipe_log_OSinfo();
-
-    /* Initialise the libconfig code that handles nwipe.conf */
-    nwipe_conf_init();
 
     /* Check that hdparm exists, we use hdparm for some HPA/DCO detection etc, if not
      * exit nwipe. These checks are required if the PATH environment is not setup !
@@ -383,6 +384,11 @@ int main( int argc, char** argv )
         }
         else
         {
+            if( nwipe_options.PDF_preview_details == 1 )
+            {
+                nwipe_gui_preview_org_customer( SHOWING_PRIOR_TO_DRIVE_SELECTION );
+            }
+
             nwipe_gui_select( nwipe_enumerated, c1 );
         }
     }

--- a/src/options.h
+++ b/src/options.h
@@ -65,6 +65,8 @@ typedef struct
     int rounds;  // The number of times that the wipe method should be called.
     int sync;  // A flag to indicate whether and how often writes should be sync'd.
     int verbose;  // Make log more verbose
+    int PDF_enable;  // 0=PDF creation disabled, 1=PDF creation enabled
+    int PDF_preview_details;  // 0=Disable preview Org/Cust/date/time before drive selection, 1=Enable Preview
     nwipe_verify_t verify;  // A flag to indicate whether writes should be verified.
 } nwipe_options_t;
 


### PR DESCRIPTION
Added new options in GUI config menu to display preview of organisation, customer, date/time at startup prior to drive selection. This preview is disabled as default but can be enabled in the config menu.

The purpose of the preview is to allow the user to check & update as required the organisation details, customer & current date/time so that the details provided on the PDF certificate/report are correct.