### PR TITLE
device: sanitize serial numbers and fix uninitialized/fallback handling

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -656,12 +656,12 @@ static void nwipe_normalize_serial( char* serial )
         {
             *dst++ = (char) ch;
         }
-        /* Alle anderen Zeichen (Steuerzeichen, >0x7F) werden verworfen */
+        /* Alle remaining control characters will be dropped ( >0x7F) */
     }
 
     *dst = '\0';
 
-    /* Vorhandene trim()-Logik wiederverwenden */
+    /* Use existing trim() function */
     trim( serial );
 }
 


### PR DESCRIPTION
This patch fixes several issues that could cause garbage or control characters to appear in the ncurses UI when displaying device serial numbers.

Key changes:
- Added nwipe_normalize_serial() to strip control characters, non-ASCII bytes and trim whitespace from all serial numbers before they are shown in the UI.
- Initialize the serialnumber buffer in nwipe_get_device_bus_type_and_serialno() to avoid passing undefined data back to check_device() when no valid "Serial Number:" field is found.
- Prevent ioctl(HDIO_GET_IDENTITY) from being called on an invalid file descriptor when open() fails.
- Ensure consistent null termination and sanitize the final device_serial_no regardless of whether it came from HDIO, smartctl output, or quiet-mode anonymization.

These fixes resolve cases where devices (especially virtual/QEMU or USB-attached drives) could report malformed or unexpected serial strings, resulting in UI corruption such as extra characters, ^A, or line wrapping.

Should solve https://github.com/martijnvanbrummelen/nwipe/issues/689