### PR TITLE
Device geometry, scattered I/O, verification error paths

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,7 +22,7 @@ NWIPE_CORE = \
     method.c method.h \
     pass.c pass.h \
     pass_internal.c pass_internal.h \
-    pass_static.c pass_random.c \
+    pass_static.c pass_random.c pass_scatter.c \
     device.c device.h \
     hpa_dco.c hpa_dco.h \
     miscellaneous.c miscellaneous.h \

--- a/src/context.h
+++ b/src/context.h
@@ -72,6 +72,7 @@ typedef enum {
 typedef enum {
     NWIPE_IO_DIRECTION_FORWARD = 0, /* Start -> End */
     NWIPE_IO_DIRECTION_REVERSE, /* End -> Start */
+    NWIPE_IO_DIRECTION_SCATTER /* Random Order */
 } nwipe_io_direction_t;
 
 #define NWIPE_KNOB_SPEEDRING_SIZE 30
@@ -220,7 +221,7 @@ typedef struct nwipe_context_t_
     int HPA_display_toggle_state;  // 0 or 1 Used to toggle between "[1TB] [ 33C]" and [HDA STATUS]
     time_t HPA_toggle_time;  // records a time, then if for instance 3 seconds has elapsed the display changes
     nwipe_io_mode_t io_mode;  // specific I/O method for a given drive, direct or cached.
-    nwipe_io_direction_t io_direction;  // specific I/O direction for a given drive, forward or reverse.
+    nwipe_io_direction_t io_direction;  // drive-specific I/O direction, forward/reverse or scatter.
     int test_use1;
     int test_use2;
 

--- a/src/context.h
+++ b/src/context.h
@@ -111,9 +111,11 @@ typedef struct nwipe_context_t_
      * Device fields
      */
     int device_busy;  // If libparted considers the device busy/mounted (0 = no, 1 = yes)
-    int device_block_size;  // The soft block size reported by the device, as logical
-    int device_sector_size;  // The logical sector size reported by libparted
-    int device_phys_sector_size;  // The physical sector size reported by libparted
+    int device_sector_size;  // The logical sector size reported by the device
+    int device_phys_sector_size;  // The physical sector size reported by the device
+    size_t device_io_block_size;  // The block size for both cached and direct I/O
+    size_t device_io_block_alignment;  // The alignment for the I/O block size
+    size_t device_io_buffer_alignment;  // The alignment for allocated I/O buffers
     int device_bus;  // The device bus number.
     int device_fd;  // The file descriptor of the device file being wiped.
     int device_host;  // The host number.

--- a/src/device.c
+++ b/src/device.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <ctype.h>
+#include <limits.h>
 
 #include "nwipe.h"
 #include "context.h"
@@ -46,6 +47,29 @@
 
 #include <parted/parted.h>
 #include <parted/debug.h>
+
+/*
+ * Tunable sizes for the wiping / verification I/O path.
+ *
+ * NWIPE_IO_BLOCKSIZE:
+ *   - Target size of individual read()/write() operations.
+ *   - Default is 4 MiB, so each syscall moves a lot of data instead of only
+ *     4 KiB, drastically reducing syscall overhead.
+ *
+ * Notes:
+ *   - We do NOT depend on O_DIRECT here; all code works fine with normal,
+ *     buffered I/O.
+ *   - But all I/O buffers are allocated aligned to the device block size so
+ *     that the same code also works with O_DIRECT when the device is opened
+ *     with it.
+ */
+#ifndef NWIPE_IO_BLOCKSIZE
+#define NWIPE_IO_BLOCKSIZE ( 4 * 1024 * 1024UL ) /* 4 MiB I/O block */
+#endif
+
+#if NWIPE_IO_BLOCKSIZE > INT_MAX
+#error "NWIPE_IO_BLOCKSIZE must fit in an int"
+#endif
 
 int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount );
 char* trim( char* str );

--- a/src/device.c
+++ b/src/device.c
@@ -360,7 +360,6 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
 
     next_device->device_size = dev->length * dev->sector_size;
     next_device->device_sector_size = dev->sector_size;  // logical sector size
-    next_device->device_block_size = dev->sector_size;  // set as logical but could be a multiple of logical sector size
     next_device->device_phys_sector_size = dev->phys_sector_size;  // physical sector size
     next_device->device_size_in_sectors = next_device->device_size / next_device->device_sector_size;
     next_device->device_size_in_512byte_sectors = next_device->device_size / 512;
@@ -1137,3 +1136,256 @@ void remove_ATA_prefix( char* str )
         str[idx_post] = 0;
     }
 }
+
+/* Returns 1 if n is positive and a power of two, 0 otherwise. */
+static inline int is_positive_power_of_two( int n )
+{
+    return n > 0 && ( n & ( n - 1 ) ) == 0;
+}
+
+/*
+ * Query kernel for the device's logical/physical sector sizes via ioctl,
+ * cross-check them against the values previously obtained from libparted,
+ * and update the device context with the most trustworthy and sane result.
+ *
+ * - All sizes must be positive and a power of two.
+ * - Physical sector size must be a multiple of logical sector size.
+ * - Ioctl values are preferred over libparted when otherwise valid.
+ * - Invalid logical sector size is considered as fatal (returns -1).
+ *
+ * Returns 0 on success, -1 if no valid geometry could be established.
+ */
+static int nwipe_update_device_sectors( nwipe_context_t* c )
+{
+    int ioctl_sector_size = 0;
+    int ioctl_phys_sector_size = 0;
+    int libparted_sector_size = c->device_sector_size;
+    int libparted_phys_sector_size = c->device_phys_sector_size;
+
+    /* ---- Ioctl ( we have libparted as fallback ) ---- */
+    if( ioctl( c->device_fd, BLKSSZGET, &ioctl_sector_size ) != 0 )
+    {
+        nwipe_perror( errno, __FUNCTION__, "BLKSSZGET" );
+        nwipe_log( NWIPE_LOG_WARNING, "Device '%s' failed ioctl BLKSSZGET.", c->device_name );
+    }
+
+    if( ioctl( c->device_fd, BLKPBSZGET, &ioctl_phys_sector_size ) != 0 )
+    {
+        nwipe_perror( errno, __FUNCTION__, "BLKPBSZGET" );
+        nwipe_log( NWIPE_LOG_WARNING, "Device '%s' failed ioctl BLKPBSZGET.", c->device_name );
+    }
+
+    /* ---- Logical sector size ---- */
+    if( is_positive_power_of_two( ioctl_sector_size ) ) /* Ioctl */
+    {
+        if( ioctl_sector_size != libparted_sector_size )
+        {
+            nwipe_log( NWIPE_LOG_WARNING,
+                       "Device '%s' logical sector size mismatch: libparted=%i, ioctl=%i, using ioctl value.",
+                       c->device_name,
+                       libparted_sector_size,
+                       ioctl_sector_size );
+        }
+        c->device_sector_size = ioctl_sector_size;
+    }
+    else if( is_positive_power_of_two( libparted_sector_size ) ) /* Libparted */
+    {
+        nwipe_log( NWIPE_LOG_WARNING,
+                   "Device '%s' ioctl logical sector size invalid (%i), using libparted value (%i)",
+                   c->device_name,
+                   ioctl_sector_size,
+                   libparted_sector_size );
+        c->device_sector_size = libparted_sector_size;
+    }
+    else
+    {
+        nwipe_log( NWIPE_LOG_ERROR,
+                   "Device '%s' no valid logical sector size: libparted=%i, ioctl=%i.",
+                   c->device_name,
+                   libparted_sector_size,
+                   ioctl_sector_size );
+        return -1;
+    }
+
+    /* ---- Physical sector size ---- */
+    if( is_positive_power_of_two( ioctl_phys_sector_size )
+        && ioctl_phys_sector_size % c->device_sector_size == 0 ) /* Ioctl */
+    {
+        if( ioctl_phys_sector_size != libparted_phys_sector_size )
+        {
+            nwipe_log( NWIPE_LOG_WARNING,
+                       "Device '%s' physical sector size mismatch: libparted=%i, ioctl=%i, using ioctl value.",
+                       c->device_name,
+                       libparted_phys_sector_size,
+                       ioctl_phys_sector_size );
+        }
+        c->device_phys_sector_size = ioctl_phys_sector_size;
+    }
+    else if( is_positive_power_of_two( libparted_phys_sector_size )
+             && libparted_phys_sector_size % c->device_sector_size == 0 ) /* Libparted */
+    {
+        nwipe_log( NWIPE_LOG_WARNING,
+                   "Device '%s' ioctl physical sector size invalid (%i), using libparted value (%i).",
+                   c->device_name,
+                   ioctl_phys_sector_size,
+                   libparted_phys_sector_size );
+        c->device_phys_sector_size = libparted_phys_sector_size;
+    }
+    else
+    {
+        nwipe_log( NWIPE_LOG_WARNING,
+                   "Device '%s' no valid physical sector size: libparted=%i, ioctl=%i, using logical sector size.",
+                   c->device_name,
+                   libparted_phys_sector_size,
+                   ioctl_phys_sector_size );
+
+        /*
+         * We allow this to fail, as it's only used as a performance boost
+         * But downstream users of this variable cannot use the invalid value.
+         * It is common to use the logical sector size as a safe fallback here.
+         */
+        c->device_phys_sector_size = c->device_sector_size;
+    }
+
+    return 0;
+} /* nwipe_update_device_sectors */
+
+/*
+ * Sets minimum I/O buffer alignment for a given device context.
+ *
+ * This is the logical sector size, raised to at least 512 bytes
+ * to satisfy O_DIRECT requirements - also usable for cached I/O.
+ */
+static void nwipe_set_io_buffer_alignment( nwipe_context_t* c )
+{
+    if( c->device_sector_size < 512 )
+    {
+        /* O_DIRECT requires at least 512 bytes */
+        c->device_io_buffer_alignment = 512;
+    }
+    else
+    {
+        /* The logical sector size is the minimum requirement */
+        c->device_io_buffer_alignment = (size_t) c->device_sector_size;
+    }
+} /* nwipe_set_io_buffer_alignment */
+
+/*
+ * Sets effective I/O block size for a given device context.
+ *
+ * For direct I/O, aligns to the physical sector size (falling back to
+ * logical sector size) for performance (where possible). For cached I/O,
+ * uses st_blksize as a performance hint; alignment is left to the kernel.
+ *
+ * It is a multiple of the alignment base and never exceeds device_size.
+ * A warning is printed if device_size is misaligned with logical sector size.
+ */
+static void nwipe_set_io_block_size( nwipe_context_t* c )
+{
+    size_t bs = 0;
+    size_t io_bs = (size_t) NWIPE_IO_BLOCKSIZE;
+    size_t st_blksize = 4096; /* Sane default (covers 4K and 512) */
+    size_t dev_sector_size = (size_t) c->device_sector_size;
+    size_t dev_phy_sector_size = (size_t) c->device_phys_sector_size;
+
+    /* We use external values only if we can trust them to be accurate */
+
+    if( is_positive_power_of_two( (int) c->device_stat.st_blksize ) )
+        st_blksize = (size_t) c->device_stat.st_blksize;
+
+    /* Sanity-check the device size and warn if it's not a multiple of the logical sector size */
+
+    if( c->device_size > 0 && c->device_size % (u64) dev_sector_size != 0 )
+    {
+        nwipe_log( NWIPE_LOG_WARNING,
+                   "%s: The size of '%s' is not a multiple of its logical sector size %zu.",
+                   __FUNCTION__,
+                   c->device_name,
+                   dev_sector_size );
+    }
+
+    /* Now calculate the I/O size based on the I/O access mode requirements */
+
+    if( c->io_mode == NWIPE_IO_MODE_DIRECT )
+    {
+        /* Alignment with logical sector size is the hard requirement */
+        bs = dev_sector_size;
+
+        if( dev_phy_sector_size % dev_sector_size == 0 )
+        {
+            /*
+             * For best performance, we align to the physical sector size.
+             * We can only do this if it is aligned to the logical sector size.
+             * But this is usually always the case with any sane block devices.
+             */
+            bs = dev_phy_sector_size;
+        }
+    }
+    else
+    {
+        /*
+         * In cached I/O we use the recommended buffered block size,
+         * we do not need to consider any direct I/O alignment rules.
+         */
+        bs = st_blksize;
+    }
+
+    c->device_io_block_alignment = bs;
+
+    /* We cannot go lower than our chosen minimum block size */
+    if( io_bs < bs )
+    {
+        io_bs = bs;
+    }
+
+    /* Round down to next multiple of the minimum block size. */
+    if( io_bs % bs != 0 )
+    {
+        io_bs -= ( io_bs % bs );
+    }
+
+    /* This shouldn't be possible here, but just in case. */
+    if( io_bs == 0 )
+    {
+        io_bs = bs;
+    }
+
+    /*
+     * Clamp to device size; safe because device_size should be a multiple of
+     * logical sector size, so the result would also be aligned for direct I/O.
+     */
+    if( (u64) io_bs > c->device_size )
+    {
+        io_bs = (size_t) c->device_size;
+        io_bs -= ( io_bs % bs );
+        if( io_bs == 0 )
+            io_bs = bs;
+    }
+
+    c->device_io_block_size = io_bs;
+
+} /* nwipe_set_io_block_size */
+
+/*
+ * Request device geometry from the kernel and compute I/O parameters.
+ * This populates the context with the correct values usable for any I/O.
+ *
+ * Queries sector sizes via ioctl (with libparted as fallback), then
+ * sets the alignment and block size used by subsequent I/O operations.
+ *
+ * Returns 0 on success, -1 if no valid geometry could be established.
+ * Requires open FD; call right before a wipe begins (but after HPA/DCO).
+ */
+int nwipe_update_geometry_for_io( nwipe_context_t* c )
+{
+    if( nwipe_update_device_sectors( c ) != 0 )
+    {
+        nwipe_log( NWIPE_LOG_ERROR, "No sane sector sizes for '%s'.", c->device_name );
+        return -1;
+    }
+
+    nwipe_set_io_buffer_alignment( c );
+    nwipe_set_io_block_size( c );
+
+    return 0;
+} /* nwipe_update_geometry_for_io */

--- a/src/device.h
+++ b/src/device.h
@@ -23,32 +23,7 @@
 #ifndef DEVICE_H_
 #define DEVICE_H_
 
-#include <limits.h>
-
 #define MAX_LENGTH_OF_DEVICE_STRING 8
-
-/*
- * Tunable sizes for the wiping / verification I/O path.
- *
- * NWIPE_IO_BLOCKSIZE:
- *   - Target size of individual read()/write() operations.
- *   - Default is 4 MiB, so each syscall moves a lot of data instead of only
- *     4 KiB, drastically reducing syscall overhead.
- *
- * Notes:
- *   - We do NOT depend on O_DIRECT here; all code works fine with normal,
- *     buffered I/O.
- *   - But all I/O buffers are allocated aligned to the device block size so
- *     that the same code also works with O_DIRECT when the device is opened
- *     with it.
- */
-#ifndef NWIPE_IO_BLOCKSIZE
-#define NWIPE_IO_BLOCKSIZE ( 4 * 1024 * 1024UL ) /* 4 MiB I/O block */
-#endif
-
-#if NWIPE_IO_BLOCKSIZE > INT_MAX
-#error "NWIPE_IO_BLOCKSIZE must fit in an int"
-#endif
 
 void nwipe_device_identify( nwipe_context_t* c );  // Get hardware information about the device.
 int nwipe_device_scan( nwipe_context_t*** c );  // Find devices that we can wipe.

--- a/src/device.h
+++ b/src/device.h
@@ -23,7 +23,32 @@
 #ifndef DEVICE_H_
 #define DEVICE_H_
 
+#include <limits.h>
+
 #define MAX_LENGTH_OF_DEVICE_STRING 8
+
+/*
+ * Tunable sizes for the wiping / verification I/O path.
+ *
+ * NWIPE_IO_BLOCKSIZE:
+ *   - Target size of individual read()/write() operations.
+ *   - Default is 4 MiB, so each syscall moves a lot of data instead of only
+ *     4 KiB, drastically reducing syscall overhead.
+ *
+ * Notes:
+ *   - We do NOT depend on O_DIRECT here; all code works fine with normal,
+ *     buffered I/O.
+ *   - But all I/O buffers are allocated aligned to the device block size so
+ *     that the same code also works with O_DIRECT when the device is opened
+ *     with it.
+ */
+#ifndef NWIPE_IO_BLOCKSIZE
+#define NWIPE_IO_BLOCKSIZE ( 4 * 1024 * 1024UL ) /* 4 MiB I/O block */
+#endif
+
+#if NWIPE_IO_BLOCKSIZE > INT_MAX
+#error "NWIPE_IO_BLOCKSIZE must fit in an int"
+#endif
 
 void nwipe_device_identify( nwipe_context_t* c );  // Get hardware information about the device.
 int nwipe_device_scan( nwipe_context_t*** c );  // Find devices that we can wipe.
@@ -46,6 +71,9 @@ int nwipe_get_device_bus_type_and_serialno( char* device,
                                             char* serialnumber,
                                             char* sysfs_path,
                                             size_t sysfs_path_size );
+
+int nwipe_update_geometry_for_io( nwipe_context_t* c );
+
 void strip_CR_LF( char* );
 void determine_disk_capacity_nomenclature( u64, char* );
 void remove_ATA_prefix( char* );

--- a/src/display_help.c
+++ b/src/display_help.c
@@ -177,6 +177,11 @@ void display_help()
     "        Helpful when bad blocks otherwise prevent wiping major areas of the device\n" \
     "        Beware throughput may be degraded as it writes against the spin direction\n\n" \
     BHCYN \
+    "      --scatter\n" reset \
+    "        Use scattered I/O direction (random segmented order across the device)\n" \
+    "        More mechanical exercise; good for burning-in or stress-testing devices\n" \
+    "        Beware the throughput may be degraded due to random access patterns used\n\n" \
+    BHCYN \
     "      --no-retry-on-io-errors\n" reset \
     "        Do NOT retry single failed read/write operations; immediately error\n" \
     "        or skip the failing block. (default is retry 3 times with 5s sleep\n" \

--- a/src/gui.c
+++ b/src/gui.c
@@ -1880,7 +1880,9 @@ void nwipe_gui_options( void )
                NWIPE_GUI_OPTIONS_METHOD_X,
                "Method:  %s%s",
                nwipe_method_label( nwipe_options.method ),
-               nwipe_options.io_direction == NWIPE_IO_DIRECTION_FORWARD ? "" : " (R)" );
+               nwipe_options.io_direction == NWIPE_IO_DIRECTION_FORWARD       ? ""
+                   : nwipe_options.io_direction == NWIPE_IO_DIRECTION_REVERSE ? " (R)"
+                                                                              : " (S)" );
 
     mvwprintw( options_window, NWIPE_GUI_OPTIONS_VERIFY_Y, NWIPE_GUI_OPTIONS_VERIFY_X, "Verify:  " );
 
@@ -2072,7 +2074,10 @@ void nwipe_gui_io_direction( void )
 
     int yy;
     int keystroke;
-    int focus = nwipe_options.io_direction == NWIPE_IO_DIRECTION_FORWARD ? 0 : 1;
+
+    int focus = nwipe_options.io_direction == NWIPE_IO_DIRECTION_FORWARD ? 0
+        : nwipe_options.io_direction == NWIPE_IO_DIRECTION_REVERSE       ? 1
+                                                                         : 2;
 
     /* Update the footer window. */
     werase( footer_window );
@@ -2089,6 +2094,7 @@ void nwipe_gui_io_direction( void )
 
         mvwprintw( main_window, yy++, tab1, "  Start -> End (Forward)" );
         mvwprintw( main_window, yy++, tab1, "  End -> Start (Reverse)" );
+        mvwprintw( main_window, yy++, tab1, "  Random Order (Scatter)" );
         yy++;
 
         mvwaddch( main_window, 2 + focus, tab1, ACS_RARROW );
@@ -2119,6 +2125,17 @@ void nwipe_gui_io_direction( void )
                 mvwprintw( main_window, yy++, tab2, "An alternative is to enable no-abort-on-bad-block" );
                 mvwprintw( main_window, yy++, tab2, "to skip over it, proceeding chosen I/O direction." );
                 break;
+
+            case 2:
+                mvwprintw( main_window, yy++, tab2, "Wipes the device in a random segmented order,    " );
+                mvwprintw( main_window, yy++, tab2, "giving long seeks and short sequential writes.   " );
+                mvwprintw( main_window, yy++, tab2, "Focuses on mechanical exercise for the device,   " );
+                mvwprintw( main_window, yy++, tab2, "while keeping throughput acceptable, and every   " );
+                mvwprintw( main_window, yy++, tab2, "byte still erased; only traversal order changed. " );
+                yy++;
+                mvwprintw( main_window, yy++, tab2, "Can be useful to burn-in or stress-test devices. " );
+                mvwprintw( main_window, yy++, tab2, "Beware random access may degrade the throughput. " );
+                break;
         }
 
         box( main_window, 0, 0 );
@@ -2141,15 +2158,15 @@ void nwipe_gui_io_direction( void )
             case KEY_DOWN:
             case 'j':
             case 'J':
-                if( focus < 1 )
-                    focus = 1;
+                if( focus < 2 )
+                    focus += 1;
                 break;
 
             case KEY_UP:
             case 'k':
             case 'K':
                 if( focus > 0 )
-                    focus = 0;
+                    focus -= 1;
                 break;
 
             case KEY_ENTER:
@@ -2157,8 +2174,10 @@ void nwipe_gui_io_direction( void )
             case 10:
                 if( focus == 0 )
                     nwipe_options.io_direction = NWIPE_IO_DIRECTION_FORWARD;
-                else
+                else if( focus == 1 )
                     nwipe_options.io_direction = NWIPE_IO_DIRECTION_REVERSE;
+                else
+                    nwipe_options.io_direction = NWIPE_IO_DIRECTION_SCATTER;
                 return;
 
             case KEY_BACKSPACE:
@@ -7888,8 +7907,12 @@ void* nwipe_gui_status( void* ptr )
 
                     if( c[i]->wipe_status == 1 )
                     {
-                        const char* op_prefix = c[i]->io_direction == NWIPE_IO_DIRECTION_FORWARD ? "" : "<";
-                        const char* op_suffix = c[i]->io_direction == NWIPE_IO_DIRECTION_FORWARD ? ">" : "";
+                        const char* op_prefix = c[i]->io_direction == NWIPE_IO_DIRECTION_FORWARD ? ""
+                            : c[i]->io_direction == NWIPE_IO_DIRECTION_REVERSE                   ? "<"
+                                                                                                 : "";
+                        const char* op_suffix = c[i]->io_direction == NWIPE_IO_DIRECTION_FORWARD ? ">"
+                            : c[i]->io_direction == NWIPE_IO_DIRECTION_REVERSE                   ? ""
+                                                                                                 : "";
 
                         switch( c[i]->pass_type )
                         {

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -965,24 +965,6 @@ int main( int argc, char** argv )
                 nwipe_log( NWIPE_LOG_NOTICE, "%s has serial number %s", c2[i]->device_name, c2[i]->device_serial_no );
             }
 
-            /* Do sector size and block size checking. I don't think this does anything useful as logical/Physical
-             * sector sizes are obtained by libparted in check.c */
-            if( ioctl( c2[i]->device_fd, BLKSSZGET, &c2[i]->device_sector_size ) == 0 )
-            {
-
-                if( ioctl( c2[i]->device_fd, BLKBSZGET, &c2[i]->device_block_size ) != 0 )
-                {
-                    nwipe_log( NWIPE_LOG_WARNING, "Device '%s' failed BLKBSZGET ioctl.", c2[i]->device_name );
-                    c2[i]->device_block_size = 0;
-                }
-            }
-            else
-            {
-                nwipe_log( NWIPE_LOG_WARNING, "Device '%s' failed BLKSSZGET ioctl.", c2[i]->device_name );
-                c2[i]->device_sector_size = 0;
-                c2[i]->device_block_size = 0;
-            }
-
             /* The st_size field is zero for block devices. */
             /* ioctl( c2[i]->device_fd, BLKGETSIZE64, &c2[i]->device_size ); */
 
@@ -1032,23 +1014,36 @@ int main( int argc, char** argv )
             if( c2[i]->device_size == 0 )
             {
                 nwipe_log( NWIPE_LOG_ERROR,
-                           "%s, sect/blk/dev %i/%i/%llu",
+                           "%s, log/phy/dev %i/%i/%llu",
                            c2[i]->device_name,
                            c2[i]->device_sector_size,
-                           c2[i]->device_block_size,
+                           c2[i]->device_phys_sector_size,
                            c2[i]->device_size );
                 nwipe_error++;
                 continue;
             }
-            else
+
+            /*
+             * Right before the wipe, but after HPA/DCO is done, we get the
+             * device sector sizes from the kernel. This step ensures they are
+             * compatible for direct I/O and its strict alignment requirements.
+             * The function call populates also I/O parameters like the aligned
+             * block size - all of which can be used for cached and direct I/O.
+             */
+            if( nwipe_update_geometry_for_io( c2[i] ) != 0 )
             {
-                nwipe_log( NWIPE_LOG_NOTICE,
-                           "%s, sect/blk/dev %i/%i/%llu",
-                           c2[i]->device_name,
-                           c2[i]->device_sector_size,
-                           c2[i]->device_block_size,
-                           c2[i]->device_size );
+                nwipe_log( NWIPE_LOG_ERROR, "No sane device geometry for '%s'.", c2[i]->device_name );
+                nwipe_error++;
+                continue;
             }
+
+            nwipe_log( NWIPE_LOG_NOTICE, "%s: Device geometry is as follows...", c2[i]->device_name );
+            nwipe_log( NWIPE_LOG_NOTICE, "  Logical sector size  = %i", c2[i]->device_sector_size );
+            nwipe_log( NWIPE_LOG_NOTICE, "  Physical sector size = %i", c2[i]->device_phys_sector_size );
+            nwipe_log( NWIPE_LOG_NOTICE, "  I/O block size       = %zu", c2[i]->device_io_block_size );
+            nwipe_log( NWIPE_LOG_NOTICE, "  I/O block alignment  = %zu", c2[i]->device_io_block_alignment );
+            nwipe_log( NWIPE_LOG_NOTICE, "  I/O buffer alignment = %zu", c2[i]->device_io_buffer_alignment );
+            nwipe_log( NWIPE_LOG_NOTICE, "  Total device bytes   = %llu", c2[i]->device_size );
 
             /* Fork a child process. */
             errno = pthread_create( &c2[i]->thread, NULL, nwipe_options.method, (void*) c2[i] );
@@ -1095,7 +1090,11 @@ int main( int argc, char** argv )
             break;
         }
 
-        if( c2[i]->wipe_status != 0 )
+        /*
+         * If the wipe is not done and a thread (still) exists, keep waiting.
+         * It also covers "continue;" error cases where thread was not started.
+         */
+        if( c2[i]->wipe_status != 0 && c2[i]->thread != 0 )
         {
             i = 0;
         }

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -1419,8 +1419,12 @@ void* signal_hand( void* ptr )
                     if( c[i]->thread )
                     {
                         char* status = "";
-                        const char* op_prefix = c[i]->io_direction == NWIPE_IO_DIRECTION_FORWARD ? "" : "<";
-                        const char* op_suffix = c[i]->io_direction == NWIPE_IO_DIRECTION_FORWARD ? ">" : "";
+                        const char* op_prefix = c[i]->io_direction == NWIPE_IO_DIRECTION_FORWARD ? ""
+                            : c[i]->io_direction == NWIPE_IO_DIRECTION_REVERSE                   ? "<"
+                                                                                                 : "";
+                        const char* op_suffix = c[i]->io_direction == NWIPE_IO_DIRECTION_FORWARD ? ">"
+                            : c[i]->io_direction == NWIPE_IO_DIRECTION_REVERSE                   ? ""
+                                                                                                 : "";
 
                         switch( c[i]->pass_type )
                         {

--- a/src/nwipe.h
+++ b/src/nwipe.h
@@ -104,7 +104,8 @@ typedef unsigned char u8;
 #define BLKSSZGET _IO( 0x12, 104 )
 #define BLKBSZGET _IOR( 0x12, 112, size_t )
 #define BLKBSZSET _IOW( 0x12, 113, size_t )
-#define BLKGETSIZE64 _IOR( 0x12, 114, sizeof( u64 ) )
+#define BLKPBSZGET _IO( 0x12, 123 )
+#define BLKGETSIZE64 _IOR( 0x12, 114, u64 )
 
 #define THREAD_CANCELLATION_TIMEOUT 10
 

--- a/src/options.c
+++ b/src/options.c
@@ -122,6 +122,9 @@ int nwipe_options_parse( int argc, char** argv )
         /* Reverse the I/O direction (end -> start). */
         { "reverse", no_argument, 0, 0 },
 
+        /* Scatter the I/O direction (random order). */
+        { "scatter", no_argument, 0, 0 },
+
         /* Do NOT retry on possibly transient I/O errors. */
         { "no-retry-on-io-errors", no_argument, 0, 0 },
 
@@ -496,6 +499,12 @@ int nwipe_options_parse( int argc, char** argv )
                 if( strcmp( nwipe_options_long[i].name, "reverse" ) == 0 )
                 {
                     nwipe_options.io_direction = NWIPE_IO_DIRECTION_REVERSE;
+                    break;
+                }
+
+                if( strcmp( nwipe_options_long[i].name, "scatter" ) == 0 )
+                {
+                    nwipe_options.io_direction = NWIPE_IO_DIRECTION_SCATTER;
                     break;
                 }
 
@@ -1020,8 +1029,9 @@ void nwipe_options_log( void )
 
     nwipe_log( NWIPE_LOG_NOTICE,
                "  direction    = %s",
-               nwipe_options.io_direction == NWIPE_IO_DIRECTION_FORWARD ? "start -> end (forward)"
-                                                                        : "end -> start (reverse)" );
+               nwipe_options.io_direction == NWIPE_IO_DIRECTION_FORWARD       ? "start -> end (forward)"
+                   : nwipe_options.io_direction == NWIPE_IO_DIRECTION_REVERSE ? "end -> start (reverse)"
+                                                                              : "random order (scatter)" );
 
     nwipe_log( NWIPE_LOG_NOTICE, "  quiet        = %i", nwipe_options.quiet );
     nwipe_log( NWIPE_LOG_NOTICE, "  rounds       = %i", nwipe_options.rounds );

--- a/src/pass.c
+++ b/src/pass.c
@@ -29,37 +29,47 @@ static void nwipe_log_io_direction( nwipe_context_t* c )
     nwipe_log( NWIPE_LOG_NOTICE,
                "I/O direction on '%s' is %s",
                c->device_name,
-               c->io_direction == NWIPE_IO_DIRECTION_FORWARD ? "start -> end (forward)" : "end -> start (reverse)" );
+               c->io_direction == NWIPE_IO_DIRECTION_FORWARD       ? "start -> end (forward)"
+                   : c->io_direction == NWIPE_IO_DIRECTION_REVERSE ? "end -> start (reverse)"
+                                                                   : "random order (scatter)" );
 }
 
 /* Calls the static_*_pass method for the respective c->io_direction. */
 int nwipe_static_pass( nwipe_context_t* c, nwipe_pattern_t* pattern )
 {
     nwipe_log_io_direction( c );
+
     return c->io_direction == NWIPE_IO_DIRECTION_FORWARD ? nwipe_static_forward_pass( c, pattern )
-                                                         : nwipe_static_reverse_pass( c, pattern );
+        : c->io_direction == NWIPE_IO_DIRECTION_REVERSE  ? nwipe_static_reverse_pass( c, pattern )
+                                                         : nwipe_static_scatter_pass( c, pattern );
 }
 
 /* Calls the static_*_verify method for the respective c->io_direction. */
 int nwipe_static_verify( nwipe_context_t* c, nwipe_pattern_t* pattern )
 {
     nwipe_log_io_direction( c );
+
     return c->io_direction == NWIPE_IO_DIRECTION_FORWARD ? nwipe_static_forward_verify( c, pattern )
-                                                         : nwipe_static_reverse_verify( c, pattern );
+        : c->io_direction == NWIPE_IO_DIRECTION_REVERSE  ? nwipe_static_reverse_verify( c, pattern )
+                                                         : nwipe_static_scatter_verify( c, pattern );
 }
 
 /* Calls the random_*_pass method for the respective c->io_direction. */
 int nwipe_random_pass( nwipe_context_t* c )
 {
     nwipe_log_io_direction( c );
+
     return c->io_direction == NWIPE_IO_DIRECTION_FORWARD ? nwipe_random_forward_pass( c )
-                                                         : nwipe_random_reverse_pass( c );
+        : c->io_direction == NWIPE_IO_DIRECTION_REVERSE  ? nwipe_random_reverse_pass( c )
+                                                         : nwipe_random_scatter_pass( c );
 }
 
 /* Calls the random_*_verify method for the respective c->io_direction. */
 int nwipe_random_verify( nwipe_context_t* c )
 {
     nwipe_log_io_direction( c );
+
     return c->io_direction == NWIPE_IO_DIRECTION_FORWARD ? nwipe_random_forward_verify( c )
-                                                         : nwipe_random_reverse_verify( c );
+        : c->io_direction == NWIPE_IO_DIRECTION_REVERSE  ? nwipe_random_reverse_verify( c )
+                                                         : nwipe_random_scatter_verify( c );
 }

--- a/src/pass_internal.c
+++ b/src/pass_internal.c
@@ -24,30 +24,6 @@
 #include "pass_internal.h"
 
 /*
- * Tunable sizes for the wiping / verification I/O path.
- *
- * NWIPE_IO_BLOCKSIZE:
- *   - Target size of individual read()/write() operations.
- *   - Default is 4 MiB, so each syscall moves a lot of data instead of only
- *     4 KiB, drastically reducing syscall overhead.
- *
- * Notes:
- *   - We do NOT depend on O_DIRECT here; all code works fine with normal,
- *     buffered I/O.
- *   - But all I/O buffers are allocated aligned to the device block size so
- *     that the same code also works with O_DIRECT when the device is opened
- *     with it.
- */
-
-#ifndef NWIPE_IO_BLOCKSIZE
-#define NWIPE_IO_BLOCKSIZE ( 4 * 1024 * 1024UL ) /* 4 MiB I/O block */
-#endif
-
-#if NWIPE_IO_BLOCKSIZE > INT_MAX
-#error "NWIPE_IO_BLOCKSIZE must fit in an int"
-#endif
-
-/*
  * nwipe_(p)write_with_retry / nwipe_(p)read_with_retry
  *
  * Attempt the I/O up to MAX_IO_ATTEMPTS times, sleeping IO_RETRY_DELAY_S
@@ -400,52 +376,7 @@ int nwipe_fdatasync( nwipe_context_t* c, const char* f )
 } /* nwipe_fdatasync */
 
 /*
- * Compute the effective I/O block size for a given device:
- *
- * - Must be at least the device's reported st_blksize (usually 4 KiB).
- * - Starts from NWIPE_IO_BLOCKSIZE (4 MiB by default) and adjusts.
- * - Rounded down to a multiple of st_blksize so it is compatible with
- *   O_DIRECT alignment rules.
- * - Never exceeds the device size.
- */
-size_t nwipe_effective_io_blocksize( const nwipe_context_t* c )
-{
-    size_t bs = (size_t) c->device_stat.st_blksize;
-
-    if( bs == 0 )
-    {
-        /* Should not happen for normal block devices; use a sane default. */
-        bs = 4096;
-    }
-
-    size_t io_bs = (size_t) NWIPE_IO_BLOCKSIZE;
-
-    if( io_bs < bs )
-    {
-        io_bs = bs;
-    }
-
-    /* Round down to a multiple of the device block size. */
-    if( io_bs % bs != 0 )
-    {
-        io_bs -= ( io_bs % bs );
-    }
-
-    if( io_bs == 0 )
-    {
-        io_bs = bs;
-    }
-
-    if( (u64) io_bs > c->device_size )
-    {
-        io_bs = (size_t) c->device_size;
-    }
-
-    return io_bs;
-} /* nwipe_effective_io_blocksize */
-
-/*
- * Allocate an I/O buffer aligned to the device block size.
+ * Allocate an I/O buffer aligned to the device's logical sector size.
  *
  * This is done with posix_memalign() so that the buffer can safely be used
  * with O_DIRECT if the device was opened with it. The same allocation is also
@@ -459,15 +390,8 @@ size_t nwipe_effective_io_blocksize( const nwipe_context_t* c )
  */
 void* nwipe_alloc_io_buffer( const nwipe_context_t* c, size_t size, int clear, const char* label )
 {
-    size_t align = (size_t) c->device_stat.st_blksize;
-    if( align < 512 )
-    {
-        /* O_DIRECT usually requires at least 512-byte alignment. */
-        align = 512;
-    }
-
     void* ptr = NULL;
-    int rc = posix_memalign( &ptr, align, size );
+    int rc = posix_memalign( &ptr, c->device_io_buffer_alignment, size );
     if( rc != 0 || ptr == NULL )
     {
         nwipe_log( NWIPE_LOG_FATAL,
@@ -475,7 +399,7 @@ void* nwipe_alloc_io_buffer( const nwipe_context_t* c, size_t size, int clear, c
                    __FUNCTION__,
                    label,
                    size,
-                   align,
+                   c->device_io_buffer_alignment,
                    rc );
         return NULL;
     }
@@ -499,6 +423,7 @@ void* nwipe_alloc_io_buffer( const nwipe_context_t* c, size_t size, int clear, c
  */
 int nwipe_compute_sync_rate_for_device( const nwipe_context_t* c, size_t io_blocksize )
 {
+    size_t st_blksize = 4096; /* Sane default */
     int syncRate = nwipe_options.sync;
 
     /* No periodic sync in direct I/O mode. */
@@ -511,9 +436,11 @@ int nwipe_compute_sync_rate_for_device( const nwipe_context_t* c, size_t io_bloc
     if( io_blocksize == 0 )
         return 0;
 
+    if( c->device_stat.st_blksize > 0 )
+        st_blksize = (size_t) c->device_stat.st_blksize;
+
     /* Old semantics: bytes between syncs = sync * st_blksize. */
-    unsigned long long bytes_between_sync =
-        (unsigned long long) syncRate * (unsigned long long) c->device_stat.st_blksize;
+    unsigned long long bytes_between_sync = (unsigned long long) syncRate * (unsigned long long) st_blksize;
 
     if( bytes_between_sync == 0 )
         return 0;

--- a/src/pass_internal.h
+++ b/src/pass_internal.h
@@ -38,6 +38,21 @@
 #include "logging.h"
 #include "gui.h"
 
+typedef struct
+{
+    u64 segment_size; /* How many bytes per segment */
+    u64 segment_count; /* Total number of segments for device */
+    u64* visit_order; /* Array for segment indices */
+} nwipe_scatter_plan_t;
+
+typedef struct
+{
+    char* pattern_buffer; /* Repeated pattern */
+    int pattern_length; /* Length of pattern */
+} nwipe_scatter_patt_ctx_t;
+
+typedef int ( *nwipe_scatter_fill_fn )( nwipe_context_t*, char*, size_t, off64_t, void* );
+
 ssize_t nwipe_write_with_retry( nwipe_context_t* c, int fd, const void* buf, size_t count );
 ssize_t nwipe_pwrite_with_retry( nwipe_context_t* c, int fd, const void* buf, size_t count, off64_t offset );
 ssize_t nwipe_read_with_retry( nwipe_context_t* c, int fd, void* buf, size_t count );
@@ -51,12 +66,18 @@ int nwipe_prng_is_active( const char* buf, size_t blocksize );
 
 int nwipe_static_forward_pass( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* pattern );
 int nwipe_static_reverse_pass( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* pattern );
+int nwipe_static_scatter_pass( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* pattern );
+
 int nwipe_static_forward_verify( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* pattern );
 int nwipe_static_reverse_verify( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* pattern );
+int nwipe_static_scatter_verify( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* pattern );
 
 int nwipe_random_forward_pass( NWIPE_METHOD_SIGNATURE );
 int nwipe_random_reverse_pass( NWIPE_METHOD_SIGNATURE );
+int nwipe_random_scatter_pass( NWIPE_METHOD_SIGNATURE );
+
 int nwipe_random_forward_verify( NWIPE_METHOD_SIGNATURE );
 int nwipe_random_reverse_verify( NWIPE_METHOD_SIGNATURE );
+int nwipe_random_scatter_verify( NWIPE_METHOD_SIGNATURE );
 
 #endif /* PASS_INTERNAL_H_ */

--- a/src/pass_internal.h
+++ b/src/pass_internal.h
@@ -44,7 +44,6 @@ ssize_t nwipe_read_with_retry( nwipe_context_t* c, int fd, void* buf, size_t cou
 ssize_t nwipe_pread_with_retry( nwipe_context_t* c, int fd, void* buf, size_t count, off64_t offset );
 int nwipe_fdatasync( nwipe_context_t* c, const char* f );
 
-size_t nwipe_effective_io_blocksize( const nwipe_context_t* c );
 void* nwipe_alloc_io_buffer( const nwipe_context_t* c, size_t size, int clear, const char* label );
 int nwipe_compute_sync_rate_for_device( const nwipe_context_t* c, size_t io_blocksize );
 void nwipe_update_bytes_erased( nwipe_context_t* c, u64 z, u64 bs, int synced );

--- a/src/pass_random.c
+++ b/src/pass_random.c
@@ -911,6 +911,18 @@ int nwipe_random_forward_verify( NWIPE_METHOD_SIGNATURE )
         if( memcmp( b, d, (size_t) r ) != 0 )
         {
             c->verify_errors += 1;
+
+            /* Abort verification unless noabort_block_errors is enabled */
+            if( !nwipe_options.noabort_block_errors )
+            {
+                nwipe_log( NWIPE_LOG_FATAL,
+                           "Verification mismatch on '%s' at offset %lld",
+                           c->device_name,
+                           (long long) current_offset );
+                free( b );
+                free( d );
+                return -1;
+            }
         }
 
         z -= (u64) r;
@@ -1090,6 +1102,18 @@ int nwipe_random_reverse_verify( NWIPE_METHOD_SIGNATURE )
         if( memcmp( b, d, (size_t) r ) != 0 )
         {
             c->verify_errors += 1;
+
+            /* Abort verification unless noabort_block_errors is enabled */
+            if( !nwipe_options.noabort_block_errors )
+            {
+                nwipe_log( NWIPE_LOG_FATAL,
+                           "Verification mismatch on '%s' at offset %lld",
+                           c->device_name,
+                           (long long) current_offset );
+                free( b );
+                free( d );
+                return -1;
+            }
         }
 
         z -= (u64) r;

--- a/src/pass_random.c
+++ b/src/pass_random.c
@@ -51,8 +51,8 @@ int nwipe_random_forward_pass( NWIPE_METHOD_SIGNATURE )
 
     int syncRate = nwipe_options.sync;
 
-    /* Select effective I/O block size (e.g. 4 MiB, never smaller than st_blksize). */
-    io_blocksize = nwipe_effective_io_blocksize( c );
+    /* Select effective I/O block size (e.g. 4 MiB) */
+    io_blocksize = c->device_io_block_size;
 
     /* For direct I/O we do not need periodic fdatasync(), I/O errors are detected
      * at write() time. Keep sync for cached I/O only. */
@@ -119,16 +119,8 @@ int nwipe_random_forward_pass( NWIPE_METHOD_SIGNATURE )
         }
         else
         {
+            /* Last block may be smaller than I/O block size */
             blocksize = (size_t) z;
-
-            if( (u64) c->device_stat.st_blksize > z )
-            {
-                nwipe_log( NWIPE_LOG_WARNING,
-                           "%s: The size of '%s' is not a multiple of its block size %i.",
-                           __FUNCTION__,
-                           c->device_name,
-                           c->device_stat.st_blksize );
-            }
         }
 
         /* Ask the PRNG to fill "blocksize" bytes into the output buffer. */
@@ -231,15 +223,6 @@ int nwipe_random_forward_pass( NWIPE_METHOD_SIGNATURE )
 
             if( c->device_size % (u64) io_blocksize != 0 )
             {
-                if( c->device_size % (u64) c->device_stat.st_blksize != 0 )
-                {
-                    nwipe_log( NWIPE_LOG_WARNING,
-                               "%s: The size of '%s' is not a multiple of its block size %i.",
-                               __FUNCTION__,
-                               c->device_name,
-                               c->device_stat.st_blksize );
-                }
-
                 /* The last block of the device is smaller than our I/O blocksize, adjust it */
                 rev_offset = (off64_t) ( c->device_size - ( c->device_size % (u64) io_blocksize ) );
                 rev_blocksize = (size_t) ( c->device_size % (u64) io_blocksize );
@@ -430,8 +413,8 @@ int nwipe_random_reverse_pass( NWIPE_METHOD_SIGNATURE )
 
     int syncRate = nwipe_options.sync;
 
-    /* Select effective I/O block size (e.g. 4 MiB, never smaller than st_blksize). */
-    io_blocksize = nwipe_effective_io_blocksize( c );
+    /* Select effective I/O block size (e.g. 4 MiB) */
+    io_blocksize = c->device_io_block_size;
 
     /* For direct I/O we do not need periodic fdatasync(), I/O errors are detected
      * at write() time. Keep sync for cached I/O only. */
@@ -482,16 +465,8 @@ int nwipe_random_reverse_pass( NWIPE_METHOD_SIGNATURE )
         }
         else
         {
+            /* Last block may be smaller than I/O block size */
             blocksize = (size_t) z;
-
-            if( (u64) c->device_stat.st_blksize > z )
-            {
-                nwipe_log( NWIPE_LOG_WARNING,
-                           "%s: The size of '%s' is not a multiple of its block size %i.",
-                           __FUNCTION__,
-                           c->device_name,
-                           c->device_stat.st_blksize );
-            }
         }
 
         /* Ask the PRNG to fill "blocksize" bytes into the output buffer. */
@@ -757,7 +732,7 @@ int nwipe_random_forward_verify( NWIPE_METHOD_SIGNATURE )
         return -1;
     }
 
-    io_blocksize = nwipe_effective_io_blocksize( c );
+    io_blocksize = c->device_io_block_size;
 
     /* Allocate I/O buffers of the chosen block size (aligned for possible O_DIRECT). */
     b = (char*) nwipe_alloc_io_buffer( c, io_blocksize, 0, "random_verify input buffer" );
@@ -806,17 +781,8 @@ int nwipe_random_forward_verify( NWIPE_METHOD_SIGNATURE )
         }
         else
         {
+            /* Last block may be smaller than I/O block size */
             blocksize = (size_t) z;
-
-            /* Seatbelt: device size should normally be a multiple of st_blksize. */
-            if( (u64) c->device_stat.st_blksize > z )
-            {
-                nwipe_log( NWIPE_LOG_WARNING,
-                           "%s: The size of '%s' is not a multiple of its block size %i.",
-                           __FUNCTION__,
-                           c->device_name,
-                           c->device_stat.st_blksize );
-            }
         }
 
         /* Generate expected random data into pattern buffer. */
@@ -994,7 +960,7 @@ int nwipe_random_reverse_verify( NWIPE_METHOD_SIGNATURE )
         return -1;
     }
 
-    io_blocksize = nwipe_effective_io_blocksize( c );
+    io_blocksize = c->device_io_block_size;
 
     /* Allocate I/O buffers of the chosen block size (aligned for possible O_DIRECT). */
     b = (char*) nwipe_alloc_io_buffer( c, io_blocksize, 0, "random_verify input buffer" );
@@ -1025,17 +991,8 @@ int nwipe_random_reverse_verify( NWIPE_METHOD_SIGNATURE )
         }
         else
         {
+            /* Last block may be smaller than I/O block size */
             blocksize = (size_t) z;
-
-            /* Seatbelt: device size should normally be a multiple of st_blksize. */
-            if( (u64) c->device_stat.st_blksize > z )
-            {
-                nwipe_log( NWIPE_LOG_WARNING,
-                           "%s: The size of '%s' is not a multiple of its block size %i.",
-                           __FUNCTION__,
-                           c->device_name,
-                           c->device_stat.st_blksize );
-            }
         }
 
         /* Generate expected random data into pattern buffer. */

--- a/src/pass_scatter.c
+++ b/src/pass_scatter.c
@@ -1,0 +1,928 @@
+/*
+ * pass_scatter.c: Scattered-order device pass (write & verify)
+ * Author: Copyright (c) 2026 desertwitch (dezertwitsh@gmail.com)
+ * Based on: Fabian Druschke's original algorithm and implementation
+ */
+
+#define _POSIX_C_SOURCE 200809L
+#include "pass_internal.h"
+#include "splitmix64/splitmix64.h"
+
+#define FNV_OFFSET_BASIS 14695981039346656037ULL
+#define FNV_PRIME 1099511628211ULL
+
+/*
+ * Soft target number of scatter segments
+ * Controls the region between the hard min/max clamps
+ */
+#ifndef NWIPE_SCATTER_SEGMENTS
+#define NWIPE_SCATTER_SEGMENTS 200000ULL
+#endif
+
+/*
+ * Soft minimum segment size
+ * Prevents small devices from getting too small segments
+ * Ensures disk still gets throughput (next to mechanical exercise)
+ */
+#ifndef NWIPE_SCATTER_SEGMENT_MIN
+#define NWIPE_SCATTER_SEGMENT_MIN ( 4ULL * 1024 * 1024 )
+#endif
+
+/*
+ * Soft maximum segment size
+ * Prevents large devices from getting too big segments
+ * Ensures disk still gets mechanical exercise (next to throughput)
+ */
+#ifndef NWIPE_SCATTER_SEGMENT_MAX
+#define NWIPE_SCATTER_SEGMENT_MAX ( 16ULL * 1024 * 1024 )
+#endif
+
+/*
+ * -----------------------------------------------------------------------------
+ * Plan-related functions
+ * -----------------------------------------------------------------------------
+ */
+
+/* Ceiling division of n / d */
+static inline u64 ceiling_divide( u64 n, u64 d )
+{
+    return d ? ( n + d - 1 ) / d : 0;
+} /* ceiling_divide */
+
+/* Align value upwards (to next multiple of alignment base) */
+static u64 align_up( u64 n, u64 align )
+{
+    if( align == 0 || n % align == 0 )
+        return n;
+
+    return n + align - ( n % align );
+} /* align_up */
+
+/* Hash byte_count bytes into the running hash */
+static u64 fnv1a_hash_bytes( u64 hash, const void* data, size_t byte_count )
+{
+    const unsigned char* bytes = (const unsigned char*) data;
+
+    for( size_t idx = 0; idx < byte_count; idx++ )
+        hash = ( hash ^ bytes[idx] ) * FNV_PRIME;
+
+    return hash;
+} /* fnv1a_hash_bytes */
+
+/* Produce a pass-unique seed from a device context */
+static u64 seed_from_context( const nwipe_context_t* c )
+{
+    u64 hash = FNV_OFFSET_BASIS;
+
+    /* Hash these context properties so every pass has a unique seed */
+    hash = fnv1a_hash_bytes( hash, &c->device_size, sizeof( c->device_size ) );
+    hash = fnv1a_hash_bytes( hash, &c->round_working, sizeof( c->round_working ) );
+    hash = fnv1a_hash_bytes( hash, &c->pass_working, sizeof( c->pass_working ) );
+    hash = fnv1a_hash_bytes( hash, &c->round_count, sizeof( c->round_count ) );
+    hash = fnv1a_hash_bytes( hash, &c->pass_count, sizeof( c->pass_count ) );
+
+    /* Also hash the PRNG seed into the hash if it's a random pass */
+    if( c->prng_seed.s && c->prng_seed.length > 0 )
+        hash = fnv1a_hash_bytes( hash, c->prng_seed.s, c->prng_seed.length );
+
+    return hash;
+} /* seed_from_context */
+
+/* Produce a pass-unique seed from a device context and pattern */
+static u64 seed_from_context_and_pattern( const nwipe_context_t* c, const nwipe_pattern_t* p )
+{
+    u64 hash = seed_from_context( c );
+
+    hash = fnv1a_hash_bytes( hash, &p->length, sizeof( p->length ) );
+
+    if( p->s && p->length > 0 ) /* Just in case */
+        hash = fnv1a_hash_bytes( hash, p->s, (size_t) p->length );
+
+    return hash;
+} /* seed_from_context_and_pattern */
+
+/* Build a scatter plan given a seed, device size and I/O block size */
+static int plan_build( u64 seed, u64 device_size, size_t io_block_size, nwipe_scatter_plan_t* plan )
+{
+    splitmix64_state_t rng;
+    u64 segment_size;
+    u64 total_segments;
+    u64 half_count;
+    u64 write_cursor;
+    u64 first_half_cursor;
+    u64 second_half_cursor;
+    u64 pair_index;
+    u64 num_pairs;
+
+    memset( plan, 0, sizeof( *plan ) ); /* Zero it */
+
+    /* Find out how big each segment is (given wanted amount of segments) */
+    segment_size = ceiling_divide( device_size, NWIPE_SCATTER_SEGMENTS );
+
+    /* Clamp to minimum segment size if segment size is smaller */
+    if( segment_size < NWIPE_SCATTER_SEGMENT_MIN )
+        segment_size = NWIPE_SCATTER_SEGMENT_MIN;
+
+    /* Clamp to I/O block size if segment size is smaller than it */
+    if( segment_size < (u64) io_block_size )
+        segment_size = (u64) io_block_size;
+
+    /* Clamp to maximum segment size if segment size is larger than it */
+    if( segment_size > NWIPE_SCATTER_SEGMENT_MAX )
+        segment_size = NWIPE_SCATTER_SEGMENT_MAX;
+
+    /* Align segment size to I/O block size (to pass direct I/O) */
+    segment_size = align_up( segment_size, (u64) io_block_size );
+
+    /* Clamp to device size if segment exceeds it (small devices) */
+    if( segment_size > device_size )
+        segment_size = device_size;
+
+    /* Just in case, shouldn't happen here */
+    if( segment_size == 0 )
+    {
+        nwipe_log( NWIPE_LOG_SANITY, "%s: Segment size is zero", __FUNCTION__ );
+        return -1;
+    }
+
+    /* Calculate number of needed segments given each segment size */
+    total_segments = ceiling_divide( device_size, segment_size );
+
+    /* Just in case, shouldn't happen here */
+    if( total_segments == 0 )
+    {
+        nwipe_log( NWIPE_LOG_SANITY, "%s: Segment count is zero", __FUNCTION__ );
+        return -1;
+    }
+
+    plan->segment_size = segment_size;
+    plan->segment_count = total_segments;
+
+    /* Allocate an u64 for each segment - this is for the indices */
+    plan->visit_order = malloc( (size_t) total_segments * sizeof( *plan->visit_order ) );
+    if( !plan->visit_order )
+    {
+        nwipe_perror( errno, __FUNCTION__, "malloc" );
+        nwipe_log( NWIPE_LOG_FATAL, "%s: Failed to allocate visiting order", __FUNCTION__ );
+        return -1;
+    }
+
+    half_count = total_segments / 2;
+    first_half_cursor = 0; /* 0 - 50% of device */
+    second_half_cursor = half_count; /* 50 - 100% of device */
+    write_cursor = 0;
+
+    /* Interleave the segments so we produce long jumps on the device */
+    while( first_half_cursor < half_count || second_half_cursor < total_segments )
+    {
+        if( first_half_cursor < half_count ) /* Pick one from first half */
+            plan->visit_order[write_cursor++] = first_half_cursor++;
+        if( second_half_cursor < total_segments ) /* Pick one from second half */
+            plan->visit_order[write_cursor++] = second_half_cursor++;
+    }
+
+    /* Get PRNG set up for shuffling (swapping) the segments using seed */
+    if( splitmix64_prng_init( &rng, (const uint8_t*) &seed, sizeof( seed ) ) )
+    {
+        nwipe_log( NWIPE_LOG_FATAL, "%s: Failed to init SplitMix64 PRNG", __FUNCTION__ );
+        free( plan->visit_order );
+        plan->visit_order = NULL;
+        return -1;
+    }
+
+    /*
+     * Shuffle in pairs (to keep the long jumps in place)
+     * Each pair is one from first device half, one from second device half
+     */
+    num_pairs = total_segments / 2;
+
+    if( num_pairs > 1 )
+    {
+        /* Iterate over all pairs and swap them around */
+        for( pair_index = num_pairs - 1; pair_index > 0; pair_index-- )
+        {
+            u64 random_value;
+            u64 swap_target;
+
+            /* Get a random number we can map to a position in the array */
+            splitmix64_prng_genrand_to_buf( &rng, (uint8_t*) &random_value, sizeof( random_value ) );
+
+            /* Check if the internal PRNG did not just return zeroes */
+            if( pair_index == num_pairs - 1
+                && !nwipe_prng_is_active( (const char*) &random_value, sizeof( random_value ) ) )
+            {
+                nwipe_log( NWIPE_LOG_SANITY, "%s: SplitMix64 produced all zeroes", __FUNCTION__ );
+                free( plan->visit_order );
+                plan->visit_order = NULL;
+                return -1;
+            }
+
+            /* Map the random number to a pair index */
+            swap_target = random_value % ( pair_index + 1 );
+
+            /* We don't want to swap with ourselves */
+            if( swap_target != pair_index )
+            {
+                u64 current_pair_first = pair_index * 2; /* First element of source pair */
+                u64 target_pair_first = swap_target * 2; /* First element of target pair */
+                u64 temp;
+
+                /* Swap the first element of each pair. */
+                temp = plan->visit_order[current_pair_first];
+                plan->visit_order[current_pair_first] = plan->visit_order[target_pair_first];
+                plan->visit_order[target_pair_first] = temp;
+
+                /* Swap the second element of each pair (if there is one). */
+                if( current_pair_first + 1 < total_segments && target_pair_first + 1 < total_segments )
+                {
+                    temp = plan->visit_order[current_pair_first + 1];
+                    plan->visit_order[current_pair_first + 1] = plan->visit_order[target_pair_first + 1];
+                    plan->visit_order[target_pair_first + 1] = temp;
+                }
+            }
+        }
+    }
+
+    return 0;
+} /* plan_build */
+
+/* Releases the allocated memory and zeros the plan struct */
+static void plan_free( nwipe_scatter_plan_t* plan )
+{
+    free( plan->visit_order );
+    memset( plan, 0, sizeof( *plan ) );
+} /* plan_free */
+
+/* Get the offset and amount of bytes for a given visiting index */
+static void get_segment_range( const nwipe_scatter_plan_t* plan,
+                               u64 visit_index,
+                               u64 device_size,
+                               off64_t* offset_out,
+                               size_t* length_out )
+{
+    u64 segment_index = plan->visit_order[visit_index];
+    u64 byte_offset = segment_index * plan->segment_size;
+    u64 bytes_left = device_size - byte_offset;
+
+    /* Starting offset of the segment */
+    *offset_out = (off64_t) byte_offset;
+
+    /* Use full segment size or whatever bytes left if it's the last (smaller) segment. */
+    *length_out = (size_t) ( bytes_left < plan->segment_size ? bytes_left : plan->segment_size );
+
+} /* get_segment_range */
+
+/*
+ * -----------------------------------------------------------------------------
+ * I/O functions
+ * -----------------------------------------------------------------------------
+ */
+
+/* This is the filling callback we use for PRNG */
+static int fill_prng( nwipe_context_t* c, char* buffer, size_t length, off64_t device_offset, void* opaque )
+{
+    (void) device_offset; /* not needed */
+    (void) opaque; /* not needed */
+
+    /* Read PRNG into buffer */
+    c->prng->read( &c->prng_state, buffer, length );
+
+    return 0;
+} /* fill_prng */
+
+/* This is the filling callback we use for static patterns */
+static int fill_pattern( nwipe_context_t* c, char* buffer, size_t length, off64_t device_offset, void* opaque )
+{
+    (void) c; /* not needed */
+    nwipe_scatter_patt_ctx_t* fill_ctx = (nwipe_scatter_patt_ctx_t*) opaque;
+
+    /* Window into the pattern for the requested offset */
+    int w = (int) ( device_offset % (off64_t) fill_ctx->pattern_length );
+
+    /* Buffer is guaranteed aligned and large enough for our use */
+    memcpy( buffer, &fill_ctx->pattern_buffer[w], length );
+
+    return 0;
+} /* fill_pattern */
+
+/* Generic I/O writing function taking a filling callback */
+static int scatter_write( nwipe_context_t* c,
+                          const nwipe_scatter_plan_t* plan,
+                          size_t io_blocksize,
+                          nwipe_scatter_fill_fn fill,
+                          void* fill_context )
+{
+    int r;
+    int i = 0;
+    int is_first_block = 1;
+    u64 z = c->device_size;
+    u64 bs = 0;
+    u64 visit_index;
+    char* b;
+    int syncRate;
+
+    if( c->io_mode == NWIPE_IO_MODE_DIRECT ) /* for direct I/O */
+    {
+        syncRate = 0;
+        nwipe_log( NWIPE_LOG_NOTICE, "Disabled fdatasync for %s, DirectI/O in use.", c->device_name );
+    }
+    else /* for cached I/O */
+    {
+        syncRate = nwipe_compute_sync_rate_for_device( c, io_blocksize );
+    }
+
+    /* Allocate buffer for writing */
+    b = (char*) nwipe_alloc_io_buffer( c, io_blocksize, 1, "scatter_write" );
+    if( !b )
+    {
+        nwipe_log( NWIPE_LOG_FATAL, "%s: Failed to allocate write buffer", __FUNCTION__ );
+        return -1;
+    }
+
+    /* Reset pass byte counter */
+    c->pass_done = 0;
+
+    /* Iterate over the entire visiting array */
+    for( visit_index = 0; visit_index < plan->segment_count; visit_index++ )
+    {
+        off64_t segment_offset; /* Byte offset where segment starts */
+        size_t segment_length; /* Byte length of segment */
+        size_t segment_bytes_done = 0; /* Bytes written within segment */
+
+        /* Populate the offset and length with the segment information */
+        get_segment_range( plan, visit_index, c->device_size, &segment_offset, &segment_length );
+
+        /* Write the segment in I/O-block-sized chunks. */
+        while( segment_bytes_done < segment_length )
+        {
+            off64_t current_offset = segment_offset + (off64_t) segment_bytes_done;
+            size_t blocksize = io_blocksize;
+
+            /* Last block of the segment may be smaller than an I/O block */
+            if( blocksize > segment_length - segment_bytes_done )
+                blocksize = segment_length - segment_bytes_done;
+
+            /* Ask callback for blocksize bytes of data into our buffer */
+            if( fill( c, b, blocksize, current_offset, fill_context ) )
+            {
+                nwipe_log( NWIPE_LOG_FATAL, "%s: Failed to fill write buffer", __FUNCTION__ );
+                free( b );
+                return -1;
+            }
+
+            /* Check if PRNG is active (if it's the PRNG callback) */
+            if( is_first_block )
+            {
+                if( fill == fill_prng && !nwipe_prng_is_active( b, blocksize ) )
+                {
+                    nwipe_log( NWIPE_LOG_SANITY, "%s: PRNG produced all zeroes", __FUNCTION__ );
+                    free( b );
+                    return -1;
+                }
+                is_first_block = 0;
+            }
+
+            /* Write at the calculated offset */
+            r = (int) nwipe_pwrite_with_retry( c, c->device_fd, b, blocksize, current_offset );
+
+            if( r < 0 ) /* Write failure */
+            {
+                c->pass_errors++;
+
+                if( nwipe_options.noabort_block_errors )
+                {
+                    nwipe_perror( errno, __FUNCTION__, "pwrite" );
+                    nwipe_log( NWIPE_LOG_ERROR,
+                               "Write error on '%s' at offset %lld, skipping %zu bytes.",
+                               c->device_name,
+                               (long long) current_offset,
+                               blocksize );
+
+                    /* Logically count the skipped bytes */
+                    z -= (u64) blocksize;
+                    bs += (u64) blocksize;
+                    c->round_done += (u64) blocksize;
+                    segment_bytes_done += blocksize;
+
+                    pthread_testcancel();
+                    continue;
+                }
+
+                /* Default error case (abort wipe) */
+                nwipe_perror( errno, __FUNCTION__, "pwrite" );
+                nwipe_log( NWIPE_LOG_FATAL,
+                           "Write failed on '%s' at offset %lld.",
+                           c->device_name,
+                           (long long) current_offset );
+                free( b );
+                return -1;
+            }
+
+            if( r != (int) blocksize ) /* Write short */
+            {
+                int s = (int) blocksize - r;
+
+                /* Increase error count since we skipped bytes */
+                c->pass_errors++;
+
+                nwipe_log( NWIPE_LOG_ERROR,
+                           "Short write on '%s' at offset %lld, %i bytes short.",
+                           c->device_name,
+                           (long long) current_offset,
+                           s );
+
+                /* Logically count the skipped bytes */
+                z -= (u64) s;
+                bs += (u64) s;
+                c->round_done += (u64) s;
+                segment_bytes_done += (size_t) s;
+            }
+
+            /* Count the actually out written bytes */
+            z -= (u64) r;
+            c->pass_done += (u64) r;
+            c->round_done += (u64) r;
+            segment_bytes_done += (size_t) r;
+
+            nwipe_update_bytes_erased( c, z, bs, 0 );
+
+            /* Periodic sync if requested. */
+            if( syncRate > 0 )
+            {
+                i++;
+
+                if( i >= syncRate )
+                {
+                    r = nwipe_fdatasync( c, __FUNCTION__ );
+
+                    if( r == 0 )
+                    {
+                        nwipe_update_bytes_erased( c, z, bs, 1 );
+                    }
+
+                    if( r == -1 )
+                    {
+                        free( b );
+                        return -1;
+                    }
+
+                    i = 0;
+                }
+            }
+
+            pthread_testcancel();
+        } /* while (in a segment) */
+
+        pthread_testcancel();
+    } /* for (each segment) */
+
+    free( b );
+
+    /* Final sync at end of pass. */
+    r = nwipe_fdatasync( c, __FUNCTION__ );
+    if( r == 0 )
+        nwipe_update_bytes_erased( c, z, bs, 1 );
+    if( r == -1 )
+        return -1;
+
+    return 0;
+} /* scatter_write */
+
+/* Generic I/O verification function taking a filling callback */
+static int scatter_verify( nwipe_context_t* c,
+                           const nwipe_scatter_plan_t* plan,
+                           size_t io_blocksize,
+                           nwipe_scatter_fill_fn fill,
+                           void* fill_context )
+{
+    int r;
+    int is_first_block = 1;
+    u64 z = c->device_size;
+    u64 visit_index;
+    char* b;
+    char* d;
+
+    /* Allocate read buffer (what we read from disk) */
+    b = (char*) nwipe_alloc_io_buffer( c, io_blocksize, 0, "scatter_vfy_rd" );
+    if( !b )
+    {
+        nwipe_log( NWIPE_LOG_FATAL, "%s: Failed to allocate read buffer", __FUNCTION__ );
+        return -1;
+    }
+
+    /* Allocate pattern buffer (what we want to compare against) */
+    d = (char*) nwipe_alloc_io_buffer( c, io_blocksize, 0, "scatter_vfy_pat" );
+    if( !d )
+    {
+        nwipe_log( NWIPE_LOG_FATAL, "%s: Failed to allocate pattern buffer", __FUNCTION__ );
+        free( b );
+        return -1;
+    }
+
+    /* Reset pass byte counter */
+    c->pass_done = 0;
+
+    /* Flush any pending writes to disk before starting */
+    nwipe_fdatasync( c, __FUNCTION__ );
+
+    /* Iterate over the entire visiting array */
+    for( visit_index = 0; visit_index < plan->segment_count; visit_index++ )
+    {
+        off64_t segment_offset; /* Byte offset where segment starts */
+        size_t segment_length; /* Byte length of segment */
+        size_t segment_bytes_done = 0; /* Bytes verified within segment */
+
+        /* Populate the offset and length with the segment information */
+        get_segment_range( plan, visit_index, c->device_size, &segment_offset, &segment_length );
+
+        /* Read the segment in I/O-sized blocks */
+        while( segment_bytes_done < segment_length )
+        {
+            off64_t current_offset = segment_offset + (off64_t) segment_bytes_done;
+            size_t blocksize = io_blocksize;
+
+            /* Last block of the segment may be smaller than an I/O block */
+            if( blocksize > segment_length - segment_bytes_done )
+                blocksize = segment_length - segment_bytes_done;
+
+            /* Generate the expected data using our callback function */
+            if( fill( c, d, blocksize, current_offset, fill_context ) )
+            {
+                nwipe_log( NWIPE_LOG_FATAL, "%s: Failed to fill pattern buffer", __FUNCTION__ );
+                free( b );
+                free( d );
+                return -1;
+            }
+
+            /* Check if PRNG is active (if it's the PRNG callback) */
+            if( is_first_block )
+            {
+                if( fill == fill_prng && !nwipe_prng_is_active( d, blocksize ) )
+                {
+                    nwipe_log( NWIPE_LOG_SANITY, "%s: PRNG produced all zeroes", __FUNCTION__ );
+                    free( b );
+                    free( d );
+                    return -1;
+                }
+                is_first_block = 0;
+            }
+
+            /* Read at the calculated offset */
+            r = (int) nwipe_pread_with_retry( c, c->device_fd, b, blocksize, current_offset );
+
+            if( r < 0 ) /* Read failure */
+            {
+                c->verify_errors++;
+
+                if( nwipe_options.noabort_block_errors )
+                {
+                    nwipe_perror( errno, __FUNCTION__, "pread" );
+                    nwipe_log( NWIPE_LOG_ERROR,
+                               "Read error on '%s' at offset %lld, skipping %zu bytes.",
+                               c->device_name,
+                               (long long) current_offset,
+                               blocksize );
+
+                    /* Logically count the skipped bytes */
+                    z -= (u64) blocksize;
+                    c->round_done += (u64) blocksize;
+                    segment_bytes_done += blocksize;
+
+                    pthread_testcancel();
+                    continue;
+                }
+
+                /* Default error case (abort verification) */
+                nwipe_perror( errno, __FUNCTION__, "pread" );
+                nwipe_log(
+                    NWIPE_LOG_FATAL, "Read error on '%s' at offset %lld.", c->device_name, (long long) current_offset );
+                free( b );
+                free( d );
+                return -1;
+            }
+
+            if( r != (int) blocksize ) /* Read short */
+            {
+                int s = (int) blocksize - r;
+
+                /* Increase verify errors since we skipped bytes */
+                c->verify_errors++;
+
+                nwipe_log( NWIPE_LOG_ERROR,
+                           "Short read on '%s' at offset %lld, %i bytes short.",
+                           c->device_name,
+                           (long long) current_offset,
+                           s );
+
+                z -= (u64) s;
+                c->round_done += (u64) s;
+                segment_bytes_done += (size_t) s;
+            }
+
+            /* Compare the bytes we did actually read */
+            if( memcmp( b, d, (size_t) r ) != 0 )
+            {
+                c->verify_errors++;
+            }
+
+            /* Count the actually read bytes */
+            z -= (u64) r;
+            c->pass_done += (u64) r;
+            c->round_done += (u64) r;
+            segment_bytes_done += (size_t) r;
+
+            pthread_testcancel();
+        } /* while (in a segment) */
+
+        pthread_testcancel();
+    } /* for (each segment) */
+
+    free( b );
+    free( d );
+
+    return 0;
+} /* scatter_verify */
+
+/*
+ * -----------------------------------------------------------------------------
+ * Helper functions
+ * -----------------------------------------------------------------------------
+ */
+
+/* Self-tests the scatter seeding mechanism (0 = success, -1 = failure) */
+static int self_test_scatter_seed()
+{
+    nwipe_context_t ctx1, ctx2;
+    nwipe_pattern_t patt1;
+    u64 hash_base, hash_alt;
+
+    memset( &ctx1, 0, sizeof( ctx1 ) ); /* Zero it */
+    ctx1.device_size = 123456789ULL;
+    ctx1.round_working = 1;
+    ctx1.pass_working = 1;
+
+    hash_base = seed_from_context( &ctx1 );
+
+    if( hash_base != seed_from_context( &ctx1 ) )
+    {
+        nwipe_log( NWIPE_LOG_SANITY, "%s: Scatter seed is non-deterministic.", __FUNCTION__ );
+        return -1;
+    }
+
+    ctx2 = ctx1;
+    ctx2.pass_working = 2;
+
+    if( hash_base == seed_from_context( &ctx2 ) )
+    {
+        nwipe_log( NWIPE_LOG_SANITY, "%s: Scatter seed is same after pass changed.", __FUNCTION__ );
+        return -1;
+    }
+
+    memset( &patt1, 0, sizeof( patt1 ) ); /* Zero it */
+    patt1.s = (char*) "\x92\x49\x24"; /* Borrowed from Gutmann... ;-) */
+    patt1.length = 3;
+
+    hash_base = seed_from_context_and_pattern( &ctx1, &patt1 );
+
+    if( hash_base != seed_from_context_and_pattern( &ctx1, &patt1 ) )
+    {
+        nwipe_log( NWIPE_LOG_SANITY, "%s: Scatter seed is non-deterministic (with pattern).", __FUNCTION__ );
+        return -1;
+    }
+
+    ctx2 = ctx1;
+    ctx2.device_size = 123456780ULL;
+
+    hash_alt = seed_from_context_and_pattern( &ctx2, &patt1 );
+
+    if( hash_base == hash_alt )
+    {
+        nwipe_log( NWIPE_LOG_SANITY, "%s: Scatter seed is same after device size changed.", __FUNCTION__ );
+        return -1;
+    }
+
+    return 0;
+} /* self_test_scatter_seed */
+
+/* Logs the plan parameters so the user knows what values it's using. */
+static void log_plan( const nwipe_context_t* c, const nwipe_scatter_plan_t* plan )
+{
+    nwipe_log( NWIPE_LOG_NOTICE,
+               "Scatter plan for '%s': segment=%llu, count=%llu.",
+               c->device_name,
+               (unsigned long long) plan->segment_size,
+               (unsigned long long) plan->segment_count );
+} /* log_plan */
+
+/*
+ * Pre-build a given repeating pattern buffer.
+ * Internally allocates the fill_ctx->pattern_buffer.
+ * Caller must make sure to free() it when done with it.
+ */
+static int init_pattern_fill_ctx( const nwipe_context_t* c,
+                                  const nwipe_pattern_t* pattern,
+                                  size_t io_block_size,
+                                  nwipe_scatter_patt_ctx_t* fill_ctx )
+{
+    char* stamp_cursor;
+
+    fill_ctx->pattern_length = pattern->length;
+
+    /*
+     * Allocate enough memory for the pattern buffer
+     * Each window into the buffer must offer at least one io_block_size
+     */
+    fill_ctx->pattern_buffer =
+        (char*) nwipe_alloc_io_buffer( c, io_block_size + (size_t) pattern->length * 2, 0, "scatter_pat" );
+    if( !fill_ctx->pattern_buffer )
+    {
+        nwipe_log( NWIPE_LOG_FATAL, "%s: Failed to allocate pattern buffer", __FUNCTION__ );
+        return -1;
+    }
+
+    /* Stamp pattern into the entire buffer so any window into it is valid */
+    for( stamp_cursor = fill_ctx->pattern_buffer;
+         stamp_cursor < fill_ctx->pattern_buffer + io_block_size + pattern->length;
+         stamp_cursor += pattern->length )
+    {
+        memcpy( stamp_cursor, pattern->s, (size_t) pattern->length );
+    }
+
+    return 0;
+} /* init_pattern_fill_ctx */
+
+/*
+ * -----------------------------------------------------------------------------
+ * Public functions
+ * -----------------------------------------------------------------------------
+ */
+
+int nwipe_random_scatter_pass( NWIPE_METHOD_SIGNATURE )
+{
+    nwipe_scatter_plan_t plan;
+    size_t io_block_size = c->device_io_block_size;
+    int r;
+
+    if( !c->prng_seed.s || c->prng_seed.length <= 0 )
+    {
+        nwipe_log( NWIPE_LOG_SANITY, "%s: Bad PRNG seed", __FUNCTION__ );
+        return -1;
+    }
+
+    /* Self test the seeding mechanism */
+    if( self_test_scatter_seed() != 0 )
+    {
+        nwipe_log( NWIPE_LOG_SANITY, "%s: Bad scatter seeding", __FUNCTION__ );
+        return -1;
+    }
+
+    /* Build the scattering plan */
+    if( plan_build( seed_from_context( c ), c->device_size, io_block_size, &plan ) )
+    {
+        nwipe_log( NWIPE_LOG_FATAL, "%s: Failed to build scatter plan", __FUNCTION__ );
+        return -1;
+    }
+
+    log_plan( c, &plan );
+
+    /* Seed the wipe PRNG */
+    c->prng->init( &c->prng_state, &c->prng_seed );
+
+    /* Write using the PRNG filling callback. */
+    r = scatter_write( c, &plan, io_block_size, fill_prng, NULL );
+
+    plan_free( &plan );
+
+    return r;
+} /* nwipe_random_scatter_pass */
+
+int nwipe_random_scatter_verify( NWIPE_METHOD_SIGNATURE )
+{
+    nwipe_scatter_plan_t plan;
+    size_t io_block_size = c->device_io_block_size;
+    int r;
+
+    if( !c->prng_seed.s || c->prng_seed.length <= 0 )
+    {
+        nwipe_log( NWIPE_LOG_SANITY, "%s: Bad PRNG seed", __FUNCTION__ );
+        return -1;
+    }
+
+    /* Self test the seeding mechanism */
+    if( self_test_scatter_seed() != 0 )
+    {
+        nwipe_log( NWIPE_LOG_SANITY, "%s: Bad scatter seeding", __FUNCTION__ );
+        return -1;
+    }
+
+    /* Build the scattering plan (same one as write pass) */
+    if( plan_build( seed_from_context( c ), c->device_size, io_block_size, &plan ) )
+    {
+        nwipe_log( NWIPE_LOG_FATAL, "%s: Failed to build scatter plan", __FUNCTION__ );
+        return -1;
+    }
+
+    log_plan( c, &plan );
+
+    /* Re-seed the PRNG to starting state (same one as write pass) */
+    c->prng->init( &c->prng_state, &c->prng_seed );
+
+    /* Read and compare using the PRNG filling callback. */
+    r = scatter_verify( c, &plan, io_block_size, fill_prng, NULL );
+
+    plan_free( &plan );
+
+    return r;
+} /* nwipe_random_scatter_verify */
+
+int nwipe_static_scatter_pass( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* pattern )
+{
+    nwipe_scatter_plan_t plan;
+    nwipe_scatter_patt_ctx_t fill_ctx;
+    size_t io_block_size = c->device_io_block_size;
+    int r;
+
+    if( !pattern || pattern->length <= 0 )
+    {
+        nwipe_log( NWIPE_LOG_SANITY, "%s: Bad static pattern", __FUNCTION__ );
+        return -1;
+    }
+
+    /* Self test the seeding mechanism */
+    if( self_test_scatter_seed() != 0 )
+    {
+        nwipe_log( NWIPE_LOG_SANITY, "%s: Bad scatter seeding", __FUNCTION__ );
+        return -1;
+    }
+
+    /* Build the scattering plan */
+    if( plan_build( seed_from_context_and_pattern( c, pattern ), c->device_size, io_block_size, &plan ) )
+    {
+        nwipe_log( NWIPE_LOG_FATAL, "%s: Failed to build scatter plan", __FUNCTION__ );
+        return -1;
+    }
+
+    log_plan( c, &plan );
+
+    /* Build the repeating pattern buffer */
+    if( init_pattern_fill_ctx( c, pattern, io_block_size, &fill_ctx ) )
+    {
+        nwipe_log( NWIPE_LOG_FATAL, "%s: Failed to build pattern buffer", __FUNCTION__ );
+        plan_free( &plan );
+        return -1;
+    }
+
+    /* Write using the static filling callback. */
+    r = scatter_write( c, &plan, io_block_size, fill_pattern, &fill_ctx );
+
+    free( fill_ctx.pattern_buffer );
+    plan_free( &plan );
+
+    return r;
+} /* nwipe_static_scatter_pass */
+
+int nwipe_static_scatter_verify( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* pattern )
+{
+    nwipe_scatter_plan_t plan;
+    nwipe_scatter_patt_ctx_t fill_ctx;
+    size_t io_block_size = c->device_io_block_size;
+    int r;
+
+    if( !pattern || pattern->length <= 0 )
+    {
+        nwipe_log( NWIPE_LOG_SANITY, "%s: Bad static pattern", __FUNCTION__ );
+        return -1;
+    }
+
+    /* Self test the seeding mechanism */
+    if( self_test_scatter_seed() != 0 )
+    {
+        nwipe_log( NWIPE_LOG_SANITY, "%s: Bad scatter seeding", __FUNCTION__ );
+        return -1;
+    }
+
+    /* Build the scattering plan (same one as write pass) */
+    if( plan_build( seed_from_context_and_pattern( c, pattern ), c->device_size, io_block_size, &plan ) )
+    {
+        nwipe_log( NWIPE_LOG_FATAL, "%s: Failed to build scatter plan", __FUNCTION__ );
+        return -1;
+    }
+
+    log_plan( c, &plan );
+
+    /* Build the repeating pattern buffer (same one as write pass) */
+    if( init_pattern_fill_ctx( c, pattern, io_block_size, &fill_ctx ) )
+    {
+        nwipe_log( NWIPE_LOG_FATAL, "%s: Failed to build pattern buffer", __FUNCTION__ );
+        plan_free( &plan );
+        return -1;
+    }
+
+    /* Read and compare using the static filling callback. */
+    r = scatter_verify( c, &plan, io_block_size, fill_pattern, &fill_ctx );
+
+    free( fill_ctx.pattern_buffer );
+    plan_free( &plan );
+
+    return r;
+} /* nwipe_static_scatter_verify */

--- a/src/pass_scatter.c
+++ b/src/pass_scatter.c
@@ -623,6 +623,18 @@ static int scatter_verify( nwipe_context_t* c,
             if( memcmp( b, d, (size_t) r ) != 0 )
             {
                 c->verify_errors++;
+
+                /* Abort verification unless noabort_block_errors is enabled */
+                if( !nwipe_options.noabort_block_errors )
+                {
+                    nwipe_log( NWIPE_LOG_FATAL,
+                               "Verification mismatch on '%s' at offset %lld",
+                               c->device_name,
+                               (long long) current_offset );
+                    free( b );
+                    free( d );
+                    return -1;
+                }
             }
 
             /* Count the actually read bytes */

--- a/src/pass_static.c
+++ b/src/pass_static.c
@@ -49,7 +49,7 @@ int nwipe_static_forward_pass( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* pattern 
 
     int syncRate = nwipe_options.sync;
 
-    io_blocksize = nwipe_effective_io_blocksize( c );
+    io_blocksize = c->device_io_block_size;
 
     /* For direct I/O we do not need periodic fdatasync(), I/O errors are detected
      * at write() time. Keep sync for cached I/O only. */
@@ -138,16 +138,8 @@ int nwipe_static_forward_pass( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* pattern 
         }
         else
         {
+            /* Last block may be smaller than I/O block size */
             blocksize = (size_t) z;
-
-            if( (u64) c->device_stat.st_blksize > z )
-            {
-                nwipe_log( NWIPE_LOG_WARNING,
-                           "%s: The size of '%s' is not a multiple of its block size %i.",
-                           __FUNCTION__,
-                           c->device_name,
-                           c->device_stat.st_blksize );
-            }
         }
 
         /* Record the offset we're at before the write. */
@@ -258,15 +250,6 @@ int nwipe_static_forward_pass( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* pattern 
 
             if( c->device_size % (u64) io_blocksize != 0 )
             {
-                if( c->device_size % (u64) c->device_stat.st_blksize != 0 )
-                {
-                    nwipe_log( NWIPE_LOG_WARNING,
-                               "%s: The size of '%s' is not a multiple of its block size %i.",
-                               __FUNCTION__,
-                               c->device_name,
-                               c->device_stat.st_blksize );
-                }
-
                 /* The last block of the device is smaller than our I/O blocksize, adjust it */
                 rev_offset = (off64_t) ( c->device_size - ( c->device_size % (u64) io_blocksize ) );
                 rev_blocksize = (size_t) ( c->device_size % (u64) io_blocksize );
@@ -474,7 +457,7 @@ int nwipe_static_reverse_pass( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* pattern 
 
     int syncRate = nwipe_options.sync;
 
-    io_blocksize = nwipe_effective_io_blocksize( c );
+    io_blocksize = c->device_io_block_size;
 
     /* For direct I/O we do not need periodic fdatasync(), I/O errors are detected
      * at write() time. Keep sync for cached I/O only. */
@@ -545,16 +528,8 @@ int nwipe_static_reverse_pass( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* pattern 
         }
         else
         {
+            /* Last block may be smaller than I/O block size */
             blocksize = (size_t) z;
-
-            if( (u64) c->device_stat.st_blksize > z )
-            {
-                nwipe_log( NWIPE_LOG_WARNING,
-                           "%s: The size of '%s' is not a multiple of its block size %i.",
-                           __FUNCTION__,
-                           c->device_name,
-                           c->device_stat.st_blksize );
-            }
         }
 
         /* Record the offset we're at before the write (reverse-adjusted). */
@@ -849,7 +824,7 @@ int nwipe_static_forward_verify( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* patter
         return -1;
     }
 
-    io_blocksize = nwipe_effective_io_blocksize( c );
+    io_blocksize = c->device_io_block_size;
 
     b = (char*) nwipe_alloc_io_buffer( c, io_blocksize, 0, "static_verify input buffer" );
     if( !b )
@@ -906,16 +881,8 @@ int nwipe_static_forward_verify( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* patter
         }
         else
         {
+            /* Last block may be smaller than I/O block size */
             blocksize = (size_t) z;
-
-            if( (u64) c->device_stat.st_blksize > z )
-            {
-                nwipe_log( NWIPE_LOG_WARNING,
-                           "%s: The size of '%s' is not a multiple of its block size %i.",
-                           __FUNCTION__,
-                           c->device_name,
-                           c->device_stat.st_blksize );
-            }
         }
 
         /* Record the offset we're at before the read. */
@@ -1088,7 +1055,7 @@ int nwipe_static_reverse_verify( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* patter
         return -1;
     }
 
-    io_blocksize = nwipe_effective_io_blocksize( c );
+    io_blocksize = c->device_io_block_size;
 
     b = (char*) nwipe_alloc_io_buffer( c, io_blocksize, 0, "static_verify input buffer" );
     if( !b )
@@ -1127,16 +1094,8 @@ int nwipe_static_reverse_verify( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* patter
         }
         else
         {
+            /* Last block may be smaller than I/O block size */
             blocksize = (size_t) z;
-
-            if( (u64) c->device_stat.st_blksize > z )
-            {
-                nwipe_log( NWIPE_LOG_WARNING,
-                           "%s: The size of '%s' is not a multiple of its block size %i.",
-                           __FUNCTION__,
-                           c->device_name,
-                           c->device_stat.st_blksize );
-            }
         }
 
         /* Record the offset we're at before the read (reverse-adjusted). */

--- a/src/pass_static.c
+++ b/src/pass_static.c
@@ -1002,6 +1002,18 @@ int nwipe_static_forward_verify( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* patter
         if( memcmp( b, &d[w], (size_t) r ) != 0 )
         {
             c->verify_errors += 1;
+
+            /* Abort verification unless noabort_block_errors is enabled */
+            if( !nwipe_options.noabort_block_errors )
+            {
+                nwipe_log( NWIPE_LOG_FATAL,
+                           "Verification mismatch on '%s' at offset %lld",
+                           c->device_name,
+                           (long long) current_offset );
+                free( b );
+                free( d );
+                return -1;
+            }
         }
 
         z -= (u64) r;
@@ -1184,6 +1196,18 @@ int nwipe_static_reverse_verify( NWIPE_METHOD_SIGNATURE, nwipe_pattern_t* patter
         if( memcmp( b, &d[w], (size_t) r ) != 0 )
         {
             c->verify_errors += 1;
+
+            /* Abort verification unless noabort_block_errors is enabled */
+            if( !nwipe_options.noabort_block_errors )
+            {
+                nwipe_log( NWIPE_LOG_FATAL,
+                           "Verification mismatch on '%s' at offset %lld",
+                           c->device_name,
+                           (long long) current_offset );
+                free( b );
+                free( d );
+                return -1;
+            }
         }
 
         z -= (u64) r;

--- a/tests/ci/loopback_e2e.sh
+++ b/tests/ci/loopback_e2e.sh
@@ -172,15 +172,18 @@ run_nwipe_case() {
     local method="$3"
     local verify="$4"
     local prng="${5:-isaac}"
-    local reverse="${6:-0}"
+    local iodirection="${6:-0}"
 
     local log_file="${LOG_DIR}/${case_name}.log"
     local stdout_file="${LOG_DIR}/${case_name}.stdout"
     local stderr_file="${LOG_DIR}/${case_name}.stderr"
 
-    local reverse_flag=""
-    if [[ "${reverse}" -eq 1 ]]; then
-        reverse_flag="--reverse"
+    local iodirection_flag=""
+    if [[ "${iodirection}" -eq 1 ]]; then
+        iodirection_flag="--reverse"
+    fi
+    if [[ "${iodirection}" -eq 2 ]]; then
+        iodirection_flag="--scatter"
     fi
 
     echo "==> Running case: ${case_name} (io=${io} method=${method}, verify=${verify}, prng=${prng})"
@@ -197,7 +200,7 @@ run_nwipe_case() {
         --verify="${verify}" \
         --method="${method}" \
         --prng="${prng}" \
-        ${reverse_flag} \
+        ${iodirection_flag} \
         --PDFreportpath=noPDF \
         --logfile="${log_file}" \
         "${LOOP_DEV}" \
@@ -230,35 +233,41 @@ echo "Using nwipe binary: ${NWIPE_BIN}"
 "${NWIPE_BIN}" --version || true
 
 # Zero wipe + zero verify, direct I/O
-run_nwipe_case "wipe_zero" "directio" "zero" "all"
+run_nwipe_case "direct_wipe_zero" "directio" "zero" "all"
 assert_block_is_byte "00"
-run_nwipe_case "verify_zero" "directio" "verify_zero" "off"
+run_nwipe_case "direct_verify_zero" "directio" "verify_zero" "off"
 
 # Zero wipe + zero verify, cached I/O
-run_nwipe_case "wipe_zero" "cachedio" "zero" "all"
+run_nwipe_case "cached_wipe_zero" "cachedio" "zero" "all"
 assert_block_is_byte "00"
-run_nwipe_case "verify_zero" "cachedio" "verify_zero" "off"
+run_nwipe_case "cached_verify_zero" "cachedio" "verify_zero" "off"
 
 if [[ "${MODE}" == "full" ]]; then
     # One wipe + one verify, direct I/O
-    run_nwipe_case "wipe_one" "directio" "one" "all"
+    run_nwipe_case "direct_wipe_one" "directio" "one" "all"
     assert_block_is_byte "ff"
-    run_nwipe_case "verify_one" "directio" "verify_one" "off"
+    run_nwipe_case "direct_verify_one" "directio" "verify_one" "off"
 
     # One wipe + one verify, cached I/O
-    run_nwipe_case "wipe_one" "cachedio" "one" "all"
+    run_nwipe_case "cached_wipe_one" "cachedio" "one" "all"
     assert_block_is_byte "ff"
-    run_nwipe_case "verify_one" "cachedio" "verify_one" "off"
+    run_nwipe_case "cached_verify_one" "cachedio" "verify_one" "off"
 
     # PRNG wipe + PRNG verification, direct + cached I/O
-    run_nwipe_case "wipe_prng" "directio" "prng" "all"
-    run_nwipe_case "wipe_prng" "cachedio" "prng" "all"
+    run_nwipe_case "direct_wipe_prng" "directio" "prng" "all"
+    run_nwipe_case "cached_wipe_prng" "cachedio" "prng" "all"
 
     # Run --reverse tests (different routines), direct + cached I/O:
-    run_nwipe_case "reverse_wipe_one" "directio" "one" "all" "isaac" 1
-    run_nwipe_case "reverse_wipe_prng" "directio" "prng" "all" "isaac" 1
-    run_nwipe_case "reverse_wipe_one" "cachedio" "one" "all" "isaac" 1
-    run_nwipe_case "reverse_wipe_prng" "cachedio" "prng" "all" "isaac" 1
+    run_nwipe_case "direct_reverse_wipe_one" "directio" "one" "all" "isaac" 1
+    run_nwipe_case "direct_reverse_wipe_prng" "directio" "prng" "all" "isaac" 1
+    run_nwipe_case "cached_reverse_wipe_one" "cachedio" "one" "all" "isaac" 1
+    run_nwipe_case "cached_reverse_wipe_prng" "cachedio" "prng" "all" "isaac" 1
+
+    # Run --scatter tests (different routines), direct + cached I/O:
+    run_nwipe_case "direct_scatter_wipe_one" "directio" "one" "all" "isaac" 2
+    run_nwipe_case "direct_scatter_wipe_prng" "directio" "prng" "all" "isaac" 2
+    run_nwipe_case "cached_scatter_wipe_one" "cachedio" "one" "all" "isaac" 2
+    run_nwipe_case "cached_scatter_wipe_prng" "cachedio" "prng" "all" "isaac" 2
 
     # PRNG statistical cases (STS)
     # Run these in direct I/O so we're not verifying a cache


### PR DESCRIPTION
### Updated PR as of 15/03/2026:

- Fixes for device geometry (centralized calculations, use correct alignment for I/O direct)
- New I/O scattering mode (complete re-write of #738 )
- Verification stops at first failure by default (as discussed in #572 )

closes #572

---

### Original PR as of 10/03/2026:

This fixes several brittle code paths and issues surrounding device geometry and direct I/O requirements.

- `st_blksize` is not the alignment for block device direct I/O (it is a hint for buffered/cached IO)
- `st_blksize` as an external signed type is not safe for direct use in calculations as if it were unsigned

This always worked by luck because on most operating systems `st_blksize` is `4096` (a multiple of 512).
It was likely 1-1 used from the previous cached I/O code where this was indeed the correct variable to use.
But if a device was ever not 512-aligned, or the OS presented a different `st_blksize`, direct I/O would break.

- `_IOR` internally does `sizeof` so it expects a type, not `sizeof(u64)` which leads to `sizeof(sizeof(u64))`
- We should fall back to libparted values if kernel `ioctl` fails, not reset the sectors to `0` and continue with `0`
- A `continue;` on a `nwipe.c` error would have nwipe stuck in an infinite loop waiting for a never-started thread
- Warning about device size not aligning with logical sector size falsely triggered under `st_blksize` on direct I/O
- Calculations for I/O block size and alignment should be done once centrally instead of multiple times elsewhere

The code establishing this important "baseline" was cleaned up and moved to central locations to be reusable.
The device geometry is now sanity-checked and presented nicely in the logs, so it's clear what I/O is really using.