### PR TITLE
Added mmcblk device type MMC

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -38,7 +38,8 @@ typedef enum nwipe_device_t_ {
     NWIPE_DEVICE_ATA,
     NWIPE_DEVICE_NVME,
     NWIPE_DEVICE_VIRT,
-    NWIPE_DEVICE_SAS
+    NWIPE_DEVICE_SAS,
+    NWIPE_DEVICE_MMC
 } nwipe_device_t;
 
 typedef enum nwipe_pass_t_ {

--- a/src/device.c
+++ b/src/device.c
@@ -365,6 +365,10 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
             strcpy( next_device->device_type_str, " SAS" );
             check_HPA = 1;
             break;
+
+        case NWIPE_DEVICE_MMC:
+            strcpy( next_device->device_type_str, " MMC" );
+            break;
     }
     if( next_device->device_is_ssd )
     {
@@ -638,6 +642,13 @@ int nwipe_get_device_bus_type_and_serialno( char* device, nwipe_device_t* bus, i
                             {
                                 *bus = NWIPE_DEVICE_VIRT;
                             }
+                            else
+                            {
+                                if( strstr( result, "/mmcblk" ) != 0 )
+                                {
+                                    *bus = NWIPE_DEVICE_MMC;
+                                }
+                            }
                         }
                     }
                 }
@@ -859,9 +870,9 @@ int nwipe_get_device_bus_type_and_serialno( char* device, nwipe_device_t* bus, i
 
                 if( exit_status == 1 )
                 {
-                    nwipe_log( NWIPE_LOG_WARNING, "%s USB bridge, no pass-through support", device );
+                    nwipe_log( NWIPE_LOG_WARNING, "Smartctl is unable to provide smart data for %s", device );
 
-                    if( *bus == NWIPE_DEVICE_USB )
+                    if( *bus == NWIPE_DEVICE_USB || *bus == NWIPE_DEVICE_MMC )
                     {
                         strcpy( serialnumber, "(S/N: unknown)" );
                         set_return_value = 5;


### PR DESCRIPTION
Added the abbreviation MMC for mmcblk devices such as SD and microSD cards and some low budget laptops.

Changed log message from "USB bridge, no pass-through support" to "Smart data unavailable" as no smart data could be caused by a non USB device such as mmcblk as well as USB devices with no ATA pass through and other devices that smartctl does not detect.