### PR TITLE
Fix v0.40 regression (failing -std=c99, Fedora packaging)

### DIFF
--- a/src/prng.c
+++ b/src/prng.c
@@ -17,6 +17,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#define _POSIX_C_SOURCE 200809L
+
 #include "nwipe.h"
 #include "prng.h"
 #include "context.h"

--- a/src/prng.c
+++ b/src/prng.c
@@ -566,7 +566,7 @@ _Static_assert( ( STASH_CAPACITY % SIZE_OF_AES_CTR_PRNG ) == 0,
 #endif
 
 /** @brief Thread-local ring buffer storage for prefetched keystream. */
-NW_THREAD_LOCAL static unsigned char stash[STASH_CAPACITY] NW_ALIGN( 64 );
+static NW_THREAD_LOCAL unsigned char stash[STASH_CAPACITY] NW_ALIGN( 64 );
 
 /**
  * @name Ring indices (thread-local)
@@ -585,9 +585,9 @@ NW_THREAD_LOCAL static unsigned char stash[STASH_CAPACITY] NW_ALIGN( 64 );
  * threads. One PRNG instance per thread.
  * @}
  */
-NW_THREAD_LOCAL static size_t rb_head = 0; /* next byte to read */
-NW_THREAD_LOCAL static size_t rb_tail = 0; /* next byte to write */
-NW_THREAD_LOCAL static size_t rb_count = 0; /* occupied bytes */
+static NW_THREAD_LOCAL size_t rb_head = 0; /* next byte to read */
+static NW_THREAD_LOCAL size_t rb_tail = 0; /* next byte to write */
+static NW_THREAD_LOCAL size_t rb_count = 0; /* occupied bytes */
 
 /**
  * @brief Free space available in the ring (bytes).


### PR DESCRIPTION
Fix build failures under strict -std=c99 (Fedora packaging)

`__thread` must come after `static` under `-std=c99`; reorder to
`static __thread` via the NW_THREAD_LOCAL macro declarations.

`CLOCK_MONOTONIC`, `posix_memalign` and `fileno` are POSIX extensions
hidden by strict standards mode without `_POSIX_C_SOURCE` defined.

Fedora 43 packaging of v0.40 failed due to both issues.
Should also benefit other distros building with strict flags.

https://bugzilla.redhat.com/show_bug.cgi?id=2436624

```
prng.c:569:1: error: ‘__thread’ before ‘static’
  569 | NW_THREAD_LOCAL static unsigned char stash[STASH_CAPACITY] NW_ALIGN( 64 );
      | ^~~~~~~~~~~~~~~
prng.c:588:1: error: ‘__thread’ before ‘static’
  588 | NW_THREAD_LOCAL static size_t rb_head = 0; /* next byte to read */
      | ^~~~~~~~~~~~~~~
prng.c:589:1: error: ‘__thread’ before ‘static’
  589 | NW_THREAD_LOCAL static size_t rb_tail = 0; /* next byte to write */
      | ^~~~~~~~~~~~~~~
prng.c:590:1: error: ‘__thread’ before ‘static’
  590 | NW_THREAD_LOCAL static size_t rb_count = 0; /* occupied bytes */
      | ^~~~~~~~~~~~~~~
```

```
prng.c:819:20: error: 'CLOCK_MONOTONIC' undeclared
prng.c: warning: implicit declaration of function 'clock_gettime'
prng.c: warning: implicit declaration of function 'posix_memalign'
prng.c: warning: implicit declaration of function 'fileno'
```