### PR TITLE
Fix_segfault_on_first_run_as_non_root

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -186,8 +186,8 @@ int nwipe_conf_init()
             {
                 nwipe_log( NWIPE_LOG_ERROR, "Failed to write basic config to %s", nwipe_customers_file );
             }
+            fclose( fp_customers );
         }
-        fclose( fp_customers );
     }
     return ( 0 );
 }


### PR DESCRIPTION
Incorrectly trying to close a uninitialised file pointer stream when the file could not be opened.