### PR TITLE
Make completion footer more informative

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -892,7 +892,8 @@ void nwipe_log_summary( nwipe_context_t** ptr, int nwipe_selected )
                    serial_no );
 
         /* Create the PDF report/certificate */
-        if( strcmp( nwipe_options.PDFreportpath, "noPDF" ) != 0 )
+        if( nwipe_options.PDF_enable == 1 )
+        // if( strcmp( nwipe_options.PDFreportpath, "noPDF" ) != 0 )
         {
             /* to have some progress indication. can help if there are many/slow disks */
             fprintf( stderr, "." );

--- a/src/options.c
+++ b/src/options.c
@@ -398,6 +398,23 @@ int nwipe_options_parse( int argc, char** argv )
 
                 nwipe_options.PDFreportpath[strlen( optarg )] = '\0';
                 strncpy( nwipe_options.PDFreportpath, optarg, sizeof( nwipe_options.PDFreportpath ) );
+
+                /* Command line options will override what's in nwipe.conf */
+                if( strcmp( nwipe_options.PDFreportpath, "noPDF" ) == 0 )
+                {
+                    nwipe_options.PDF_enable = 0;
+                    nwipe_conf_update_setting( "PDF_Certificate.PDF_Enable", "DISABLED" );
+                }
+                else
+                {
+                    if( strcmp( nwipe_options.PDFreportpath, "." ) )
+                    {
+                        /* and if the user has specified a PDF path then enable PDF */
+                        nwipe_options.PDF_enable = 1;
+                        nwipe_conf_update_setting( "PDF_Certificate.PDF_Enable", "ENABLED" );
+                    }
+                }
+
                 break;
 
             case 'e': /* exclude drives option */

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.35.4";
+const char* version_string = "0.35.5";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.35.4";
+const char* banner = "nwipe 0.35.5";


### PR DESCRIPTION
These changes solve three issues. The first issue was that it wasn't obvious that the PDFs are only created once you press return to exit after all the wipes have finished. It is now explicitly stated in the footer message if PDFs are enabled.

It also now specifies the logfile name on the footer if the user has specified a log file as a command line option. If no logfile is specified then STDOUT is displayed.

If the user specified --PDFreportpath=noPDF on the command line, prior to this commit it had no affect. This is now fixed so that it disables PDF's irrespective of what is in nwipe.conf. i.e command line options override the entries in nwipe.conf

If the user has specified a --PDFreportpath=noPDF=/some/path then PDF's are enabled irrespective of the value in nwipe.conf