### PR TITLE
move the include of time.h

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -33,6 +33,8 @@
 #define _DEFAULT_SOURCE
 #endif
 
+#include <time.h>
+
 #ifndef _POSIX_SOURCE
 #define _POSIX_SOURCE
 #endif
@@ -42,7 +44,6 @@
 #include <ncurses.h>
 #include <panel.h>
 #include <stdint.h>
-#include <time.h>
 #include <libconfig.h>
 #include <string.h>
 #include <strings.h>


### PR DESCRIPTION
The definition of the newly used _POSIX_SOURCE affects preprocessing of the time.h. As result on RHEL7 (possibly 6 as well) the timespec structure is not defined.

Fixes bug #519 