### PR TITLE
move the define off64_t

### DIFF
--- a/src/nwipe.h
+++ b/src/nwipe.h
@@ -36,15 +36,6 @@ void* signal_hand( void* );
 #define _FILE_OFFSET_BITS 64
 #endif
 
-/* workaround for Fedora */
-#ifndef off64_t
-#ifndef off_t
-#define off64_t int64_t
-#else
-#define off64_t off_t
-#endif
-#endif
-
 /* Busybox headers. */
 #ifdef BB_VER
 #include "busybox.h"
@@ -67,6 +58,15 @@ void* signal_hand( void* );
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
+
+/* workaround for Fedora */
+#ifndef off64_t
+#ifndef off_t
+#define off64_t int64_t
+#else
+#define off64_t off_t
+#endif
+#endif
 
 /*#include "config.h"*/
 


### PR DESCRIPTION
Move the definition of the off64_t using int64_t  bellow the include stdint.h, which is actually defining it.

Without change wrong order is breaking the build on RHEL7/8/9.