### PR TITLE
Added an option in the config menu to toggle visibility of host UUID & host S/N in the PDF.

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -122,6 +122,7 @@ int nwipe_conf_init()
      */
     nwipe_conf_populate( "PDF_Certificate.PDF_Enable", "ENABLED" );
     nwipe_conf_populate( "PDF_Certificate.PDF_Preview", "DISABLED" );
+    nwipe_conf_populate( "PDF_Certificate.PDF_Host_Visibility", "DISABLED" );
     nwipe_conf_populate( "PDF_Certificate.PDF_tag", "DISABLED" );
     nwipe_conf_populate( "PDF_Certificate.User_Defined_Tag", "Empty Tag" );
 

--- a/src/create_pdf.c
+++ b/src/create_pdf.c
@@ -1017,24 +1017,34 @@ void pdf_header_footer_text( nwipe_context_t* c, char* page_title )
     pdf_add_image_data( pdf, NULL, 45, 665, 100, 100, bin2c_shred_db_jpg, 27063 );
     pdf_set_font( pdf, "Helvetica-Bold" );
 
-    if( nwipe_options.PDFtag )
+    if( nwipe_options.PDFtag || nwipe_options.PDF_toggle_host_info )
     {
         snprintf( model_header, sizeof( model_header ), " %s: %s ", "Disk Model", c->device_model );
         pdf_add_text_wrap( pdf, NULL, model_header, 11, 0, 718, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
         snprintf( serial_header, sizeof( serial_header ), " %s: %s ", "Disk S/N", c->device_serial_no );
         pdf_add_text_wrap( pdf, NULL, serial_header, 11, 0, 703, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
-        snprintf( hostid_header, sizeof( hostid_header ), " %s: %s ", "System S/N", dmidecode_system_serial_number );
-        pdf_add_text_wrap( pdf, NULL, hostid_header, 11, 0, 688, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
-        snprintf( hostid_header, sizeof( hostid_header ), " %s: %s ", "System uuid", dmidecode_system_uuid );
-        pdf_add_text_wrap( pdf, NULL, hostid_header, 11, 0, 673, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
+
+        /* Display host UUID & S/N is host visibility is enabled in PDF */
+        if( nwipe_options.PDF_toggle_host_info )
+        {
+            snprintf(
+                hostid_header, sizeof( hostid_header ), " %s: %s ", "System S/N", dmidecode_system_serial_number );
+            pdf_add_text_wrap( pdf, NULL, hostid_header, 11, 0, 688, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
+            snprintf( hostid_header, sizeof( hostid_header ), " %s: %s ", "System uuid", dmidecode_system_uuid );
+            pdf_add_text_wrap( pdf, NULL, hostid_header, 11, 0, 673, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
+        }
 
         /* libconfig: Obtain PDF_Certificate.User_Defined_Tag from nwipe.conf */
         setting = config_lookup( &nwipe_cfg, "PDF_Certificate" );
 
         if( config_setting_lookup_string( setting, "User_Defined_Tag", &user_defined_tag ) )
         {
-            snprintf( tag_header, sizeof( tag_header ), " %s: %s ", "Tag", user_defined_tag );
-            pdf_add_text_wrap( pdf, NULL, tag_header, 11, 0, 658, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
+            if( user_defined_tag[0] != 0 )
+            {
+                snprintf( tag_header, sizeof( tag_header ), " %s: %s ", "Tag", user_defined_tag );
+                pdf_add_text_wrap(
+                    pdf, NULL, tag_header, 11, 0, 658, PDF_BLACK, page_width, PDF_ALIGN_CENTER, &height );
+            }
         }
         else
         {

--- a/src/gui.c
+++ b/src/gui.c
@@ -3288,7 +3288,7 @@ void nwipe_gui_config( void )
     extern int terminate_signal;
 
     /* Number of entries in the configuration menu. Includes blank lines */
-    const int total_menu_entries = 9;
+    const int total_menu_entries = 11;
 
     /* The first tabstop. */
     const int tab1 = 2;
@@ -3326,6 +3326,7 @@ void nwipe_gui_config( void )
         mvwprintw( main_window, yy++, tab1, "  %s", "PDF Report - Select Customer  " );
         mvwprintw( main_window, yy++, tab1, "  %s", "PDF Report - Add Customer     " );
         mvwprintw( main_window, yy++, tab1, "  %s", "PDF Report - Delete Customer  " );
+        mvwprintw( main_window, yy++, tab1, "  %s", "PDF Report - Host Info Display " );
         mvwprintw( main_window, yy++, tab1, "  %s", "PDF Report - User defined tag " );
         mvwprintw( main_window, yy++, tab1, "  %s", "PDF Report - Preview Details  " );
         mvwprintw( main_window, yy++, tab1, "  %s", "PDF Report - Preview at Start " );
@@ -3355,7 +3356,7 @@ void nwipe_gui_config( void )
 
             case 1:
 
-                mvwprintw( main_window, 2, tab2, "PDF Report - Edit Organisation         " );
+                mvwprintw( main_window, 2, tab2, "PDF - Edit Organisation         " );
 
                 mvwprintw( main_window, 4, tab2, "This option allows you to edit details " );
                 mvwprintw( main_window, 5, tab2, "of the organisation that is performing " );
@@ -3365,7 +3366,7 @@ void nwipe_gui_config( void )
                 break;
 
             case 2:
-                mvwprintw( main_window, 2, tab2, "PDF Report - Select Customer           " );
+                mvwprintw( main_window, 2, tab2, "PDF - Select Customer           " );
 
                 mvwprintw( main_window, 4, tab2, "Allows selection of a customer as      " );
                 mvwprintw( main_window, 5, tab2, "displayed on the PDF report. Customer  " );
@@ -3379,7 +3380,7 @@ void nwipe_gui_config( void )
 
             case 3:
 
-                mvwprintw( main_window, 2, tab2, "PDF Report - Add Customer              " );
+                mvwprintw( main_window, 2, tab2, "PDF - Add Customer              " );
 
                 mvwprintw( main_window, 4, tab2, "This option allows you to add a new    " );
                 mvwprintw( main_window, 5, tab2, "customer. A customer can be optionally " );
@@ -3394,7 +3395,7 @@ void nwipe_gui_config( void )
 
             case 4:
 
-                mvwprintw( main_window, 2, tab2, "PDF Report - Delete Customer           " );
+                mvwprintw( main_window, 2, tab2, "PDF - Delete Customer           " );
 
                 mvwprintw( main_window, 4, tab2, "This option allows you to delete a     " );
                 mvwprintw( main_window, 5, tab2, "customer. A customer can be optionally " );
@@ -3409,7 +3410,23 @@ void nwipe_gui_config( void )
 
             case 5:
 
-                mvwprintw( main_window, 2, tab2, "PDF Report - Add user defined tag to PDF" );
+                mvwprintw( main_window, 2, tab2, "PDF - Toggle Host Information Visibility" );
+
+                mvwprintw( main_window, 4, tab2, "Controls the display of the host's UUID" );
+                mvwprintw( main_window, 5, tab2, "and serial number on the generated PDF." );
+                if( nwipe_options.PDF_toggle_host_info )
+                {
+                    mvwprintw( main_window, 7, tab2, "Host Visibility = ENABLED" );
+                }
+                else
+                {
+                    mvwprintw( main_window, 7, tab2, "Host Visibility = DISABLED" );
+                }
+                break;
+
+            case 6:
+
+                mvwprintw( main_window, 2, tab2, "PDF - Add user defined tag to PDF" );
 
                 mvwprintw( main_window, 4, tab2, "The report supports user-defined text, " );
                 mvwprintw( main_window, 5, tab2, "which may be used to identify the host " );
@@ -3417,7 +3434,7 @@ void nwipe_gui_config( void )
                 mvwprintw( main_window, 7, tab2, "at the user's discretion.              " );
                 break;
 
-            case 6:
+            case 7:
 
                 mvwprintw( main_window, 2, tab2, "PDF Report - Preview Organisation,     " );
                 mvwprintw( main_window, 3, tab2, "Customer and Date/Time details         " );
@@ -3428,7 +3445,7 @@ void nwipe_gui_config( void )
                 mvwprintw( main_window, 8, tab2, "the PDF report.                        " );
                 break;
 
-            case 7:
+            case 8:
 
                 if( nwipe_options.PDF_preview_details )
                 {
@@ -3447,7 +3464,7 @@ void nwipe_gui_config( void )
                 mvwprintw( main_window, 10, tab2, "drive selection and starting the erase." );
                 break;
 
-            case 9:
+            case 10:
 
                 mvwprintw( main_window, 2, tab2, "Set System Date & Time                 " );
 
@@ -3485,7 +3502,7 @@ void nwipe_gui_config( void )
 
                 if( focus < total_menu_entries - 1 )
                 {
-                    if( focus == 7 )
+                    if( focus == 8 )
                     {
                         focus += 2; /* mind the gaps */
                     }
@@ -3502,7 +3519,7 @@ void nwipe_gui_config( void )
 
                 if( focus > 0 )
                 {
-                    if( focus == 9 )
+                    if( focus == 10 )
                     {
                         focus -= 2; /* mind the gaps */
                     }
@@ -3561,14 +3578,32 @@ void nwipe_gui_config( void )
                     break;
 
                 case 5:
-                    nwipe_gui_user_defined_tag();
+                    /* Toggle on pressing ENTER key */
+                    if( nwipe_options.PDF_toggle_host_info == 0 )
+                    {
+                        nwipe_options.PDF_toggle_host_info = 1;
+
+                        /* write the setting to nwipe.conf */
+                        nwipe_conf_update_setting( "PDF_Certificate.PDF_Host_Visibility", "ENABLED" );
+                    }
+                    else
+                    {
+                        nwipe_options.PDF_toggle_host_info = 0;
+
+                        /* write the setting to nwipe.conf */
+                        nwipe_conf_update_setting( "PDF_Certificate.PDF_Host_Visibility", "DISABLED" );
+                    }
                     break;
 
                 case 6:
-                    nwipe_gui_preview_org_customer( SHOWING_IN_CONFIG_MENUS );
+                    nwipe_gui_user_defined_tag();
                     break;
 
                 case 7:
+                    nwipe_gui_preview_org_customer( SHOWING_IN_CONFIG_MENUS );
+                    break;
+
+                case 8:
                     /* Toggle on pressing ENTER key */
                     if( nwipe_options.PDF_preview_details == 0 )
                     {
@@ -3586,7 +3621,7 @@ void nwipe_gui_config( void )
                     }
                     break;
 
-                case 9:
+                case 10:
                     nwipe_gui_set_date_time();
                     break;
             }

--- a/src/options.c
+++ b/src/options.c
@@ -29,6 +29,7 @@
 #include "version.h"
 #include "conf.h"
 #include "cpu_features.h"
+#include "libconfig.h"
 
 /* The global options struct. */
 nwipe_options_t nwipe_options;
@@ -46,6 +47,10 @@ int nwipe_options_parse( int argc, char** argv )
     extern nwipe_prng_t nwipe_add_lagg_fibonacci_prng;
     extern nwipe_prng_t nwipe_xoroshiro256_prng;
     extern nwipe_prng_t nwipe_aes_ctr_prng;
+
+    extern config_t nwipe_cfg;
+    config_setting_t* setting;
+    const char* user_defined_tag;
 
     /* The getopt() result holder. */
     int nwipe_opt;
@@ -176,12 +181,15 @@ int nwipe_options_parse( int argc, char** argv )
     nwipe_options.verbose = 0;
     nwipe_options.verify = NWIPE_VERIFY_LAST;
     nwipe_options.io_mode = NWIPE_IO_MODE_AUTO; /* Default: auto-select I/O mode. */
+    nwipe_options.PDF_toggle_host_info = 0; /* Default: host visibility on PDF disabled */
     nwipe_options.PDFtag = 0;
     memset( nwipe_options.logfile, '\0', sizeof( nwipe_options.logfile ) );
     memset( nwipe_options.PDFreportpath, '\0', sizeof( nwipe_options.PDFreportpath ) );
     strncpy( nwipe_options.PDFreportpath, ".", 2 );
 
-    /* Read PDF Enable/Disable settings from nwipe.conf if available  */
+    /*
+     * Read PDF Enable/Disable settings from nwipe.conf if available
+     */
     if( ( ret = nwipe_conf_read_setting( "PDF_Certificate.PDF_Enable", &read_value ) ) )
     {
         /* error occurred */
@@ -215,41 +223,63 @@ int nwipe_options_parse( int argc, char** argv )
         }
     }
 
-    /* Read PDF tag Enable/Disable settings from nwipe.conf if available  */
-    if( ( ret = nwipe_conf_read_setting( "PDF_Certificate.PDF_tag", &read_value ) ) )
+    /*
+     * Read PDF host visibility settings from nwipe.conf if available
+     */
+    if( ( ret = nwipe_conf_read_setting( "PDF_Certificate.PDF_Host_Visibility", &read_value ) ) )
     {
         /* error occurred */
-        nwipe_log( NWIPE_LOG_ERROR,
-                   "nwipe_conf_read_setting():Error reading PDF_Certificate.PDF_tag from nwipe.conf, ret code %i",
-                   ret );
+        nwipe_log(
+            NWIPE_LOG_ERROR,
+            "nwipe_conf_read_setting():Error reading PDF_Certificate.PDF_toggle_host_info from nwipe.conf, ret code %i",
+            ret );
 
-        /* Use default values */
-        nwipe_options.PDFtag = 1;
+        nwipe_options.PDF_toggle_host_info = 0; /* Disable host visibility on PDF */
     }
     else
     {
         if( !strcmp( read_value, "ENABLED" ) )
         {
-            nwipe_options.PDFtag = 1;
+            nwipe_options.PDF_toggle_host_info = 1;
         }
         else
         {
             if( !strcmp( read_value, "DISABLED" ) )
             {
-                nwipe_options.PDFtag = 0;
+                nwipe_options.PDF_toggle_host_info = 0;
             }
             else
             {
                 // error occurred
-                nwipe_log(
-                    NWIPE_LOG_ERROR,
-                    "PDF_Certificate.PDF_tag in nwipe.conf returned a value that was neither ENABLED or DISABLED" );
-                nwipe_options.PDFtag = 0;  // Default to Enabled
+                nwipe_log( NWIPE_LOG_ERROR,
+                           "PDF_Certificate.PDF_toggle_host_info in nwipe.conf returned a value that was neither "
+                           "ENABLED or DISABLED" );
+                nwipe_options.PDF_toggle_host_info = 0;  // Default to disabled
             }
         }
     }
 
-    /* PDF Preview enable/disable */
+    /*
+     * Read PDF tag Enable/Disable settings from nwipe.conf if available
+     */
+
+    setting = config_lookup( &nwipe_cfg, "PDF_Certificate" );
+
+    if( config_setting_lookup_string( setting, "User_Defined_Tag", &user_defined_tag ) )
+    {
+        if( user_defined_tag[0] != 0 )
+        {
+            nwipe_options.PDFtag = 1;
+        }
+        else
+        {
+            nwipe_options.PDFtag = 0;
+        }
+    }
+
+    /*
+     * PDF Preview enable/disable
+     */
     if( ( ret = nwipe_conf_read_setting( "PDF_Certificate.PDF_Preview", &read_value ) ) )
     {
         /* error occurred */
@@ -283,7 +313,9 @@ int nwipe_options_parse( int argc, char** argv )
         }
     }
 
-    /* Initialise each of the strings in the excluded drives array */
+    /*
+     * Initialise each of the strings in the excluded drives array
+     */
     for( i = 0; i < MAX_NUMBER_EXCLUDED_DRIVES; i++ )
     {
         nwipe_options.exclude[i][0] = 0;

--- a/src/options.h
+++ b/src/options.h
@@ -73,6 +73,7 @@ typedef struct
     int verbose;  // Make log more verbose
     int PDF_enable;  // 0=PDF creation disabled, 1=PDF creation enabled
     int PDF_preview_details;  // 0=Disable preview Org/Cust/date/time before drive selection, 1=Enable Preview
+    int PDF_toggle_host_info;  // 0=Disable visibility of host Info on PDF. UUID & S/N
     int PDFtag;  // Enable display of hostID, such as UUID or serial no. on PDF report.
     nwipe_verify_t verify;  // A flag to indicate whether writes should be verified.
     nwipe_io_mode_t io_mode;  // Global runtime I/O mode selection (auto/direct/cached), note in auto mode each


### PR DESCRIPTION
Added an extra option in the config menu to toggle visibility of host UUID & host S/N in the PDF. Also changed the functionality of Tag visibility. If the user enters a custom tag in the config menu it will automatically be displayed in the PDF, if you remove the custom tag, then the tag field disappears from the PDF. The command line option --pdftag, now only enables the tag field. To enable visibility of host UUID & host S/N this must be enabled in the config menu. Any change is saved to nwipe.conf and is reinstated next time nwipe starts.