### PR TITLE
Populates device block size before hidden sector

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -87,8 +87,9 @@ typedef struct nwipe_context_t_
     /*
      * Device fields
      */
-    int device_block_size;  // The soft block size reported by the device.
-    int device_sector_size;  // The hard sector size reported by the device.
+    int device_block_size;  // The soft block size reported by the device, as logical
+    int device_sector_size;  // The logical sector size reported by libparted
+    int device_phys_sector_size;  // The physical sector size reported by libparted
     int device_bus;  // The device bus number.
     int device_fd;  // The file descriptor of the device file being wiped.
     int device_host;  // The host number.

--- a/src/device.c
+++ b/src/device.c
@@ -229,7 +229,9 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
     }
 
     next_device->device_size = dev->length * dev->sector_size;
-    next_device->device_sector_size = dev->sector_size;
+    next_device->device_sector_size = dev->sector_size;  // logical sector size
+    next_device->device_block_size = dev->sector_size;  // set as logical but could be a multiple of logical sector size
+    next_device->device_phys_sector_size = dev->phys_sector_size;  // physical sector size
     next_device->device_size_in_sectors = next_device->device_size / next_device->device_sector_size;
     next_device->device_size_in_512byte_sectors = next_device->device_size / 512;
     Determine_C_B_nomenclature( next_device->device_size, next_device->device_size_txt, NWIPE_DEVICE_SIZE_TXT_LENGTH );
@@ -409,6 +411,12 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
                next_device->device_model,
                next_device->device_size_text,
                next_device->device_serial_no );
+
+    nwipe_log( NWIPE_LOG_INFO,
+               "%s, sector(logical)/block(physical) sizes %i/%i",
+               next_device->device_name,
+               dev->sector_size,
+               dev->phys_sector_size );
 
     /******************************
      * Check for hidden sector_size

--- a/src/hpa_dco.c
+++ b/src/hpa_dco.c
@@ -464,12 +464,13 @@ int hpa_dco_status( nwipe_context_t* ptr )
                 nwipe_log( NWIPE_LOG_INFO, "DCO Real max sectors not found" );
             }
 
-            nwipe_log( NWIPE_LOG_INFO,
-                       "libata: apparent max sectors reported as %lli with sector size as %i/%i on %s",
-                       c->device_size_in_sectors,
-                       c->device_block_size,
-                       c->device_sector_size,
-                       c->device_name );
+            nwipe_log(
+                NWIPE_LOG_INFO,
+                "libata: apparent max sectors reported as %lli with sector size as %i/%i (logical/physical) on %s",
+                c->device_size_in_sectors,
+                c->device_sector_size,  // logical
+                c->device_phys_sector_size,  // physical
+                c->device_name );
 
             /* close */
             r = pclose( fp );

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -542,7 +542,8 @@ int main( int argc, char** argv )
                 nwipe_log( NWIPE_LOG_NOTICE, "%s has serial number %s", c2[i]->device_name, c2[i]->device_serial_no );
             }
 
-            /* Do sector size and block size checking. */
+            /* Do sector size and block size checking. I don't think this does anything useful as logical/Physical
+             * sector sizes are obtained by libparted in check.c */
             if( ioctl( c2[i]->device_fd, BLKSSZGET, &c2[i]->device_sector_size ) == 0 )
             {
 

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.35.7";
+const char* version_string = "0.35.8";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.35.7";
+const char* banner = "nwipe 0.35.8";


### PR DESCRIPTION
Now populates the block size (physical) before
the hidden sector determination function runs.

The naming of block/sector can be very confusing in nwipe. So I have created a device_phy_sector_size
in the drive context, so we have

->device_sector_size // logical sector size
->device_phys_sector_size // physical sector size
->device_block_size // Usually the same as logical size but could be increased by nwipe to encompass
multiple logical sectors, i.e a block of sectors