### PR TITLE
Add user selectable host information

### DIFF
--- a/man/nwipe.8
+++ b/man/nwipe.8
@@ -72,6 +72,9 @@ Do not show the GUI interface. Can only be used with the autonuke option.
 Nowait option is automatically invoked with the nogui option.
 SIGUSR1 can be used to retrieve the current wiping statistics.
 .TP
+\fB\-\-pdftag\fR
+Enables a field on the PDF that holds a tag that identifies the host computer
+.TP
 \fB\-v\fR, \fB\-\-verbose\fR
 Log more messages, useful for debugging.
 .TP

--- a/src/conf.c
+++ b/src/conf.c
@@ -122,6 +122,7 @@ int nwipe_conf_init()
      */
     nwipe_conf_populate( "PDF_Certificate.PDF_Enable", "ENABLED" );
     nwipe_conf_populate( "PDF_Certificate.PDF_Preview", "DISABLED" );
+    nwipe_conf_populate( "PDF_Certificate.PDF_tag", "DISABLED" );
 
     /**
      * The currently selected customer that will be printed on the report

--- a/src/logging.c
+++ b/src/logging.c
@@ -507,6 +507,11 @@ void nwipe_log_OSinfo()
     return;
 }
 
+/* Globally accessable dmidecode host identifiable data. */
+char dmidecode_system_serial_number[DMIDECODE_RESULT_LENGTH];
+char dmidecode_system_uuid[DMIDECODE_RESULT_LENGTH];
+char dmidecode_baseboard_serial_number[DMIDECODE_RESULT_LENGTH];
+
 int nwipe_log_sysinfo()
 {
     FILE* fp;
@@ -559,8 +564,15 @@ int nwipe_log_sysinfo()
     char cmd[sizeof( dmidecode_keywords ) + sizeof( dmidecode_command2 )];
 
     unsigned int keywords_idx;
+    unsigned int i;
 
     keywords_idx = 0;
+
+    /* Initialise every character in the string with zero */
+    for( i = 0; i < DMIDECODE_RESULT_LENGTH; i++ )
+    {
+        dmidecode_system_serial_number[i] = 0;
+    }
 
     p_dmidecode_command = 0;
 
@@ -619,11 +631,35 @@ int nwipe_log_sysinfo()
                     else
                     {
                         nwipe_log( NWIPE_LOG_INFO, "%s = %s", &dmidecode_keywords[keywords_idx][0][0], path );
+
+                        /* if system-serial-number copy result to extern string */
+                        if( keywords_idx == 5 )
+                        {
+                            strncpy( dmidecode_system_serial_number, path, DMIDECODE_RESULT_LENGTH );
+                            dmidecode_system_serial_number[DMIDECODE_RESULT_LENGTH - 1] = 0;
+                        }
+                        if( keywords_idx == 6 )
+                        {
+                            strncpy( dmidecode_system_uuid, path, DMIDECODE_RESULT_LENGTH );
+                            dmidecode_system_uuid[DMIDECODE_RESULT_LENGTH - 1] = 0;
+                        }
                     }
                 }
                 else
                 {
                     nwipe_log( NWIPE_LOG_INFO, "%s = %s", &dmidecode_keywords[keywords_idx][0][0], path );
+
+                    /* if system-serial-number copy result to extern string */
+                    if( keywords_idx == 5 )
+                    {
+                        strncpy( dmidecode_system_serial_number, path, DMIDECODE_RESULT_LENGTH );
+                        dmidecode_system_serial_number[DMIDECODE_RESULT_LENGTH - 1] = 0;
+                    }
+                    if( keywords_idx == 6 )
+                    {
+                        strncpy( dmidecode_system_uuid, path, DMIDECODE_RESULT_LENGTH );
+                        dmidecode_system_uuid[DMIDECODE_RESULT_LENGTH - 1] = 0;
+                    }
                 }
             }
             /* close */

--- a/src/logging.h
+++ b/src/logging.h
@@ -29,6 +29,8 @@
 #define OS_info_Line_offset 31 /* OS_info line offset in log */
 #define OS_info_Line_Length 48 /* OS_info line length */
 
+#define DMIDECODE_RESULT_LENGTH 64
+
 typedef enum nwipe_log_t_ {
     NWIPE_LOG_NONE = 0,
     NWIPE_LOG_DEBUG,  // Output only when --verbose option used on cmd line.

--- a/src/options.c
+++ b/src/options.c
@@ -117,6 +117,9 @@ int nwipe_options_parse( int argc, char** argv )
         /* Verify that wipe patterns are being written to the device. */
         { "verify", required_argument, 0, 0 },
 
+        /* Enables a field on the PDF that holds a tag that identifies the host computer */
+        { "pdftag", no_argument, 0, 0 },
+
         /* Display program version. */
         { "verbose", no_argument, 0, 'v' },
 
@@ -142,11 +145,12 @@ int nwipe_options_parse( int argc, char** argv )
     nwipe_options.sync = DEFAULT_SYNC_RATE;
     nwipe_options.verbose = 0;
     nwipe_options.verify = NWIPE_VERIFY_LAST;
+    nwipe_options.PDFtag = 0;
     memset( nwipe_options.logfile, '\0', sizeof( nwipe_options.logfile ) );
     memset( nwipe_options.PDFreportpath, '\0', sizeof( nwipe_options.PDFreportpath ) );
     strncpy( nwipe_options.PDFreportpath, ".", 2 );
 
-    /* Read PDF settings from nwipe.conf if available  */
+    /* Read PDF Enable/Disable settings from nwipe.conf if available  */
     if( ( ret = nwipe_conf_read_setting( "PDF_Certificate.PDF_Enable", &read_value ) ) )
     {
         /* error occurred */
@@ -176,6 +180,40 @@ int nwipe_options_parse( int argc, char** argv )
                     NWIPE_LOG_ERROR,
                     "PDF_Certificate.PDF_Enable in nwipe.conf returned a value that was neither ENABLED or DISABLED" );
                 nwipe_options.PDF_enable = 1;  // Default to Enabled
+            }
+        }
+    }
+
+    /* Read PDF tag Enable/Disable settings from nwipe.conf if available  */
+    if( ( ret = nwipe_conf_read_setting( "PDF_Certificate.PDF_tag", &read_value ) ) )
+    {
+        /* error occurred */
+        nwipe_log( NWIPE_LOG_ERROR,
+                   "nwipe_conf_read_setting():Error reading PDF_Certificate.PDF_tag from nwipe.conf, ret code %i",
+                   ret );
+
+        /* Use default values */
+        nwipe_options.PDFtag = 1;
+    }
+    else
+    {
+        if( !strcmp( read_value, "ENABLED" ) )
+        {
+            nwipe_options.PDFtag = 1;
+        }
+        else
+        {
+            if( !strcmp( read_value, "DISABLED" ) )
+            {
+                nwipe_options.PDFtag = 0;
+            }
+            else
+            {
+                // error occurred
+                nwipe_log(
+                    NWIPE_LOG_ERROR,
+                    "PDF_Certificate.PDF_tag in nwipe.conf returned a value that was neither ENABLED or DISABLED" );
+                nwipe_options.PDFtag = 0;  // Default to Enabled
             }
         }
     }
@@ -319,6 +357,12 @@ int nwipe_options_parse( int argc, char** argv )
                     /* Else we do not know this verification level. */
                     fprintf( stderr, "Error: Unknown verification level '%s'.\n", optarg );
                     exit( EINVAL );
+                }
+
+                if( strcmp( nwipe_options_long[i].name, "pdftag" ) == 0 )
+                {
+                    nwipe_options.PDFtag = 1;
+                    break;
                 }
 
                 /* getopt_long should raise on invalid option, so we should never get here. */
@@ -732,6 +776,8 @@ void display_help()
     puts( "                           option. Send SIGUSR1 to log current stats.\n" );
     puts( "      --nousb              Do NOT show or wipe any USB devices whether in GUI" );
     puts( "                           mode, --nogui or --autonuke modes.\n" );
+    puts( "      --pdftag             Enables a field on the PDF that holds a tag that\n" );
+    puts( "                           identifies the host computer\n" );
     puts( "  -e, --exclude=DEVICES    Up to ten comma separated devices to be excluded." );
     puts( "                           --exclude=/dev/sdc" );
     puts( "                           --exclude=/dev/sdc,/dev/sdd" );

--- a/src/options.h
+++ b/src/options.h
@@ -68,6 +68,7 @@ typedef struct
     int verbose;  // Make log more verbose
     int PDF_enable;  // 0=PDF creation disabled, 1=PDF creation enabled
     int PDF_preview_details;  // 0=Disable preview Org/Cust/date/time before drive selection, 1=Enable Preview
+    int PDFtag;  // Enable display of hostID, such as UUID or serial no. on PDF report.
     nwipe_verify_t verify;  // A flag to indicate whether writes should be verified.
 } nwipe_options_t;
 


### PR DESCRIPTION
You can now specify --pdftag to enable the
display of system UUID and system serial
number information on the PDF report.

Nwipe defaults to not displaying system IDs
but some users like to record the system UUID
or serial number on the Erasure Report along
with the disk information.