### PR TITLE
Implement Bruce Schneier 7-Pass wiping method

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2305,7 +2305,7 @@ void nwipe_gui_method( void )
     extern int terminate_signal;
 
     /* The number of implemented methods. */
-    const int count = 10;
+    const int count = 11;
 
     /* The first tabstop. */
     const int tab1 = 2;
@@ -2367,6 +2367,10 @@ void nwipe_gui_method( void )
     {
         focus = 9;
     }
+    if( nwipe_options.method == &nwipe_bruce7 )
+    {
+        focus = 10;
+    }
 
     do
     {
@@ -2389,6 +2393,7 @@ void nwipe_gui_method( void )
         mvwprintw( main_window, yy++, tab1, "  %s", nwipe_method_label( &nwipe_verify_zero ) );
         mvwprintw( main_window, yy++, tab1, "  %s", nwipe_method_label( &nwipe_verify_one ) );
         mvwprintw( main_window, yy++, tab1, "  %s", nwipe_method_label( &nwipe_is5enh ) );
+        mvwprintw( main_window, yy++, tab1, "  %s", nwipe_method_label( &nwipe_bruce7 ) );
         mvwprintw( main_window, yy++, tab1, "                                             " );
 
         /* Print the cursor. */
@@ -2524,6 +2529,19 @@ void nwipe_gui_method( void )
                 mvwprintw( main_window, 10, tab2, "device to verify the PRNG stream was             " );
                 mvwprintw( main_window, 11, tab2, "successfully written.                            " );
                 break;
+            case 10:
+
+                mvwprintw( main_window, 2, tab2, "Security Level: very high (7 passes)" );
+
+                mvwprintw( main_window, 4, tab2, "Bruce Schneier 7-Pass Wiping Method:              " );
+                mvwprintw( main_window, 5, tab2, "A secure erasure technique developed by the       " );
+                mvwprintw( main_window, 6, tab2, "renowned cryptographer Bruce Schneier.            " );
+                mvwprintw( main_window, 7, tab2, "                                                 " );
+                mvwprintw( main_window, 8, tab2, "This method first overwrites the device with      " );
+                mvwprintw( main_window, 9, tab2, "ones (0xFF), followed by zeroes (0x00). Then,     " );
+                mvwprintw( main_window, 10, tab2, "it performs five additional passes of PRNG-       " );
+                mvwprintw( main_window, 11, tab2, "generated random data to maximize security.       " );
+                break;
 
         } /* switch */
 
@@ -2618,6 +2636,10 @@ void nwipe_gui_method( void )
 
         case 9:
             nwipe_options.method = &nwipe_is5enh;
+            break;
+
+        case 10:
+            nwipe_options.method = &nwipe_bruce7;
             break;
     }
 

--- a/src/method.h
+++ b/src/method.h
@@ -54,6 +54,7 @@ void* nwipe_zero( void* ptr );
 void* nwipe_one( void* ptr );
 void* nwipe_verify_zero( void* ptr );
 void* nwipe_verify_one( void* ptr );
+void* nwipe_bruce7( void* ptr );
 
 void calculate_round_size( nwipe_context_t* );
 

--- a/src/options.c
+++ b/src/options.c
@@ -386,6 +386,11 @@ int nwipe_options_parse( int argc, char** argv )
                     nwipe_options.method = &nwipe_is5enh;
                     break;
                 }
+                if( strcmp( optarg, "bruce7" ) == 0 )
+                {
+                    nwipe_options.method = &nwipe_bruce7;
+                    break;
+                }
 
                 /* Else we do not know this wipe method. */
                 fprintf( stderr, "Error: Unknown wipe method '%s'.\n", optarg );
@@ -710,7 +715,8 @@ void display_help()
     puts( "                          one                    - Overwrite with ones (0xFF)" );
     puts( "                          verify_zero            - Verifies disk is zero filled" );
     puts( "                          verify_one             - Verifies disk is 0xFF filled" );
-    puts( "                          is5enh                 - HMG IS5 enhanced\n" );
+    puts( "                          is5enh                 -  HMG IS5 enhanced\n" );
+    puts( "                          bruce7                 -  Schneier Bruce 7-pass mixed pattern\n" );
     puts( "  -l, --logfile=FILE      Filename to log to. Default is STDOUT\n" );
     puts( "  -P, --PDFreportpath=PATH Path to write PDF reports to. Default is \".\"" );
     puts( "                           If set to \"noPDF\" no PDF reports are written.\n" );


### PR DESCRIPTION
- Added a new wiping method following the Bruce Schneier 7-Pass standard.
- Overwrites the device with:
  - Pass 1: All ones (0xFF)
  - Pass 2: All zeroes (0x00)
  - Pass 3-7: Five passes of PRNG-generated random data.
- Updated method.h with the function prototype for `nwipe_bruce7`.
- Added `nwipe_bruce7()` implementation in method.c.
- Registered method label in `nwipe_method_label()`.
- Updated UI in options.c to display security level and details.