### PR TITLE
fix type error on i686

### DIFF
--- a/src/prng.c
+++ b/src/prng.c
@@ -269,7 +269,7 @@ int nwipe_add_lagg_fibonacci_prng_init( NWIPE_PRNG_INIT_SIGNATURE )
         *state = malloc( sizeof( add_lagg_fibonacci_state_t ) );
     }
     add_lagg_fibonacci_init(
-        (add_lagg_fibonacci_state_t*) *state, (unsigned long*) ( seed->s ), seed->length / sizeof( unsigned long ) );
+        (add_lagg_fibonacci_state_t*) *state, (long unsigned int*) ( seed->s ), seed->length / sizeof( long unsigned int ) );
 
     return 0;
 }
@@ -285,7 +285,7 @@ int nwipe_xoroshiro256_prng_init( NWIPE_PRNG_INIT_SIGNATURE )
         *state = malloc( sizeof( xoroshiro256_state_t ) );
     }
     xoroshiro256_init(
-        (xoroshiro256_state_t*) *state, (unsigned long*) ( seed->s ), seed->length / sizeof( unsigned long ) );
+        (xoroshiro256_state_t*) *state, (long unsigned int*) ( seed->s ), seed->length / sizeof( long unsigned int ) );
 
     return 0;
 }

--- a/src/prng.c
+++ b/src/prng.c
@@ -269,7 +269,7 @@ int nwipe_add_lagg_fibonacci_prng_init( NWIPE_PRNG_INIT_SIGNATURE )
         *state = malloc( sizeof( add_lagg_fibonacci_state_t ) );
     }
     add_lagg_fibonacci_init(
-        (add_lagg_fibonacci_state_t*) *state, (long unsigned int*) ( seed->s ), seed->length / sizeof( long unsigned int ) );
+        (add_lagg_fibonacci_state_t*) *state, (uint64_t*) ( seed->s ), seed->length / sizeof( uint64_t ) );
 
     return 0;
 }
@@ -285,7 +285,7 @@ int nwipe_xoroshiro256_prng_init( NWIPE_PRNG_INIT_SIGNATURE )
         *state = malloc( sizeof( xoroshiro256_state_t ) );
     }
     xoroshiro256_init(
-        (xoroshiro256_state_t*) *state, (long unsigned int*) ( seed->s ), seed->length / sizeof( long unsigned int ) );
+        (xoroshiro256_state_t*) *state, (uint64_t*) ( seed->s ), seed->length / sizeof( uint64_t ) );
 
     return 0;
 }


### PR DESCRIPTION
This fixes the type error on i686 when compiling with gcc 14. Mentioned in bug report #578