### PR TITLE
feat: introduce --force for in use devices

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -57,7 +57,8 @@ typedef enum nwipe_select_t_ {
     NWIPE_SELECT_TRUE_PARENT,  // A parent of this device has been selected, so the wipe is implied.
     NWIPE_SELECT_FALSE,  // Do not wipe this device.
     NWIPE_SELECT_FALSE_CHILD,  // A child of this device has been selected, so we can't wipe this device.
-    NWIPE_SELECT_DISABLED  // Do not wipe this device and do not allow it to be selected.
+    NWIPE_SELECT_DISABLED,  // We cannot wipe this device for technical reasons (do not allow selection).
+    NWIPE_SELECT_DISABLED_BUSY,  // The device is in use and --force is not set (do not allow selection).
 } nwipe_select_t;
 
 /* I/O mode for data path: auto, direct, or cached. */
@@ -109,6 +110,7 @@ typedef struct nwipe_context_t_
     /*
      * Device fields
      */
+    int device_busy;  // If libparted considers the device busy/mounted (0 = no, 1 = yes)
     int device_block_size;  // The soft block size reported by the device, as logical
     int device_sector_size;  // The logical sector size reported by libparted
     int device_phys_sector_size;  // The physical sector size reported by libparted

--- a/src/device.c
+++ b/src/device.c
@@ -313,6 +313,13 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
     /* Zero the allocation. */
     memset( next_device, 0, sizeof( nwipe_context_t ) );
 
+    /*
+     * Get device busy state (possibly mounted or otherwise in use)
+     * If libparted says device is safe to partition, it's safe to wipe.
+     * So for our disk wiping purposes it should be an equally good metric.
+     */
+    next_device->device_busy = ped_device_is_busy( dev );
+
     /* Get device information */
     next_device->device_model = dev->model;
     remove_ATA_prefix( next_device->device_model );
@@ -553,6 +560,11 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
                next_device->device_name,
                dev->sector_size,
                dev->phys_sector_size );
+
+    if( next_device->device_busy )
+    {
+        nwipe_log( NWIPE_LOG_WARNING, "%s is reported as IN USE (it could be mounted)", next_device->device_name );
+    }
 
     /******************************
      * Check for hidden sector_size

--- a/src/display_help.c
+++ b/src/display_help.c
@@ -31,6 +31,11 @@ void display_help()
     "  -h, --help\n" reset \
     "        Prints this help\n\n" \
     BHCYN \
+    "      --force\n" reset \
+    "        Also allow wiping of devices that are considered in use (mounted).\n" \
+    "        Beware this option is considered dangerous and is disabled by default.\n" \
+    "        This means that by default even --autonuke will exclude any such devices.\n\n" \
+    BHCYN \
     "      --autonuke\n" reset \
     "        If no devices have been specified on the command line, starts wiping\n" \
     "        all devices immediately. If devices have been specified, starts wiping\n" \

--- a/src/gui.c
+++ b/src/gui.c
@@ -1244,6 +1244,15 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
                         wprintw( main_window, "[????] %s ", "Unrecognized Device" );
                         break;
 
+                    case NWIPE_SELECT_DISABLED_BUSY:
+
+                        /* We can't wipe this element because it is in use and --force is not set. */
+                        wprintw( main_window,
+                                 "[----] %s %s ",
+                                 c[i + offset]->gui_device_name,
+                                 c[i + offset]->device_type_str );
+                        break;
+
                     default:
 
                         /* TODO: Handle the sanity error. */
@@ -1283,6 +1292,14 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
                         wprintw( main_window, " " );
                         wprintw( main_window, "[HS? N/A]" );
                         break;
+                }
+
+                if( c[i + offset]->device_busy )
+                {
+                    wprintw( main_window, " " );
+                    wattron( main_window, COLOR_PAIR( 9 ) );
+                    wprintw( main_window, "[IN USE]" );
+                    wattroff( main_window, COLOR_PAIR( 9 ) );
                 }
 
                 /* print the drive model and serial number */

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -669,8 +669,12 @@ int main( int argc, char** argv )
     /* Now set specific nwipe options */
     for( i = 0; i < nwipe_enumerated; i++ )
     {
-
-        if( nwipe_options.autonuke == 1 )
+        if( c1[i]->device_busy && !nwipe_options.force )
+        {
+            /* Do not allow to wipe in-use devices if --force is not set. */
+            c1[i]->select = NWIPE_SELECT_DISABLED_BUSY;
+        }
+        else if( nwipe_options.autonuke == 1 )
         {
             /* When the autonuke option is set, select all disks. */
             // TODO - partitions
@@ -817,6 +821,16 @@ int main( int argc, char** argv )
         {
             /* A result buffer for the BLKGETSIZE64 ioctl. */
             u64 size64;
+
+            /* Should be filtered out earlier, but keep it as a last-minute seatbelt. */
+            if( c2[i]->device_busy && !nwipe_options.force )
+            {
+                nwipe_log( NWIPE_LOG_FATAL,
+                           "Device '%s' is IN USE but --force is not set, not wiping it.",
+                           c2[i]->device_name );
+                c2[i]->select = NWIPE_SELECT_DISABLED_BUSY;
+                continue;
+            }
 
             /* Initialise the spinner character index */
             c2[i]->spinner_idx = 0;

--- a/src/options.c
+++ b/src/options.c
@@ -75,6 +75,9 @@ int nwipe_options_parse( int argc, char** argv )
 
     /* The list of acceptable long options. */
     static struct option nwipe_options_long[] = {
+        /* Set when user wants to allow wiping of devices that are in use. */
+        { "force", no_argument, 0, 0 },
+
         /* Set when the user wants to wipe without a confirmation prompt. */
         { "autonuke", no_argument, 0, 0 },
 
@@ -154,6 +157,7 @@ int nwipe_options_parse( int argc, char** argv )
         { 0, 0, 0, 0 } };
 
     /* Set default options. */
+    nwipe_options.force = 0;
     nwipe_options.autonuke = 0;
     nwipe_options.autopoweroff = 0;
     nwipe_options.method = &nwipe_random;
@@ -350,6 +354,11 @@ int nwipe_options_parse( int argc, char** argv )
         switch( nwipe_opt )
         {
             case 0: /* Long options without short counterparts. */
+                if( strcmp( nwipe_options_long[i].name, "force" ) == 0 )
+                {
+                    nwipe_options.force = 1;
+                    break;
+                }
 
                 if( strcmp( nwipe_options_long[i].name, "autonuke" ) == 0 )
                 {
@@ -962,6 +971,8 @@ void nwipe_options_log( void )
      *  Prints a manifest of options to the log.
      */
     nwipe_log( NWIPE_LOG_NOTICE, "Program options are set as follows..." );
+
+    nwipe_log( NWIPE_LOG_NOTICE, "  force        = %i (%s)", nwipe_options.force, nwipe_options.force ? "on" : "off" );
 
     nwipe_log(
         NWIPE_LOG_NOTICE, "  autonuke     = %i (%s)", nwipe_options.autonuke, nwipe_options.autonuke ? "on" : "off" );

--- a/src/options.h
+++ b/src/options.h
@@ -51,6 +51,7 @@ void display_help();
 
 typedef struct
 {
+    int force;  // Allow wiping of busy/mounted devices (0 = no, 1 = yes)
     int autonuke;  // Do not prompt the user for confirmation when set.
     int autopoweroff;  // Power off on completion of wipe
     int noblank;  // Do not perform a final blanking pass.


### PR DESCRIPTION
As discussed in #741:

> [...] the general idea is showing mounted disks (so users don't think "Why are my disks missing?") in GUI but not allowing them to be selected unless --force is also set. In CLI mode, to keep things consistent everywhere, --autonuke will not include mounted disks by default unless --force is also set.

closes #741