### PR TITLE
Temperature Thread

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -827,7 +827,7 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
                 wprintw( main_window, "[%s] ", c[i + offset]->device_size_text );
 
                 /* Read the drive temperature values */
-                nwipe_update_temperature( c[i + offset] );
+                // nwipe_update_temperature( c[i + offset] );
 
                 /* print the temperature */
                 wprintw_temperature( c[i + offset] );
@@ -6716,10 +6716,10 @@ int compute_stats( void* ptr )
         nwipe_misc_thread_data->errors += c[i]->fsyncdata_errors;
 
         /* Read the drive temperature values */
-        if( nwipe_time_now > ( c[i]->temp1_time + 60 ) )
-        {
-            nwipe_update_temperature( c[i] );
-        }
+        //        if( nwipe_time_now > ( c[i]->temp1_time + 60 ) )
+        //        {
+        //            nwipe_update_temperature( c[i] );
+        //        }
 
     } /* for statistics */
 

--- a/src/temperature.h
+++ b/src/temperature.h
@@ -43,6 +43,7 @@ void nwipe_update_temperature( nwipe_context_t* );
 int nwipe_init_scsi_temperature( nwipe_context_t* );
 int nwipe_get_scsi_temperature( nwipe_context_t* );
 void nwipe_shut_scsi_temperature( nwipe_context_t* );
+void* nwipe_update_temperature_thread( void* ptr );
 
 /**
  * This function is normally called only once. It's called after both the


### PR DESCRIPTION
Due to significant delays in obtaining drive temperature from some drives especially SAS which was causing a noticeable freeze of a second or two or more in the GUI wipe status screen, being made worse the more drives that were being simultaneously wiped.

The temperature update code was separated from the GUI code by placing the temperature update in it's own thread.