### PR TITLE
XORoshiro-256 and ALFG as default PRNG for 64-Bit and 32-Bit platforms. Also PRNG method as default method.

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -130,7 +130,7 @@ int nwipe_options_parse( int argc, char** argv )
     nwipe_options.autonuke = 0;
     nwipe_options.autopoweroff = 0;
     nwipe_options.method = &nwipe_random;
-    nwipe_options.prng = ( sizeof( unsigned long int ) >= 8 ) ? &nwipe_xoroshiro256_prng : &add_lagg_fibonacci_prng;
+    nwipe_options.prng = ( sizeof( unsigned long int ) >= 8 ) ? &nwipe_xoroshiro256_prng : &nwipe_add_lagg_fibonacci_prng;
     nwipe_options.rounds = 1;
     nwipe_options.noblank = 0;
     nwipe_options.nousb = 0;

--- a/src/options.c
+++ b/src/options.c
@@ -130,7 +130,8 @@ int nwipe_options_parse( int argc, char** argv )
     nwipe_options.autonuke = 0;
     nwipe_options.autopoweroff = 0;
     nwipe_options.method = &nwipe_random;
-    nwipe_options.prng = ( sizeof( unsigned long int ) >= 8 ) ? &nwipe_xoroshiro256_prng : &nwipe_add_lagg_fibonacci_prng;
+    nwipe_options.prng =
+        ( sizeof( unsigned long int ) >= 8 ) ? &nwipe_xoroshiro256_prng : &nwipe_add_lagg_fibonacci_prng;
     nwipe_options.rounds = 1;
     nwipe_options.noblank = 0;
     nwipe_options.nousb = 0;

--- a/src/options.c
+++ b/src/options.c
@@ -129,8 +129,8 @@ int nwipe_options_parse( int argc, char** argv )
     /* Set default options. */
     nwipe_options.autonuke = 0;
     nwipe_options.autopoweroff = 0;
-    nwipe_options.method = &nwipe_dodshort;
-    nwipe_options.prng = ( sizeof( unsigned long int ) >= 8 ) ? &nwipe_isaac64 : &nwipe_isaac;
+    nwipe_options.method = &nwipe_random;
+    nwipe_options.prng = ( sizeof( unsigned long int ) >= 8 ) ? &nwipe_xoroshiro256_prng : &add_lagg_fibonacci_prng;
     nwipe_options.rounds = 1;
     nwipe_options.noblank = 0;
     nwipe_options.nousb = 0;


### PR DESCRIPTION
For legacy 32-bit systems, such as a Pentium 2, selecting an appropriate pseudo-random number generator (PRNG) is crucial for ensuring both performance and quality of randomness. When comparing the Xoroshiro256 algorithm with a Lagged Fibonacci Generator (LFG) utilizing subtraction and carry, several factors come into play, especially regarding performance on such dated hardware.

### Performance Considerations on 32-bit Systems

1. **Xoroshiro256** is part of the Xoroshiro/Xoshiro family, known for its speed and excellent statistical properties. However, its implementation typically relies on 64-bit arithmetic operations to achieve optimal performance, which is not ideal on 32-bit systems. On such systems, 64-bit operations are internally broken down into multiple steps, leading to a decrease in performance.

2. **Lagged Fibonacci Generator (LFG)** with subtraction and carry operations is a more traditional PRNG. Its main advantage lies in its straightforward implementation using 32-bit arithmetic, making it inherently compatible with 32-bit architectures. Although LFGs may not match the speed of some of the more modern alternatives, they run directly on 32-bit systems without the overhead of emulating 64-bit operations, potentially offering better performance on older hardware.

### Recommendation for Legacy 32-bit Systems

Given these considerations, **the Lagged Fibonacci Generator with subtraction and carry operations** appears to be more suitable for legacy 32-bit systems from a performance standpoint for two primary reasons:

- **Direct Compatibility**: Operating natively with 32-bit arithmetic means there's no additional overhead from emulating 64-bit operations, which could make a noticeable difference in execution speed on older hardware.
- **Simplicity**: The implementation is less complex than that of more modern PRNGs like Xoroshiro256, which can be advantageous on hardware with limited resources.

### Conclusion

While performance is a critical factor, it's important to note that the choice of PRNG should also consider other aspects such as the required quality of randomness, the application's specific needs, and overall project requirements. If feasible, conducting benchmarks for both PRNGs under actual conditions on your specific 32-bit system is recommended to make an informed decision.

This recommendation is made with the understanding that, on older 32-bit architectures, optimizing for system compatibility and performance may outweigh the benefits of using a PRNG with superior statistical properties but higher computational demands.

**Regarding PRNG stream, i think it is the most used, and most suitable method nowadays for modern HDDs.**