### PR TITLE
Add static linking libraries that are required by parted 3.6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,8 +67,14 @@ PKG_CHECK_MODULES(
 	    ], [AC_MSG_ERROR([libconfig library not found])])]
 )
 
-AC_CHECK_LIB([intl], [libintl_dgettext]) # needed to statically link libparted, but not given in its pkgconfig file
-AC_CHECK_LIB([uuid], [uuid_generate])    # needed to statically link libparted, but not given in its pkgconfig file
+# Libraries needed for static linking with parted
+if echo "$LDFLAGS" | grep -q "static"; then
+	AC_CHECK_LIB([intl], [libintl_dgettext])
+	AC_CHECK_LIB([uuid], [uuid_generate])
+	AC_CHECK_LIB([devmapper], [dm_task_create], [LIBS="-ldevmapper $LIBS"], [AC_MSG_ERROR([devmapper library not found])])
+	AC_CHECK_LIB([blkid], [blkid_new_probe], [LIBS="-lblkid $LIBS"], [AC_MSG_ERROR([blkid library not found])])
+fi
+
 PKG_CHECK_MODULES([PARTED], [libparted])
 AC_CHECK_LIB([pthread], [main], ,[AC_MSG_ERROR([pthread development library not found])])
 

--- a/configure.ac
+++ b/configure.ac
@@ -69,10 +69,9 @@ PKG_CHECK_MODULES(
 
 # Libraries needed for static linking with parted
 if echo "$LDFLAGS" | grep -q "static"; then
-	AC_CHECK_LIB([intl], [libintl_dgettext])
-	AC_CHECK_LIB([uuid], [uuid_generate])
-	AC_CHECK_LIB([devmapper], [dm_task_create], [LIBS="-ldevmapper $LIBS"], [AC_MSG_ERROR([devmapper library not found])])
-	AC_CHECK_LIB([blkid], [blkid_new_probe], [LIBS="-lblkid $LIBS"], [AC_MSG_ERROR([blkid library not found])])
+	AC_CHECK_LIB([uuid], [uuid_generate], [LIBS="-luuid $LIBS"], [AC_MSG_ERROR([libuuid is required for static linking but not found])])
+	AC_CHECK_LIB([devmapper], [dm_task_create], [LIBS="-ldevmapper $LIBS"], [AC_MSG_ERROR([libdevmapper is required for static linking but not found])])
+	AC_CHECK_LIB([blkid], [blkid_new_probe], [LIBS="-lblkid $LIBS"], [AC_MSG_ERROR([libblkid is required for static linking but not found])])
 fi
 
 PKG_CHECK_MODULES([PARTED], [libparted])


### PR DESCRIPTION
Only checks the static libraries when `-static` is specified and removed `libintl` which is no longer required by parted 3.6.

A statically linked `nwipe` can be built with 
```
sh autogen.sh && ./configure LDFLAGS=-static && make
```
All the static libraries need to be built before this step, alternatively use the buildah script from https://github.com/deamen/nwipe-static-builder/blob/master/README.md


