### PR TITLE
Fix typo in create_pdf.c

### DIFF
--- a/src/create_pdf.c
+++ b/src/create_pdf.c
@@ -476,7 +476,7 @@ int create_pdf( nwipe_context_t* ptr )
                     {
                         if( nwipe_options.prng == &nwipe_xoroshiro256_prng )
                         {
-                            snprintf( prng_type, sizeof( prng_type ), "XORshiro256" );
+                            snprintf( prng_type, sizeof( prng_type ), "XORoshiro256" );
                         }
                         else
                         {


### PR DESCRIPTION
Fix mini typo on PRNG algorithm: XORoshiro256 is missing an "o"