### PR TITLE
Fix hidden sector detection for logical 4096 size

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -101,7 +101,9 @@ typedef struct nwipe_context_t_
     char device_name_without_path[100];
     char gui_device_name[100];
     unsigned long long device_size;  // The device size in bytes.
-    u64 device_size_in_sectors;  // The device size in sectors
+    u64 device_size_in_sectors;  // The device size in number of logical sectors, this may be 512 or 4096 sectors
+    u64 device_size_in_512byte_sectors;  // The device size in number of 512byte sectors, irrespective of logical sector
+                                         // size reported by libata
     unsigned long long bytes_erased;  // Irrespective of pass, this how much of the drive has been erased, CANNOT be
                                       // greater than device_size.
     char* device_size_text;  // The device size in a more (human)readable format.

--- a/src/device.c
+++ b/src/device.c
@@ -231,6 +231,7 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
     next_device->device_size = dev->length * dev->sector_size;
     next_device->device_sector_size = dev->sector_size;
     next_device->device_size_in_sectors = next_device->device_size / next_device->device_sector_size;
+    next_device->device_size_in_512byte_sectors = next_device->device_size / 512;
     Determine_C_B_nomenclature( next_device->device_size, next_device->device_size_txt, NWIPE_DEVICE_SIZE_TXT_LENGTH );
     next_device->device_size_text = next_device->device_size_txt;
     next_device->result = -2;

--- a/src/hpa_dco.c
+++ b/src/hpa_dco.c
@@ -465,8 +465,10 @@ int hpa_dco_status( nwipe_context_t* ptr )
             }
 
             nwipe_log( NWIPE_LOG_INFO,
-                       "libata: apparent max sectors reported as %lli on %s",
+                       "libata: apparent max sectors reported as %lli with sector size as %i/%i on %s",
                        c->device_size_in_sectors,
+                       c->device_block_size,
+                       c->device_sector_size,
                        c->device_name );
 
             /* close */
@@ -553,8 +555,8 @@ int hpa_dco_status( nwipe_context_t* ptr )
 #endif
 
     /* If any of the HPA or DCO values are larger than the apparent size then HPA is enabled. */
-    if( /*c->HPA_reported_set > c->device_size_in_sectors || */ c->HPA_reported_real > c->device_size_in_sectors
-        || c->DCO_reported_real_max_sectors > c->device_size_in_sectors )
+    if( /*c->HPA_reported_set > c->device_size_in_sectors || */ c->HPA_reported_real > c->device_size_in_512byte_sectors
+        || c->DCO_reported_real_max_sectors > c->device_size_in_512byte_sectors )
     {
         c->HPA_status = HPA_ENABLED;
         nwipe_log( NWIPE_LOG_WARNING, " *********************************" );
@@ -602,7 +604,7 @@ int hpa_dco_status( nwipe_context_t* ptr )
         /* If the DCO is reporting a real max sectors > the apparent size
          * as reported by libata then that is what we will use as the real disc size
          */
-        if( c->DCO_reported_real_max_size > c->device_size_in_sectors )
+        if( c->DCO_reported_real_max_size > c->device_size_in_512byte_sectors )
         {
             c->Calculated_real_max_size_in_bytes = c->DCO_reported_real_max_sectors * c->device_sector_size;
         }
@@ -612,13 +614,13 @@ int hpa_dco_status( nwipe_context_t* ptr )
              * is the value we need, however if that is zero, then c->HPA_reported_set and if that is zero then
              * c->device_size as reported by libata
              */
-            if( c->HPA_reported_real > c->device_size_in_sectors )
+            if( c->HPA_reported_real > c->device_size_in_512byte_sectors )
             {
                 c->Calculated_real_max_size_in_bytes = c->HPA_reported_real * c->device_sector_size;
             }
             else
             {
-                if( c->HPA_reported_set > c->device_size_in_sectors )
+                if( c->HPA_reported_set > c->device_size_in_512byte_sectors )
                 {
                     c->Calculated_real_max_size_in_bytes = c->HPA_reported_set * c->device_sector_size;
                 }
@@ -674,6 +676,7 @@ int hpa_dco_status( nwipe_context_t* ptr )
                "c->DCO_reported_real_max_size=%lli, c->DCO_reported_real_max_sectors=%lli, c->HPA_sectors=%lli, "
                "c->HPA_reported_set=%lli, c->HPA_reported_real=%lli, c->device_type=%i, "
                "libata:c->device_size_in_sectors=%lli ",
+               "libata:c->device_size_in_512byte_sectors=%lli ",
                c->Calculated_real_max_size_in_bytes,
                c->device_size,
                c->device_sector_size,
@@ -683,7 +686,8 @@ int hpa_dco_status( nwipe_context_t* ptr )
                c->HPA_reported_set,
                c->HPA_reported_real,
                c->device_type,
-               c->device_size_in_sectors );
+               c->device_size_in_sectors,
+               c->device_size_in_512byte_sectors );
 
     return set_return_value;
 }

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.35.5";
+const char* version_string = "0.35.6";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.35.5";
+const char* banner = "nwipe 0.35.6";


### PR DESCRIPTION
This fixes an issue where nwipe detects a discrepancy between the number of sectors reported by hdparm and nwipe's own HPA/DCO functions that were reporting the same values, using number of sectors based on 512 byte sectors but disagreed with the number of sectors
generated from libata which was reporting the number of sectors based on 4096 byte sectors.

This has been fixed by always calculating the number of sectors returned by libata using 512 bytes per sector so a direct comparison can be made to data from hdparm & nwipe's HPA/DCO functions.