### PR TITLE
Fix nwipe not auto exiting on completion in non gui mode.

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.35.2";
+const char* version_string = "0.35.3";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.35.2";
+const char* banner = "nwipe 0.35.3";


### PR DESCRIPTION
Fix nwipe not auto exiting on completion in non gui mode.

This was caused by the temperature thread not exiting on completion of all wipes but this bug only occurred in non gui mode.