### PR TITLE
Add a new search location when looking for hdparm and smartctl.

### DIFF
--- a/src/create_pdf.c
+++ b/src/create_pdf.c
@@ -829,6 +829,7 @@ int nwipe_get_smart_data( nwipe_context_t* c )
     char smartctl_command[] = "smartctl -a %s";
     char smartctl_command2[] = "/sbin/smartctl -a %s";
     char smartctl_command3[] = "/usr/bin/smartctl -a %s";
+    char smartctl_command4[] = "/usr/sbin/smartctl -a %s";
     char final_cmd_smartctl[sizeof( smartctl_command3 ) + 256];
     char result[512];
     char smartctl_labels_to_anonymize[][18] = {
@@ -850,7 +851,14 @@ int nwipe_get_smart_data( nwipe_context_t* c )
         {
             if( system( "which /usr/bin/smartctl > /dev/null 2>&1" ) )
             {
-                nwipe_log( NWIPE_LOG_WARNING, "Command not found. Install smartmontools !" );
+                if( system( "which /usr/sbin/smartctl > /dev/null 2>&1" ) )
+                {
+                    nwipe_log( NWIPE_LOG_WARNING, "Command not found. Install smartmontools !" );
+                }
+                else
+                {
+                    sprintf( final_cmd_smartctl, smartctl_command4, c->device_name );
+                }
             }
             else
             {

--- a/src/device.c
+++ b/src/device.c
@@ -526,6 +526,7 @@ int nwipe_get_device_bus_type_and_serialno( char* device, nwipe_device_t* bus, i
     char smartctl_command[] = "smartctl -i %s";
     char smartctl_command2[] = "/sbin/smartctl -i %s";
     char smartctl_command3[] = "/usr/bin/smartctl -i %s";
+    char smartctl_command4[] = "/usr/sbin/smartctl -i %s";
     char device_shortform[50];
     char result[512];
     char final_cmd_readlink[sizeof( readlink_command ) + sizeof( device_shortform )];
@@ -706,7 +707,14 @@ int nwipe_get_device_bus_type_and_serialno( char* device, nwipe_device_t* bus, i
         {
             if( system( "which /usr/bin/smartctl > /dev/null 2>&1" ) )
             {
-                nwipe_log( NWIPE_LOG_WARNING, "Command not found. Install smartmontools !" );
+                if( system( "which /usr/sbin/smartctl > /dev/null 2>&1" ) )
+                {
+                    nwipe_log( NWIPE_LOG_WARNING, "Command not found. Install smartmontools !" );
+                }
+                else
+                {
+                    sprintf( final_cmd_smartctl, smartctl_command4, device );
+                }
             }
             else
             {

--- a/src/hpa_dco.c
+++ b/src/hpa_dco.c
@@ -59,13 +59,15 @@ int hpa_dco_status( nwipe_context_t* ptr )
     int dco_line_found;
 
     FILE* fp;
-    char path_hdparm_cmd1_get_hpa[] = "hdparm --verbose -N";
-    char path_hdparm_cmd2_get_hpa[] = "/sbin/hdparm --verbose -N";
-    char path_hdparm_cmd3_get_hpa[] = "/usr/bin/hdparm --verbose -N";
+    char path_hdparm_cmd10_get_hpa[] = "hdparm --verbose -N";
+    char path_hdparm_cmd20_get_hpa[] = "/sbin/hdparm --verbose -N";
+    char path_hdparm_cmd30_get_hpa[] = "/usr/bin/hdparm --verbose -N";
+    char path_hdparm_cmd31_get_hpa[] = "/usr/sbin/hdparm --verbose -N";
 
-    char path_hdparm_cmd4_get_dco[] = "hdparm --verbose --dco-identify";
-    char path_hdparm_cmd5_get_dco[] = "/sbin/hdparm --verbose --dco-identify";
-    char path_hdparm_cmd6_get_dco[] = "/usr/bin/hdparm --verbose --dco-identify";
+    char path_hdparm_cmd40_get_dco[] = "hdparm --verbose --dco-identify";
+    char path_hdparm_cmd50_get_dco[] = "/sbin/hdparm --verbose --dco-identify";
+    char path_hdparm_cmd60_get_dco[] = "/usr/bin/hdparm --verbose --dco-identify";
+    char path_hdparm_cmd61_get_dco[] = "/usr/sbin/hdparm --verbose --dco-identify";
 
     char pipe_std_err[] = "2>&1";
 
@@ -78,8 +80,8 @@ int hpa_dco_status( nwipe_context_t* ptr )
     /* Use the longest of the 'path_hdparm_cmd.....' strings above to
      *determine size in the strings below
      */
-    char hdparm_cmd_get_hpa[sizeof( path_hdparm_cmd3_get_hpa ) + sizeof( c->device_name ) + sizeof( pipe_std_err )];
-    char hdparm_cmd_get_dco[sizeof( path_hdparm_cmd6_get_dco ) + sizeof( c->device_name ) + sizeof( pipe_std_err )];
+    char hdparm_cmd_get_hpa[sizeof( path_hdparm_cmd30_get_hpa ) + sizeof( c->device_name ) + sizeof( pipe_std_err )];
+    char hdparm_cmd_get_dco[sizeof( path_hdparm_cmd60_get_dco ) + sizeof( c->device_name ) + sizeof( pipe_std_err )];
 
     /* Initialise return value */
     set_return_value = 0;
@@ -96,25 +98,43 @@ int hpa_dco_status( nwipe_context_t* ptr )
         {
             if( system( "which /usr/bin/hdparm > /dev/null 2>&1" ) )
             {
-                nwipe_log( NWIPE_LOG_WARNING, "hdparm command not found." );
-                nwipe_log( NWIPE_LOG_WARNING,
-                           "Required by nwipe for HPA/DCO detection & correction and ATA secure erase." );
-                nwipe_log( NWIPE_LOG_WARNING, "** Please install hdparm **\n" );
-                cleanup();
-                exit( 1 );
+                if( system( "which /usr/sbin/hdparm > /dev/null 2>&1" ) )
+                {
+                    nwipe_log( NWIPE_LOG_WARNING, "hdparm command not found." );
+                    nwipe_log( NWIPE_LOG_WARNING,
+                               "Required by nwipe for HPA/DCO detection & correction and ATA secure erase." );
+                    nwipe_log( NWIPE_LOG_WARNING, "** Please install hdparm **\n" );
+                    cleanup();
+                    exit( 1 );
+                }
+                else
+                {
+                    snprintf( hdparm_cmd_get_hpa,
+                              sizeof( hdparm_cmd_get_hpa ),
+                              "%s %s %s\n",
+                              path_hdparm_cmd31_get_hpa,
+                              c->device_name,
+                              pipe_std_err );
+                    snprintf( hdparm_cmd_get_dco,
+                              sizeof( hdparm_cmd_get_dco ),
+                              "%s %s %s\n",
+                              path_hdparm_cmd61_get_dco,
+                              c->device_name,
+                              pipe_std_err );
+                }
             }
             else
             {
                 snprintf( hdparm_cmd_get_hpa,
                           sizeof( hdparm_cmd_get_hpa ),
                           "%s %s %s\n",
-                          path_hdparm_cmd3_get_hpa,
+                          path_hdparm_cmd30_get_hpa,
                           c->device_name,
                           pipe_std_err );
                 snprintf( hdparm_cmd_get_dco,
                           sizeof( hdparm_cmd_get_dco ),
                           "%s %s %s\n",
-                          path_hdparm_cmd6_get_dco,
+                          path_hdparm_cmd60_get_dco,
                           c->device_name,
                           pipe_std_err );
             }
@@ -124,13 +144,13 @@ int hpa_dco_status( nwipe_context_t* ptr )
             snprintf( hdparm_cmd_get_hpa,
                       sizeof( hdparm_cmd_get_hpa ),
                       "%s %s %s\n",
-                      path_hdparm_cmd2_get_hpa,
+                      path_hdparm_cmd20_get_hpa,
                       c->device_name,
                       pipe_std_err );
             snprintf( hdparm_cmd_get_dco,
                       sizeof( hdparm_cmd_get_dco ),
                       "%s %s %s\n",
-                      path_hdparm_cmd5_get_dco,
+                      path_hdparm_cmd50_get_dco,
                       c->device_name,
                       pipe_std_err );
         }
@@ -140,13 +160,13 @@ int hpa_dco_status( nwipe_context_t* ptr )
         snprintf( hdparm_cmd_get_hpa,
                   sizeof( hdparm_cmd_get_hpa ),
                   "%s %s %s\n",
-                  path_hdparm_cmd1_get_hpa,
+                  path_hdparm_cmd10_get_hpa,
                   c->device_name,
                   pipe_std_err );
         snprintf( hdparm_cmd_get_dco,
                   sizeof( hdparm_cmd_get_dco ),
                   "%s %s %s\n",
-                  path_hdparm_cmd4_get_dco,
+                  path_hdparm_cmd40_get_dco,
                   c->device_name,
                   pipe_std_err );
     }

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -171,12 +171,15 @@ int main( int argc, char** argv )
         {
             if( system( "which /usr/bin/hdparm > /dev/null 2>&1" ) )
             {
-                nwipe_log( NWIPE_LOG_WARNING, "hdparm command not found." );
-                nwipe_log( NWIPE_LOG_WARNING,
-                           "Required by nwipe for HPA/DCO detection & correction and ATA secure erase." );
-                nwipe_log( NWIPE_LOG_WARNING, "** Please install hdparm **\n" );
-                cleanup();
-                exit( 1 );
+                if( system( "which /usr/sbin/hdparm > /dev/null 2>&1" ) )
+                {
+                    nwipe_log( NWIPE_LOG_WARNING, "hdparm command not found." );
+                    nwipe_log( NWIPE_LOG_WARNING,
+                               "Required by nwipe for HPA/DCO detection & correction and ATA secure erase." );
+                    nwipe_log( NWIPE_LOG_WARNING, "** Please install hdparm **\n" );
+                    cleanup();
+                    exit( 1 );
+                }
             }
         }
     }


### PR DESCRIPTION
The new search location is /usr/sbin/. Previously we searched /sbin/ and /usr/bin/ but /sbin is symbolically linked to /usr/sbin/ so just in case there was some issue with the symbolic link we also now search /usr/sbin/