### PR TITLE
Fix conditional jump on uninitialised value

### DIFF
--- a/src/hpa_dco.c
+++ b/src/hpa_dco.c
@@ -722,6 +722,9 @@ u64 nwipe_read_dco_real_max_sectors( char* device )
     unsigned char buffer[LBA_SIZE];  // Received data block
     unsigned char sense_buffer[SENSE_BUFFER_SIZE];  // Sense data
 
+    /* Zero the data block prior to use */
+    memset( buffer, 0, LBA_SIZE );
+
     /* three characters represent one byte of sense data, i.e
      * two characters and a space "01 AE 67"
      */


### PR DESCRIPTION
This fixes a valgrind detected error. We check that the number of real max sectors is greater than zero before incrementing the value by 1. However occasionally the ioctl call may not be able to obtain the dco and therefore the ioctl data block is never populated. By zeroing the data block prior to use and if it is not populated by the ioctl call then the calculated real max sectors will be zero and no increment will occur which is what we want.