### PR TITLE
PDF_Gen37_single_column_smart_data

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -434,7 +434,6 @@ int nwipe_conf_read_setting( char* group_name_setting_name, const char** setting
         /* Retrieve data from nwipe.conf */
         if( CONFIG_TRUE == config_setting_lookup_string( setting, setting_name, setting_value ) )
         {
-            nwipe_log( NWIPE_LOG_INFO, "setting_value = %s", *setting_value );
             return_status = 0; /* Success */
         }
         else

--- a/src/create_pdf.h
+++ b/src/create_pdf.h
@@ -45,6 +45,8 @@
  */
 int create_pdf( nwipe_context_t* ptr );
 
-int nwipe_get_smart_data( char* );
+int nwipe_get_smart_data( nwipe_context_t* );
+
+void create_header_and_footer( nwipe_context_t*, char* );
 
 #endif /* CREATE_PDF_H_ */


### PR DESCRIPTION
Previously smart data was completely located on page 2 in two columns using a variable width font. This had two issues. The font size had to be very small to fit on the page which made it difficult to read and variable width fonts were used because the smart attribute table took up too much width when all the data was displayed in two newspaper type columns. This made the smart attribute table look messy.

This patch now displays the smart data over page two and three in mono spaced font and with a larger font size so it's easier to read and the columns with the smart attribute table are now aligned correctly.

In terms of the code, I placed the header and footer creation code in it's own function as this is called multiple times and will make it easier to add additional information pages in the future.