### PR TITLE
Uninitialized 'b' and 'd' in pass.c, causing undefined behaviour

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -392,36 +392,32 @@ int nwipe_conf_update_setting( char* group_name_setting_name, char* setting_valu
 
 int nwipe_conf_read_setting( char* group_name_setting_name, const char** setting_value )
 {
-    /* You would call this function if you wanted to read a settings value in nwipe.conf, i.e
-     *
-     * const char ** pReturnString;
-     * nwipe_conf_read_setting( "PDF_Certificate", "PDF_Enable", pReturnString );
-     *
-     */
-
-    /* Separate group_name_setting_name i.e "PDF_Certificate.PDF_Enable" string
-     * into two separate strings by replacing the period with a NULL.
-     */
-
     int return_status;
     int length = strlen( group_name_setting_name );
 
-    char* group_name = malloc( length );
-    char* setting_name = malloc( length );
+    char* group_name = malloc( length + 1 );  // Allocate extra byte for '\0'
+    char* setting_name = malloc( length + 1 );  // Allocate extra byte for '\0'
+
+    // Initialize memory to zero to ensure strings are null-terminated
+    memset( group_name, 0, length + 1 );
+    memset( setting_name, 0, length + 1 );
 
     int idx = 0;
 
+    // Find the position of the period (.) to split the string
     while( group_name_setting_name[idx] != 0 && group_name_setting_name[idx] != '.' )
     {
-        if( group_name_setting_name[idx] == '.' )
-        {
-            break;
-        }
         idx++;
     }
-    memcpy( group_name, group_name_setting_name, idx );
-    strcpy( setting_name, &group_name_setting_name[idx + 1] );
 
+    // Copy the group name to group_name
+    memcpy( group_name, group_name_setting_name, idx );
+    group_name[idx] = '\0';  // Null-terminate group_name
+
+    // Copy the setting name to setting_name
+    strcpy( setting_name, &group_name_setting_name[idx + 1] );  // setting_name is null-terminated by strcpy
+
+    config_setting_t* setting;
     if( !( setting = config_lookup( &nwipe_cfg, group_name ) ) )
     {
         nwipe_log( NWIPE_LOG_ERROR, "Can't find group name %s.%s in %s", group_name, setting_name, nwipe_config_file );
@@ -429,10 +425,10 @@ int nwipe_conf_read_setting( char* group_name_setting_name, const char** setting
     }
     else
     {
-        /* Retrieve data from nwipe.conf */
+        // Retrieve data from nwipe.conf
         if( CONFIG_TRUE == config_setting_lookup_string( setting, setting_name, setting_value ) )
         {
-            return_status = 0; /* Success */
+            return_status = 0;  // Success
         }
         else
         {
@@ -442,11 +438,11 @@ int nwipe_conf_read_setting( char* group_name_setting_name, const char** setting
         }
     }
 
+    // Free allocated memory
     free( group_name );
     free( setting_name );
-    return ( return_status );
-
-}  // end nwipe_conf_read_setting()
+    return return_status;
+}
 
 int nwipe_conf_populate( char* path, char* value )
 {

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -1092,7 +1092,14 @@ int cleanup()
     /* Print the logs held in memory to the console */
     for( i = log_elements_displayed; i < log_elements_allocated; i++ )
     {
-        printf( "%s\n", log_lines[i] );
+        if( log_lines[i] != NULL )
+        {
+            // Ensure the string is not longer than MAX_LOG_LINE_CHARS
+            char safe_print[MAX_LOG_LINE_CHARS + 1];
+            strncpy( safe_print, log_lines[i], MAX_LOG_LINE_CHARS );
+            safe_print[MAX_LOG_LINE_CHARS] = '\0';  // Ensure null-termination
+            printf( "%s\n", safe_print );
+        }
     }
     fflush( stdout );
 
@@ -1114,6 +1121,7 @@ int cleanup()
 
     return 0;
 }
+
 void check_for_autopoweroff( void )
 {
     char cmd[] = "shutdown -Ph +1 \"System going down in one minute\"";

--- a/src/pass.c
+++ b/src/pass.c
@@ -194,6 +194,12 @@ int nwipe_random_verify( nwipe_context_t* c )
 
         } /* partial read */
 
+        // Assuming 'b' and 'd' need to be zero-initialized before their use in memcmp
+        // Add initialization code before memcmp call
+
+        memset( b, 0, blocksize );  // Zero-initialize buffer 'b'
+        memset( d, 0, blocksize );  // Zero-initialize buffer 'd'
+
         /* Compare buffer contents. */
         if( memcmp( b, d, blocksize ) != 0 )
         {


### PR DESCRIPTION
Reference to https://github.com/martijnvanbrummelen/nwipe/issues/563


`b` and `d` were not initialized, thus causing errors in valgrind, maybe affecting other operations in nwipe as well.



```
==10289== Conditional jump or move depends on uninitialised value(s)
==10289==    at 0x484E90E: bcmp (vg_replace_strmem.c:1229)
==10289==    by 0x41138B: nwipe_random_verify (pass.c:198)
==10289==    by 0x4160A6: nwipe_runmethod (method.c:961)
==10289==    by 0x417019: nwipe_random (method.c:742)
==10289==    by 0x4E98946: start_thread (pthread_create.c:444)
==10289==    by 0x4F1E873: clone (clone.S:100)
```