### PR TITLE
Add_check_for_root_execution

### DIFF
--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -126,6 +126,12 @@ int main( int argc, char** argv )
     /* Initialised and populated in device scan.     */
     nwipe_context_t** c1 = 0;
 
+    if( geteuid() != 0 )
+    {
+        printf( "nwipe must run with root permissions, which is not the case.\nAborting\n" );
+        exit( 99 );
+    }
+
     int wipe_threads_started = 0;
 
     /** NOTE ** NOTE ** NOTE ** NOTE ** NOTE ** NOTE ** NOTE ** NOTE ** NOTE **


### PR DESCRIPTION
Checks user is running nwipe as root (required), if not exits with a warning message.