### PR TITLE
configure.ac: Fix check for parted

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ PKG_CHECK_MODULES(
 
 AC_CHECK_LIB([intl], [libintl_dgettext]) # needed to statically link libparted, but not given in its pkgconfig file
 AC_CHECK_LIB([uuid], [uuid_generate])    # needed to statically link libparted, but not given in its pkgconfig file
-PKG_CHECK_MODULES([PARTED], [libparted], [libconfig])
+PKG_CHECK_MODULES([PARTED], [libparted])
 AC_CHECK_LIB([pthread], [main], ,[AC_MSG_ERROR([pthread development library not found])])
 
 # Checks for header files.


### PR DESCRIPTION
PKG_CHECK_MODULES needs all modules in a single list or else the following error message appears during configure run:

`  ./configure: 6807: libconfig: not found`

because the macro interprets "[libconfig]" as the action that needs to be done if parted was found.