### PR TITLE
Combine duplicated code into function

### DIFF
--- a/src/create_pdf.c
+++ b/src/create_pdf.c
@@ -133,22 +133,7 @@ int create_pdf( nwipe_context_t* ptr )
      * Create header and footer on page 1, with the exception of the green
      * tick/red icon which is set from the 'status' section below
      */
-    pdf_add_text_wrap( pdf, NULL, pdf_footer, 12, 0, 30, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
-    pdf_add_line( pdf, NULL, 50, 50, 550, 50, 3, PDF_BLACK );
-    pdf_add_line( pdf, NULL, 50, 650, 550, 650, 3, PDF_BLACK );
-    pdf_add_image_data( pdf, NULL, 45, 665, 100, 100, bin2c_shred_db_jpg, 27063 );
-    pdf_set_font( pdf, "Helvetica-Bold" );
-    snprintf( model_header, sizeof( model_header ), " %s: %s ", "Model", c->device_model );
-    pdf_add_text_wrap( pdf, NULL, model_header, 14, 0, 755, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
-    snprintf( serial_header, sizeof( serial_header ), " %s: %s ", "S/N", c->device_serial_no );
-    pdf_add_text_wrap( pdf, NULL, serial_header, 14, 0, 735, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
-    pdf_set_font( pdf, "Helvetica" );
-
-    pdf_add_text_wrap( pdf, NULL, "Disk Erasure Report", 24, 0, 695, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
-    snprintf( barcode, sizeof( barcode ), "%s:%s", c->device_model, c->device_serial_no );
-    pdf_add_text_wrap(
-        pdf, NULL, "Page 1 - Erasure Status", 14, 0, 670, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
-    pdf_add_barcode( pdf, NULL, PDF_BARCODE_128A, 100, 790, 400, 25, barcode, PDF_BLACK );
+    pdf_header_footer_text( c, "1" );
 
     /* ------------------------ */
     /* Organisation Information */
@@ -975,21 +960,7 @@ void create_header_and_footer( nwipe_context_t* c, char* page_title )
      * Create header and footer on most recently added page, with the exception
      * of the green tick/red icon which is set from the 'status' section below.
      */
-    pdf_add_text_wrap( pdf, NULL, pdf_footer, 12, 0, 30, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
-    pdf_add_line( pdf, NULL, 50, 50, 550, 50, 3, PDF_BLACK );
-    pdf_add_line( pdf, NULL, 50, 650, 550, 650, 3, PDF_BLACK );
-    pdf_add_image_data( pdf, NULL, 45, 665, 100, 100, bin2c_shred_db_jpg, 27063 );
-    pdf_set_font( pdf, "Helvetica-Bold" );
-    snprintf( model_header, sizeof( model_header ), " %s: %s ", "Model", c->device_model );
-    pdf_add_text_wrap( pdf, NULL, model_header, 14, 0, 755, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
-    snprintf( serial_header, sizeof( serial_header ), " %s: %s ", "S/N", c->device_serial_no );
-    pdf_add_text_wrap( pdf, NULL, serial_header, 14, 0, 735, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
-    pdf_set_font( pdf, "Helvetica" );
-
-    pdf_add_text_wrap( pdf, NULL, "Disk Erasure Report", 24, 0, 695, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
-    snprintf( barcode, sizeof( barcode ), "%s:%s", c->device_model, c->device_serial_no );
-    pdf_add_text_wrap( pdf, NULL, page_title, 14, 0, 670, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
-    pdf_add_barcode( pdf, NULL, PDF_BARCODE_128A, 100, 790, 400, 25, barcode, PDF_BLACK );
+    pdf_header_footer_text( c, page_title );
 
     /**********************************************************
      * Display the appropriate status icon, top right on page on
@@ -1019,4 +990,23 @@ void create_header_and_footer( nwipe_context_t* c, char* page_title )
 
             break;
     }
+}
+
+void pdf_header_footer_text( nwipe_context_t* c, char* page_title )
+{
+    pdf_add_text_wrap( pdf, NULL, pdf_footer, 12, 0, 30, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
+    pdf_add_line( pdf, NULL, 50, 50, 550, 50, 3, PDF_BLACK );
+    pdf_add_line( pdf, NULL, 50, 650, 550, 650, 3, PDF_BLACK );
+    pdf_add_image_data( pdf, NULL, 45, 665, 100, 100, bin2c_shred_db_jpg, 27063 );
+    pdf_set_font( pdf, "Helvetica-Bold" );
+    snprintf( model_header, sizeof( model_header ), " %s: %s ", "Model", c->device_model );
+    pdf_add_text_wrap( pdf, NULL, model_header, 14, 0, 755, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
+    snprintf( serial_header, sizeof( serial_header ), " %s: %s ", "S/N", c->device_serial_no );
+    pdf_add_text_wrap( pdf, NULL, serial_header, 14, 0, 735, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
+    pdf_set_font( pdf, "Helvetica" );
+
+    pdf_add_text_wrap( pdf, NULL, "Disk Erasure Report", 24, 0, 695, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
+    snprintf( barcode, sizeof( barcode ), "%s:%s", c->device_model, c->device_serial_no );
+    pdf_add_text_wrap( pdf, NULL, page_title, 14, 0, 670, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
+    pdf_add_barcode( pdf, NULL, PDF_BARCODE_128A, 100, 790, 400, 25, barcode, PDF_BLACK );
 }

--- a/src/create_pdf.h
+++ b/src/create_pdf.h
@@ -49,4 +49,6 @@ int nwipe_get_smart_data( nwipe_context_t* );
 
 void create_header_and_footer( nwipe_context_t*, char* );
 
+void pdf_header_footer_text( nwipe_context_t*, char* );
+
 #endif /* CREATE_PDF_H_ */

--- a/src/version.c
+++ b/src/version.c
@@ -4,7 +4,7 @@
  * used by configure to dynamically assign those values
  * to documentation files.
  */
-const char* version_string = "0.39";
+const char* version_string = "0.39.1";
 const char* program_name = "nwipe";
 const char* author_name = "Martijn van Brummelen";
 const char* email_address = "git@brumit.nl";
@@ -15,4 +15,4 @@ Nick Law <shredos.eraser@gmail.com> (@PartialVolume) and others\n\
 This is free software; see the source for copying conditions.\n\
 There is NO warranty; not even for MERCHANTABILITY or FITNESS\n\
 FOR A PARTICULAR PURPOSE.\n";
-const char* banner = "nwipe 0.39";
+const char* banner = "nwipe 0.39.1";


### PR DESCRIPTION
The fifteen lines of code that creates the header and footer text in the PDF appears in two separate places. The first occurrence  in the create_pdf(..) function and second in the create_header_and_footer(..) function.

This duplicated code was combined into a third function pdf_header_footer_text(..) and is now called from the other functions.

This was done as I need to add some user selectable changes to the header text that will include host identification such as system tag, UUID, hostname without creating further duplicated code.