### PR TITLE
Fix some strcpy compiler warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.63])
-AC_INIT([nwipe],[0.35],[git@brumit.nl])
+AC_INIT([nwipe],[0.35.9],[git@brumit.nl])
 AM_INIT_AUTOMAKE(foreign subdir-objects)
 AC_CONFIG_FILES([Makefile src/Makefile man/Makefile])
 AC_OUTPUT

--- a/man/nwipe.1
+++ b/man/nwipe.1
@@ -1,4 +1,4 @@
-.TH NWIPE "24" "October 2023" "nwipe version 0.35" "User Commands"
+.TH NWIPE "16" "February 2024" "nwipe version 0.35.9" "User Commands"
 .SH NAME
 nwipe \- securely erase disks
 .SH SYNOPSIS

--- a/src/device.c
+++ b/src/device.c
@@ -283,7 +283,7 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
         /* If the serial number hasn't already been populated */
         if( next_device->device_serial_no[0] == 0 )
         {
-            strcpy( next_device->device_serial_no, tmp_serial );
+            strncpy( next_device->device_serial_no, tmp_serial, NWIPE_SERIALNUMBER_LENGTH );
         }
     }
 
@@ -292,13 +292,16 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
     {
         if( next_device->device_serial_no[0] == 0 )
         {
-            strcpy( next_device->device_serial_no, "???????????????" );
+            strncpy( next_device->device_serial_no, "????????????????????", NWIPE_SERIALNUMBER_LENGTH + 1 );
         }
         else
         {
-            strcpy( next_device->device_serial_no, "XXXXXXXXXXXXXXX" );
+            strncpy( next_device->device_serial_no, "XXXXXXXXXXXXXXXXXXXX", NWIPE_SERIALNUMBER_LENGTH + 1 );
         }
     }
+    /* strncpy would have copied the null terminator BUT just to be sure, just in case somebody changes the length
+     * of those strings we should explicitly terminate the string */
+    next_device->device_serial_no[NWIPE_SERIALNUMBER_LENGTH] = 0;
 
     /* Initialise the variables that toggle the [size][temp c] with [HPA status]
      * Not currently used, but may be used in the future or for other purposes

--- a/src/version.c
+++ b/src/version.c
@@ -4,14 +4,14 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.35.8";
+const char* version_string = "0.35.9";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
-const char* years = "2023";
+const char* years = "2024";
 const char* copyright = "Copyright Darik Horn <dajhorn-dban@vanadac.com>\n\
 Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.35.8";
+const char* banner = "nwipe 0.35.9";


### PR DESCRIPTION
Replace three strcpy commands with strncpy,
bump minor version ready for more testing.