### PR TITLE
Renamed N and M to MT_STATE_SIZE and MT_MIDDLE_WORD due to const naming of mt19937ar-cok.h, causing conflicts with SHA-512 HMAC's libssl.

### DIFF
--- a/src/mt19937ar-cok/mt19937ar-cok.c
+++ b/src/mt19937ar-cok/mt19937ar-cok.c
@@ -1,16 +1,16 @@
-/* 
-	This code is modified for use in nwipe.
+/*
+    This code is modified for use in nwipe.
 
    A C-program for MT19937, with initialization improved 2002/2/10.
    Coded by Takuji Nishimura and Makoto Matsumoto.
    This is a faster version by taking Shawn Cokus's optimization,
    Matthe Bellew's simplification, Isaku Wada's real version.
 
-   Before using, initialize the state by using init_genrand(seed) 
+   Before using, initialize the state by using init_genrand(seed)
    or init_by_array(init_key, key_length).
 
    Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
-   All rights reserved.                          
+   All rights reserved.
 
    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions
@@ -23,8 +23,8 @@
         notice, this list of conditions and the following disclaimer in the
         documentation and/or other materials provided with the distribution.
 
-     3. The names of its contributors may not be used to endorse or promote 
-        products derived from this software without specific prior written 
+     3. The names of its contributors may not be used to endorse or promote
+        products derived from this software without specific prior written
         permission.
 
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -48,77 +48,89 @@
 #include <stdio.h>
 #include "mt19937ar-cok.h"
 
-/* initializes state[N] with a seed */
-void init_genrand( twister_state_t* state, unsigned long s)
+/* initializes state[MT_STATE_SIZE] with a seed */
+void init_genrand( twister_state_t* state, unsigned long s )
 {
-	int j;
-	state->array[0]= s & 0xffffffffUL;
-	for( j = 1; j < N; j++ )
-	{
-		state->array[j] = (1812433253UL * (state->array[j-1] ^ (state->array[j-1] >> 30)) + j); 
-		state->array[j] &= 0xffffffffUL;  /* for >32 bit machines */
-	}
-	state->left = 1;
-	state->initf = 1;
+    int j;
+    state->array[0] = s & 0xffffffffUL;
+    for( j = 1; j < MT_STATE_SIZE; j++ )
+    {
+        state->array[j] = ( 1812433253UL * ( state->array[j - 1] ^ ( state->array[j - 1] >> 30 ) ) + j );
+        state->array[j] &= 0xffffffffUL; /* for >32 bit machines */
+    }
+    state->left = 1;
+    state->initf = 1;
 }
-
 
 void twister_init( twister_state_t* state, unsigned long init_key[], unsigned long key_length )
 {
     int i = 1;
-	 int j = 0;
-    int k = ( N > key_length ? N : key_length );
+    int j = 0;
+    int k = ( MT_STATE_SIZE > key_length ? MT_STATE_SIZE : key_length );
 
     init_genrand( state, 19650218UL );
 
     for( ; k; k-- )
-	 {
-		state->array[i] = (state->array[i] ^ ((state->array[i-1] ^ (state->array[i-1] >> 30)) * 1664525UL)) + init_key[j] + j;
-		state->array[i] &= 0xffffffffUL; /* for WORDSIZE > 32 machines */
-		++i;
-		++j;
+    {
+        state->array[i] = ( state->array[i] ^ ( ( state->array[i - 1] ^ ( state->array[i - 1] >> 30 ) ) * 1664525UL ) )
+            + init_key[j] + j;
+        state->array[i] &= 0xffffffffUL; /* for WORDSIZE > 32 machines */
+        ++i;
+        ++j;
 
-		if ( i >= N )
-		{
-			state->array[0] = state->array[N-1];
-			i = 1;
-		}
+        if( i >= MT_STATE_SIZE )
+        {
+            state->array[0] = state->array[MT_STATE_SIZE - 1];
+            i = 1;
+        }
 
-		if ( j >= key_length )
-		{
-			j = 0;
-		}
+        if( j >= key_length )
+        {
+            j = 0;
+        }
     }
 
-    for( k = N -1; k; k-- )
-	 {
-		state->array[i] = (state->array[i] ^ ((state->array[i-1] ^ (state->array[i-1] >> 30)) * 1566083941UL)) - i;
-		state->array[i] &= 0xffffffffUL;
-		++i;
+    for( k = MT_STATE_SIZE - 1; k; k-- )
+    {
+        state->array[i] =
+            ( state->array[i] ^ ( ( state->array[i - 1] ^ ( state->array[i - 1] >> 30 ) ) * 1566083941UL ) ) - i;
+        state->array[i] &= 0xffffffffUL;
+        ++i;
 
-		if ( i >= N )
-		{
-			state->array[0] = state->array[N-1];
-			i = 1;
-		}
+        if( i >= MT_STATE_SIZE )
+        {
+            state->array[0] = state->array[MT_STATE_SIZE - 1];
+            i = 1;
+        }
     }
 
-	state->array[0] = 0x80000000UL; /* MSB is 1; assuring non-zero initial array */ 
-	state->left = 1;
-	state->initf = 1;
+    state->array[0] = 0x80000000UL; /* MSB is 1; assuring non-zero initial array */
+    state->left = 1;
+    state->initf = 1;
 }
 
 static void next_state( twister_state_t* state )
 {
-    unsigned long *p = state->array;
+    unsigned long* p = state->array;
     int j;
 
-    if( state->initf == 0) { init_genrand( state, 5489UL ); }
-    state->left = N;
+    // Ensures the generator is initialized
+    if( state->initf == 0 )
+    {
+        init_genrand( state, 5489UL );
+    }
+    state->left = MT_STATE_SIZE;
     state->next = state->array;
-    for( j = N - M + 1; --j; p++ ) { *p = p[M]   ^ TWIST(p[0], p[1]); }
-    for( j = M; --j; p++ )         { *p = p[M-N] ^ TWIST(p[0], p[1]); }
-    *p = p[M-N] ^ TWIST(p[0], state->array[0]);
+
+    for( j = MT_STATE_SIZE - MT_MIDDLE_WORD + 1; --j; p++ )
+    {
+        *p = p[MT_MIDDLE_WORD] ^ TWIST( p[0], p[1] );
+    }
+    for( j = MT_MIDDLE_WORD; --j; p++ )
+    {
+        *p = p[MT_MIDDLE_WORD - MT_STATE_SIZE] ^ TWIST( p[0], p[1] );
+    }
+    *p = p[MT_MIDDLE_WORD - MT_STATE_SIZE] ^ TWIST( p[0], state->array[0] );
 }
 
 /* generates a random number on [0,0xffffffff]-interval */
@@ -126,14 +138,18 @@ unsigned long twister_genrand_int32( twister_state_t* state )
 {
     unsigned long y;
 
-    if ( --state->left == 0 ) { next_state( state ); }
+    // Advance internal state if necessary
+    if( --state->left == 0 )
+    {
+        next_state( state );
+    }
     y = *state->next++;
 
-    /* Tempering */
-    y ^= (y >> 11);
-    y ^= (y << 7) & 0x9d2c5680UL;
-    y ^= (y << 15) & 0xefc60000UL;
-    y ^= (y >> 18);
+    // Tempering
+    y ^= ( y >> 11 );
+    y ^= ( y << 7 ) & 0x9d2c5680UL;
+    y ^= ( y << 15 ) & 0xefc60000UL;
+    y ^= ( y >> 18 );
 
     return y;
 }

--- a/src/mt19937ar-cok/mt19937ar-cok.h
+++ b/src/mt19937ar-cok/mt19937ar-cok.h
@@ -1,30 +1,29 @@
 /*
- * mt19937ar-cok.h:  The Mersenne Twister PRNG implementation for nwipe.
- *
+ * mt19937ar-cok.h: The Mersenne Twister PRNG implementation for nwipe.
  */
 
 #ifndef MT19937AR_H_
 #define MT19937AR_H_
 
 /* Period parameters */
-#define N 624
-#define M 397
-#define MATRIX_A 0x9908b0dfUL   /* constant vector a */
+#define MT_STATE_SIZE 624
+#define MT_MIDDLE_WORD 397
+#define MATRIX_A 0x9908b0dfUL /* constant vector a */
 #define UMASK 0x80000000UL /* most significant w-r bits */
 #define LMASK 0x7fffffffUL /* least significant r bits */
-#define MIXBITS(u,v) ( ((u) & UMASK) | ((v) & LMASK) )
-#define TWIST(u,v) ((MIXBITS(u,v) >> 1) ^ ((v)&1UL ? MATRIX_A : 0UL))
+#define MIXBITS( u, v ) ( ( (u) &UMASK ) | ( (v) &LMASK ) )
+#define TWIST( u, v ) ( ( MIXBITS( u, v ) >> 1 ) ^ ( (v) &1UL ? MATRIX_A : 0UL ) )
 
 typedef struct twister_state_t_
 {
-	unsigned long array[N];
-	int left;
-	int initf;
-	unsigned long *next;
-} twister_state_t; 
+    unsigned long array[MT_STATE_SIZE];  // Updated to use MT_STATE_SIZE
+    int left;
+    int initf;
+    unsigned long* next;
+} twister_state_t;
 
 /* Initialize the MT state. ( 0 < key_length <= 624 ). */
-void twister_init( twister_state_t* state, unsigned long init_key[], unsigned long key_length);
+void twister_init( twister_state_t* state, unsigned long init_key[], unsigned long key_length );
 
 /* Generate a random integer on the [0,0xffffffff] interval. */
 unsigned long twister_genrand_int32( twister_state_t* state );


### PR DESCRIPTION
Necessary for further implementation of AES and SHA algorithms, due to conflicting const naming in `mt19937ar-cok.h` and `mt19937ar-cok.c`