### PR TITLE
Create_PDF_Certificate_Group

### DIFF
--- a/src/conf.h
+++ b/src/conf.h
@@ -46,7 +46,10 @@ int nwipe_conf_update_setting( char*, char* );
  */
 int nwipe_conf_read_setting( char*, const char** );
 
+int nwipe_conf_populate( char* path, char* value );
+
 #define FIELD_LENGTH 256
 #define NUMBER_OF_FIELDS 4
+#define MAX_GROUP_DEPTH 4
 
 #endif /* CONF_H_ */


### PR DESCRIPTION
The code that handles nwipe.conf now checks an existing nwipe.conf for the correct default groups. This allows future additions to the nwipe.conf file to be added to an existing nwipe.conf file. This makes the code more robust.

The code that handles creation of groups, settings and values has been made into a function so any future additions to nwipe.conf can be added with a single call to this function.

i.e
nwipe_conf_populate( "Default_Wipe.Method", "PRNG" );

The code can now handle creation of groups to a arbitrary depth of four levels, however currently we only use a group depth of 1.

i.e
```c
CCC :
{
 XXX :
 {
   YYY :
   {
     ZZZ :
     {
     };
     TTT :
     {
     };
   };
 };
};
```