### PR TITLE
Fix autopoweroff and nowait when screen blank

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.35.1";
+const char* version_string = "0.35.2";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.35.1";
+const char* banner = "nwipe 0.35.2";


### PR DESCRIPTION
If the user had blanked the screen, the autopoweroff and nowait options did not work. Instead they paused nwipe on completion of the wipe/s waiting for the b key to be pressed which reactivated compute_stats() function who's output indicates whether any wipes were still active.

This was fixed so that compute_stats() is always active while wipes are in progress irrespective of whether the screen is blanked or not. This is so that the nwipe_gui_status() function will exit assuming --autopoweroff or --nowait options have been used, when all the wipe threads have completed even if the screen has been blanked.