### PR TITLE
ShredOS specific patch to toggle font size

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.37.2";
+const char* version_string = "0.37.3";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -14,4 +14,4 @@ Modifications to original dwipe Copyright Andy Beverley <andy@andybev.com>\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.37.2";
+const char* banner = "nwipe 0.37.3";


### PR DESCRIPTION
This is only relevant to ShredOS and is disabled for other distros, as doubling font size is controlled within the terminal or window management of the distro.

When nwipe detects ShredOS it makes an additional command available to the GUI in the drive selection window and progress window (after the wipe has started) This command is 'f'. Pressing the f key whether in drive selection or progress windows will double the size of the font. Pressing 'f' again will toggle the font size back to it's original size.

In addition and depending on whether ShredOS is detected, it will add an additional item to the help footer of both the drive selection and progress windows. e.g. f=Font size