### PR TITLE
lower the build requirements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.71])
+AC_PREREQ([2.63])
 AC_INIT([nwipe],[0.35],[git@brumit.nl])
 AM_INIT_AUTOMAKE(foreign subdir-objects)
 AC_CONFIG_FILES([Makefile src/Makefile man/Makefile])


### PR DESCRIPTION
Hello,
please lower the requirements to autoconf allowing to build rhel7/8 packages (possibly rhel6, not tested). Thank you
Michal Ambroz