### PR TITLE
Add device name, e.g sda, sdb etc to PDF filename

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -82,6 +82,12 @@ typedef struct nwipe_speedring_t_
 // 20 chracters for serial number plus null Byte
 #define NWIPE_SERIALNUMBER_LENGTH 20
 
+// UUID size
+#define UUID_SIZE 40
+
+// Device name max size including /dev/ path
+#define DEVICE_NAME_MAX_SIZE 100
+
 typedef struct nwipe_context_t_
 {
     /*
@@ -99,8 +105,9 @@ typedef struct nwipe_context_t_
     int device_minor;  // The minor device number.
     int device_part;  // The device partition or slice number.
     char* device_name;  // The device file name.
-    char device_name_without_path[100];
-    char gui_device_name[100];
+    char device_name_without_path[DEVICE_NAME_MAX_SIZE];
+    char gui_device_name[DEVICE_NAME_MAX_SIZE];
+    char device_name_terse[DEVICE_NAME_MAX_SIZE];
     unsigned long long device_size;  // The device size in bytes.
     u64 device_size_in_sectors;  // The device size in number of logical sectors, this may be 512 or 4096 sectors
     u64 device_size_in_512byte_sectors;  // The device size in number of 512byte sectors, irrespective of logical sector
@@ -117,6 +124,7 @@ typedef struct nwipe_context_t_
     int device_is_ssd;  // 0 = no SSD, 1 = is a SSD
     char device_serial_no[NWIPE_SERIALNUMBER_LENGTH
                           + 1];  // Serial number(processed, 20 characters plus null termination) of the device.
+    char device_UUID[UUID_SIZE];  // Only populated with the UUID if device is a partition
     int device_target;  // The device target.
 
     u64 eta;  // The estimated number of seconds until method completion.

--- a/src/create_pdf.c
+++ b/src/create_pdf.c
@@ -801,18 +801,19 @@ int create_pdf( nwipe_context_t* ptr )
      * Create the reports filename
      *
      * Sanitize the strings that we are going to use to create the report filename
-     * by converting any non alphanumeric characters to an underscore or hyphon
+     * by converting any non alphanumeric characters to an underscore or hyphen
      */
     replace_non_alphanumeric( end_time_text, '-' );
     replace_non_alphanumeric( c->device_model, '_' );
     replace_non_alphanumeric( c->device_serial_no, '_' );
     snprintf( c->PDF_filename,
               sizeof( c->PDF_filename ),
-              "%s/nwipe_report_%s_Model_%s_Serial_%s.pdf",
+              "%s/nwipe_report_%s_Model_%s_Serial_%s_device_%s.pdf",
               nwipe_options.PDFreportpath,
               end_time_text,
               c->device_model,
-              c->device_serial_no );
+              c->device_serial_no,
+              c->device_name_terse );
 
     pdf_save( pdf, c->PDF_filename );
     pdf_destroy( pdf );

--- a/src/device.c
+++ b/src/device.c
@@ -216,6 +216,19 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
     /* remove /dev/ from device, right justify and prefix name so string length is eight characters */
     nwipe_strip_path( next_device->device_name_without_path, next_device->device_name );
 
+    const char* device_name_terse;
+    device_name_terse = skip_whitespace( next_device->device_name_without_path );
+    if( device_name_terse != NULL )
+    {
+        /* remove the leading whitespace and save result, we use the device without path and no leading or trailing
+         * space in pdf file creation later */
+        strcpy( next_device->device_name_terse, device_name_terse );
+    }
+    else
+    {
+        strcpy( next_device->device_name_terse, "_" );
+    }
+
     /* To maintain column alignment in the gui we have to remove /dev/ from device names that
      * exceed eight characters including the /dev/ path.
      */
@@ -426,6 +439,20 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
     if( check_HPA == 1 )
     {
         hpa_dco_status( next_device );
+    }
+
+    /*************************************
+     * Check whether the device has a UUID
+     */
+    char uuid[UUID_SIZE] = "";
+    if( get_device_uuid( next_device->device_name, uuid ) == 0 )
+    {
+        strncpy( next_device->device_UUID, uuid, UUID_SIZE );
+        nwipe_log( NWIPE_LOG_INFO, "UUID for %s is: %s\n", next_device->device_name, next_device->device_UUID );
+    }
+    else
+    {
+        nwipe_log( NWIPE_LOG_INFO, "No UUID available for %s\n", next_device->device_name );
     }
 
     /* print an empty line to separate the drives in the log */

--- a/src/miscellaneous.h
+++ b/src/miscellaneous.h
@@ -129,4 +129,36 @@ int write_system_datetime( char*, char*, char*, char*, char*, char* );
  */
 void fix_endian_model_names( char* model );
 
+/**
+ * Obtains the UUID of the drive partition
+ *
+ * @param constchar* device path, example /dev/sda1
+ * @param char* pointer to UUID string UUID_SIZE long
+ * @return 0 = success, -1 = failure.
+ */
+int get_device_uuid( const char*, char* );
+
+/**
+ * find_base_device - searches /sys/block for a device that matches
+ *                    the prefix of the provided name.
+ *
+ * @devname: the input device name (e.g. "sda1", "sdb2")
+ * @result:  buffer to store the matched base device name
+ * @size:    size of the result buffer
+ *
+ * Returns: 0 on success (match found), -1 on failure (no match or error)
+ */
+int find_base_device( const char*, char*, size_t );
+
+/**
+ * skip_whitespace - Returns a pointer to the first non-whitespace character
+ *                   in a given string.
+ *
+ * @str: input string
+ *
+ * Returns: pointer to the first non-whitespace character,
+ *          or NULL if str is NULL or the string contains only whitespace.
+ */
+const char* skip_whitespace( const char* );
+
 #endif /* HPA_DCO_H_ */


### PR DESCRIPTION
The purpose of this commit is to add an additional identifying piece of information to the pdf filename.

This was found to be necessary in the case of a user wiping partitions as opposed to the whole disc. Currently when wiping a partition the model name and serial number is missing from the pdf content and pdf filename so by adding the device name, it makes it less likely that an existing pdf will get overwritten. This is a stop gap fix as preferably the disk model and serial no needs to be retrieved even when wiping just a partition.

Additional functions were added including retrieval of UUID, however UUID was found to not be available for some USB devices when wiping partitions. The UUID function remains in the code and the UUID if available is output to the log but is not used anywhere else at the moment.