### PR TITLE
Extract report helpers in preparation for unified report API

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,8 +2,8 @@
 #CFLAGS = -lncurses -lparted
 AM_CFLAGS =
 AM_LDFLAGS =
-check_PROGRAMS = test_round_size
-TESTS = test_round_size
+check_PROGRAMS = test_round_size test_report
+TESTS = test_round_size test_report
 
 # this lists the binaries to produce, the (non-PHONY, binary) targets in
 # the previous manual Makefile
@@ -29,6 +29,7 @@ NWIPE_CORE = \
     conf.c conf.h \
     customers.c customers.h \
     cpu_features.c cpu_features.h \
+    report.c report.h \
     round_size.c round_size.h \
     ANSI-color-codes.h \
     display_help.c
@@ -68,3 +69,6 @@ nwipe_LDADD = $(PARTED_LIBS) $(LIBCONFIG)
 
 test_round_size_SOURCES = ../tests/unit/test_round_size.c round_size.c round_size.h
 test_round_size_CPPFLAGS = -I$(top_srcdir)/src -I$(top_builddir)
+
+test_report_SOURCES = ../tests/unit/test_report.c report.c report.h
+test_report_CPPFLAGS = -I$(top_srcdir)/src -I$(top_builddir)

--- a/src/create_single_disc_pdf.c
+++ b/src/create_single_disc_pdf.c
@@ -42,6 +42,7 @@
 #include "prng.h"
 #include "hpa_dco.h"
 #include "miscellaneous.h"
+#include "report.h"
 #include <libconfig.h>
 #include "conf.h"
 
@@ -773,23 +774,8 @@ int create_single_disc_pdf( nwipe_context_t* ptr )
      */
     nwipe_get_smart_data( c );
 
-    /*****************************
-     * Create the reports filename
-     *
-     * Sanitize the strings that we are going to use to create the report filename
-     * by converting any non alphanumeric characters to an underscore or hyphen
-     */
-    replace_non_alphanumeric( end_time_text, '-' );
-    replace_non_alphanumeric( c->device_model, '_' );
-    replace_non_alphanumeric( c->device_serial_no, '_' );
-    snprintf( c->PDF_filename,
-              sizeof( c->PDF_filename ),
-              "%s/nwipe_report_%s_Model_%s_Serial_%s_device_%s.pdf",
-              nwipe_options.PDFreportpath,
-              end_time_text,
-              c->device_model,
-              c->device_serial_no,
-              c->device_name_terse );
+    /* Build the report filename from sanitized local copies instead of mutating the device context. */
+    nwipe_report_build_pdf_filename( c, nwipe_options.PDFreportpath, c->PDF_filename, sizeof( c->PDF_filename ) );
 
     pdf_save( pdf, c->PDF_filename );
     pdf_destroy( pdf );

--- a/src/logging.c
+++ b/src/logging.c
@@ -39,6 +39,7 @@
 #include "create_pdf.h"
 #include "miscellaneous.h"
 #include "hpa_dco.h"
+#include "report.h"
 
 /* Global array to hold log values to print when logging to STDOUT */
 char** log_lines;
@@ -690,38 +691,31 @@ void nwipe_log_summary( nwipe_thread_data_ptr_t* ptrx, nwipe_context_t** ptr, in
      */
 
     int i;
-    int idx_src;
-    int idx_dest;
     char device[18];
     char status[9];
     char throughput[13];
     char total_throughput_string[13];
-    char summary_top_border[256];
-    char summary_top_column_titles[256];
     char blank[3];
     char verify[3];
-    // char duration[5];
-    char duration[314];
     char model[18];
     char serial_no[NWIPE_SERIALNUMBER_LENGTH + 1];
     char exclamation_flag[2];
     int hours;
     int minutes;
     int seconds;
-    u64 total_duration_seconds;
     u64 total_throughput;
+    nwipe_report_summary_t report_summary;
+    extern int user_abort;
     nwipe_context_t** c;
     c = ptr;
+    (void) ptrx;
 
     exclamation_flag[0] = 0;
     device[0] = 0;
     status[0] = 0;
     throughput[0] = 0;
-    summary_top_border[0] = 0;
-    summary_top_column_titles[0] = 0;
     blank[0] = 0;
     verify[0] = 0;
-    duration[0] = 0;
     model[0] = 0;
     serial_no[0] = 0;
     hours = 0;
@@ -739,6 +733,9 @@ void nwipe_log_summary( nwipe_thread_data_ptr_t* ptrx, nwipe_context_t** ptr, in
     {
         return;
     }
+
+    /* Use one consistent timestamp for summary/report derivation. */
+    t = time( NULL );
 
     /* Print the pass and verifications table */
 
@@ -768,11 +765,6 @@ void nwipe_log_summary( nwipe_thread_data_ptr_t* ptrx, nwipe_context_t** ptr, in
          * characters eg "   sda", prefixed with space to 6 characters, note that
          * we are processing the strings right to left */
 
-        idx_dest = 6;
-        device[idx_dest--] = 0;
-        idx_src = strlen( c[i]->device_name );
-        idx_src--;
-
         nwipe_strip_path( device, c[i]->device_name );
 
         nwipe_log( NWIPE_LOG_NOTIMESTAMP,
@@ -799,37 +791,22 @@ void nwipe_log_summary( nwipe_thread_data_ptr_t* ptrx, nwipe_context_t** ptr, in
 
         for( i = 0; i < nwipe_selected; i++ )
         {
-            u64 expected_size;
-            char percent_str[7];
-            char percent_display[8];
+            char percent_display[9];
 
             nwipe_strip_path( device, c[i]->device_name );
+            nwipe_report_build_summary( c[i], user_abort, t, &report_summary );
 
-            /* Determine the expected total size based on device type / HPA status */
-            if( c[i]->device_type == NWIPE_DEVICE_NVME || c[i]->device_type == NWIPE_DEVICE_VIRT
-                || c[i]->HPA_status == HPA_NOT_APPLICABLE )
+            if( strcmp( report_summary.percent_erased, "N/A" ) == 0 )
             {
-                expected_size = c[i]->device_size;
+                snprintf( percent_display, sizeof( percent_display ), "%s", report_summary.percent_erased );
             }
             else
             {
-                expected_size = c[i]->Calculated_real_max_size_in_bytes;
-            }
-
-            /* Calculate percentage (same method as in PDF) */
-            if( expected_size > 0 )
-            {
-                convert_double_to_string( percent_str,
-                                          (double) ( (double) c[i]->bytes_erased / (double) expected_size ) * 100 );
-                snprintf( percent_display, sizeof( percent_display ), "%s%%", percent_str );
-            }
-            else
-            {
-                snprintf( percent_display, sizeof( percent_display ), "N/A" );
+                snprintf( percent_display, sizeof( percent_display ), "%s%%", report_summary.percent_erased );
             }
 
             /* Set exclamation flag if bytes erased doesn't match expected */
-            if( c[i]->bytes_erased != expected_size )
+            if( c[i]->bytes_erased != report_summary.expected_size )
             {
                 strncpy( exclamation_flag, "!", 1 );
                 exclamation_flag[1] = 0;
@@ -845,7 +822,7 @@ void nwipe_log_summary( nwipe_thread_data_ptr_t* ptrx, nwipe_context_t** ptr, in
                        exclamation_flag,
                        device,
                        c[i]->bytes_erased,
-                       expected_size,
+                       report_summary.expected_size,
                        percent_display );
         }
 
@@ -858,8 +835,6 @@ void nwipe_log_summary( nwipe_thread_data_ptr_t* ptrx, nwipe_context_t** ptr, in
     /* initialise */
     total_throughput = 0;
 
-    /* Get the current time. */
-    t = time( NULL );
     p = localtime( &t );
     /* IMPORTANT: Keep maximum columns (line length) to 80 characters for use with 80x30 terminals, Shredos, ALT-F2 etc
      * --------------------------------01234567890123456789012345678901234567890123456789012345678901234567890123456789-*/
@@ -882,96 +857,21 @@ void nwipe_log_summary( nwipe_thread_data_ptr_t* ptrx, nwipe_context_t** ptr, in
 
         nwipe_strip_path( device, c[i]->device_name );
 
-        extern int user_abort;
+        nwipe_report_build_summary( c[i], user_abort, t, &report_summary );
+        nwipe_report_apply_summary( c[i], &report_summary );
 
-        /* Any errors ? if so set the exclamation_flag and fail message,
-         * All status messages should be eight characters EXACTLY !
-         */
-        if( c[i]->pass_errors != 0 || c[i]->verify_errors != 0 || c[i]->fsyncdata_errors != 0 )
-        {
-            strncpy( exclamation_flag, "!", 1 );
-            exclamation_flag[1] = 0;
-
-            strncpy( status, "-FAILED-", 8 );
-            status[8] = 0;
-
-            strcpy( c[i]->wipe_status_txt, "FAILED" );  // copy to context for use by certificate
-        }
-        else
-        {
-            if( c[i]->wipe_status == 0 /* && user_abort != 1 */ )
-            {
-                strncpy( exclamation_flag, " ", 1 );
-                exclamation_flag[1] = 0;
-
-                strncpy( status, " Erased ", 8 );
-                status[8] = 0;
-
-                strcpy( c[i]->wipe_status_txt, "ERASED" );  // copy to context for use by certificate
-            }
-            else
-            {
-                if( c[i]->wipe_status == 1 && user_abort == 1 )
-                {
-                    strncpy( exclamation_flag, "!", 1 );
-                    exclamation_flag[1] = 0;
-
-                    strncpy( status, "UABORTED", 8 );
-                    status[8] = 0;
-
-                    strcpy( c[i]->wipe_status_txt, "ABORTED" );  // copy to context for use by certificate
-                }
-                else
-                {
-                    /* If this ever happens, there is a bug ! */
-                    strncpy( exclamation_flag, " ", 1 );
-                    exclamation_flag[1] = 0;
-
-                    strncpy( status, "INSANITY", 8 );
-                    status[8] = 0;
-
-                    strcpy( c[i]->wipe_status_txt, "INSANITY" );  // copy to context for use by certificate
-                }
-            }
-        }
-
-        /* Determine the size of throughput so that the correct nomenclature can be used */
-        Determine_C_B_nomenclature( c[i]->throughput, throughput, 13 );
-
-        /* write the duration string to the drive context for later use by create_pdf() */
-        snprintf( c[i]->throughput_txt, sizeof( c[i]->throughput_txt ), "%s", throughput );
+        strncpy( exclamation_flag, report_summary.exclamation_flag, sizeof( exclamation_flag ) );
+        exclamation_flag[sizeof( exclamation_flag ) - 1] = 0;
+        strncpy( status, report_summary.display_status, sizeof( status ) - 1 );
+        status[sizeof( status ) - 1] = 0;
+        strncpy( throughput, report_summary.throughput_txt, sizeof( throughput ) );
+        throughput[sizeof( throughput ) - 1] = 0;
 
         /* Add this devices throughput to the total throughput */
         total_throughput += c[i]->throughput;
-
-        /* Retrieve the duration of the wipe in seconds and convert to hours and minutes and seconds */
-
-        if( c[i]->start_time != 0 && c[i]->end_time != 0 )
-        {
-            /* For a summary when the wipe has finished */
-            c[i]->duration = difftime( c[i]->end_time, c[i]->start_time );
-        }
-        else
-        {
-            if( c[i]->start_time != 0 && c[i]->end_time == 0 )
-            {
-                /* For a summary in the event of a system shutdown, user abort */
-                c[i]->duration = difftime( t, c[i]->start_time );
-
-                /* If end_time is zero, which may occur if the wipe is aborted, then set
-                 * end_time to current time. Important to do as endtime is used by
-                 * the PDF report function */
-                c[i]->end_time = time( &t );
-            }
-        }
-
-        total_duration_seconds = (u64) c[i]->duration;
-
-        /* Convert binary seconds into three binary variables, hours, minutes and seconds */
-        convert_seconds_to_hours_minutes_seconds( total_duration_seconds, &hours, &minutes, &seconds );
-
-        /* write the duration string to the drive context for later use by create_pdf() */
-        snprintf( c[i]->duration_str, sizeof( c[i]->duration_str ), "%02i:%02i:%02i", hours, minutes, seconds );
+        hours = report_summary.hours;
+        minutes = report_summary.minutes;
+        seconds = report_summary.seconds;
 
         /* Device Model */
         strncpy( model, c[i]->device_model, 17 );

--- a/src/report.c
+++ b/src/report.c
@@ -1,0 +1,305 @@
+#include "report.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "hpa_dco.h"
+
+static void nwipe_report_format_quantity( u64 qty, char* result, size_t result_size )
+{
+    if( result == NULL || result_size == 0 )
+    {
+        return;
+    }
+
+    memset( result, 0, result_size );
+
+    if( qty >= INT64_C( 10000000000000 ) )
+    {
+        snprintf( result, result_size, "%4llu TB", qty / INT64_C( 1000000000000 ) );
+    }
+    else if( qty >= INT64_C( 10000000000 ) )
+    {
+        snprintf( result, result_size, "%4llu GB", qty / INT64_C( 1000000000 ) );
+    }
+    else if( qty >= INT64_C( 10000000 ) )
+    {
+        snprintf( result, result_size, "%4llu MB", qty / INT64_C( 1000000 ) );
+    }
+    else if( qty >= INT64_C( 10000 ) )
+    {
+        snprintf( result, result_size, "%4llu KB", qty / INT64_C( 1000 ) );
+    }
+    else
+    {
+        snprintf( result, result_size, "%4llu B", qty );
+    }
+}
+
+static void nwipe_report_convert_seconds( u64 total_seconds, int* hours, int* minutes, int* seconds )
+{
+    int h = 0;
+    int m = 0;
+    int s = 0;
+
+    if( total_seconds % 60 )
+    {
+        m = total_seconds / 60;
+        s = total_seconds - ( m * 60 );
+    }
+    else
+    {
+        m = total_seconds / 60;
+    }
+
+    if( m > 59 )
+    {
+        h = m / 60;
+        if( m % 60 )
+        {
+            m = m - ( h * 60 );
+        }
+        else
+        {
+            m = 0;
+        }
+    }
+
+    if( hours != NULL )
+    {
+        *hours = h;
+    }
+    if( minutes != NULL )
+    {
+        *minutes = m;
+    }
+    if( seconds != NULL )
+    {
+        *seconds = s;
+    }
+}
+
+static void nwipe_report_format_percent( char* output_str, size_t output_size, double value )
+{
+    char percent_str[64] = "";
+    size_t input_idx = 0;
+    size_t output_idx = 0;
+    int decimal_digits = 0;
+
+    if( output_str == NULL || output_size == 0 )
+    {
+        return;
+    }
+
+    output_str[0] = '\0';
+    snprintf( percent_str, sizeof( percent_str ), "%5.32lf", value );
+
+    while( percent_str[input_idx] != '\0' && output_idx + 1 < output_size )
+    {
+        output_str[output_idx++] = percent_str[input_idx];
+        if( percent_str[input_idx++] == '.' )
+        {
+            while( percent_str[input_idx] != '\0' && decimal_digits < 2 && output_idx + 1 < output_size )
+            {
+                output_str[output_idx++] = percent_str[input_idx++];
+                decimal_digits++;
+            }
+            break;
+        }
+    }
+
+    output_str[output_idx] = '\0';
+}
+
+static void nwipe_report_sanitize_component( char* value, char replacement_char )
+{
+    size_t i = 0;
+
+    if( value == NULL )
+    {
+        return;
+    }
+
+    while( value[i] != '\0' )
+    {
+        if( value[i] < '0' || ( value[i] > '9' && value[i] < 'A' ) || ( value[i] > 'Z' && value[i] < 'a' )
+            || value[i] > 'z' )
+        {
+            value[i] = replacement_char;
+        }
+        i++;
+    }
+}
+
+static u64 nwipe_report_expected_size( const nwipe_context_t* ctx )
+{
+    if( ctx->device_type == NWIPE_DEVICE_NVME || ctx->device_type == NWIPE_DEVICE_VIRT
+        || ctx->HPA_status == HPA_NOT_APPLICABLE )
+    {
+        return ctx->device_size;
+    }
+
+    return ctx->Calculated_real_max_size_in_bytes;
+}
+
+void nwipe_report_build_summary( const nwipe_context_t* ctx,
+                                 int user_abort,
+                                 time_t now,
+                                 nwipe_report_summary_t* out )
+{
+    if( ctx == NULL || out == NULL )
+    {
+        return;
+    }
+
+    memset( out, 0, sizeof( *out ) );
+
+    if( ctx->pass_errors != 0 || ctx->verify_errors != 0 || ctx->fsyncdata_errors != 0 )
+    {
+        snprintf( out->exclamation_flag, sizeof( out->exclamation_flag ), "!" );
+        snprintf( out->display_status, sizeof( out->display_status ), "-FAILED-" );
+        snprintf( out->status_text, sizeof( out->status_text ), "FAILED" );
+    }
+    else if( ctx->wipe_status == 0 )
+    {
+        snprintf( out->exclamation_flag, sizeof( out->exclamation_flag ), " " );
+        snprintf( out->display_status, sizeof( out->display_status ), " Erased " );
+        snprintf( out->status_text, sizeof( out->status_text ), "ERASED" );
+    }
+    else if( ctx->wipe_status == 1 && user_abort == 1 )
+    {
+        snprintf( out->exclamation_flag, sizeof( out->exclamation_flag ), "!" );
+        snprintf( out->display_status, sizeof( out->display_status ), "UABORTED" );
+        snprintf( out->status_text, sizeof( out->status_text ), "ABORTED" );
+    }
+    else
+    {
+        snprintf( out->exclamation_flag, sizeof( out->exclamation_flag ), " " );
+        snprintf( out->display_status, sizeof( out->display_status ), "INSANITY" );
+        snprintf( out->status_text, sizeof( out->status_text ), "INSANITY" );
+    }
+
+    nwipe_report_format_quantity( ctx->throughput, out->throughput_txt, sizeof( out->throughput_txt ) );
+
+    if( ctx->end_time != 0 )
+    {
+        out->effective_end_time = ctx->end_time;
+    }
+    else if( ctx->start_time != 0 )
+    {
+        out->effective_end_time = now;
+    }
+
+    if( ctx->start_time != 0 && out->effective_end_time != 0 )
+    {
+        out->duration = difftime( out->effective_end_time, ctx->start_time );
+    }
+
+    out->total_duration_seconds = (u64) out->duration;
+    nwipe_report_convert_seconds( out->total_duration_seconds, &out->hours, &out->minutes, &out->seconds );
+    snprintf( out->duration_str,
+              sizeof( out->duration_str ),
+              "%02i:%02i:%02i",
+              out->hours,
+              out->minutes,
+              out->seconds );
+
+    out->expected_size = nwipe_report_expected_size( ctx );
+    if( out->expected_size > 0 )
+    {
+        nwipe_report_format_percent(
+            out->percent_erased, sizeof( out->percent_erased ), ( (double) ctx->bytes_erased / out->expected_size ) * 100.0 );
+    }
+    else
+    {
+        snprintf( out->percent_erased, sizeof( out->percent_erased ), "N/A" );
+    }
+}
+
+void nwipe_report_apply_summary( nwipe_context_t* ctx, const nwipe_report_summary_t* summary )
+{
+    if( ctx == NULL || summary == NULL )
+    {
+        return;
+    }
+
+    ctx->duration = summary->duration;
+    snprintf( ctx->duration_str, sizeof( ctx->duration_str ), "%s", summary->duration_str );
+    snprintf( ctx->throughput_txt, sizeof( ctx->throughput_txt ), "%s", summary->throughput_txt );
+    snprintf( ctx->wipe_status_txt, sizeof( ctx->wipe_status_txt ), "%s", summary->status_text );
+
+    if( ctx->end_time == 0 && summary->effective_end_time != 0 )
+    {
+        ctx->end_time = summary->effective_end_time;
+    }
+}
+
+void nwipe_report_build_pdf_filename( const nwipe_context_t* ctx,
+                                      const char* report_path,
+                                      char* out,
+                                      size_t out_size )
+{
+    char end_time_text[50] = "Unknown";
+    char model[128] = "Unknown";
+    char serial[NWIPE_SERIALNUMBER_LENGTH + 1] = "Unknown";
+    char device_name[DEVICE_NAME_MAX_SIZE] = "device";
+    struct tm* tm_info;
+    time_t timestamp;
+
+    if( out == NULL || out_size == 0 )
+    {
+        return;
+    }
+
+    out[0] = '\0';
+
+    if( ctx == NULL )
+    {
+        return;
+    }
+
+    timestamp = ctx->end_time != 0 ? ctx->end_time : ctx->start_time;
+    if( timestamp != 0 )
+    {
+        tm_info = localtime( &timestamp );
+        if( tm_info != NULL )
+        {
+            snprintf( end_time_text,
+                      sizeof( end_time_text ),
+                      "%i/%02i/%02i %02i:%02i:%02i",
+                      1900 + tm_info->tm_year,
+                      1 + tm_info->tm_mon,
+                      tm_info->tm_mday,
+                      tm_info->tm_hour,
+                      tm_info->tm_min,
+                      tm_info->tm_sec );
+        }
+    }
+
+    if( ctx->device_model != NULL && ctx->device_model[0] != '\0' )
+    {
+        snprintf( model, sizeof( model ), "%s", ctx->device_model );
+    }
+    if( ctx->device_serial_no[0] != '\0' )
+    {
+        snprintf( serial, sizeof( serial ), "%s", ctx->device_serial_no );
+    }
+    if( ctx->device_name_terse[0] != '\0' )
+    {
+        snprintf( device_name, sizeof( device_name ), "%s", ctx->device_name_terse );
+    }
+
+    nwipe_report_sanitize_component( end_time_text, '-' );
+    nwipe_report_sanitize_component( model, '_' );
+    nwipe_report_sanitize_component( serial, '_' );
+    nwipe_report_sanitize_component( device_name, '_' );
+
+    snprintf( out,
+              out_size,
+              "%s/nwipe_report_%s_Model_%s_Serial_%s_device_%s.pdf",
+              report_path != NULL ? report_path : ".",
+              end_time_text,
+              model,
+              serial,
+              device_name );
+}

--- a/src/report.c
+++ b/src/report.c
@@ -142,10 +142,7 @@ static u64 nwipe_report_expected_size( const nwipe_context_t* ctx )
     return ctx->Calculated_real_max_size_in_bytes;
 }
 
-void nwipe_report_build_summary( const nwipe_context_t* ctx,
-                                 int user_abort,
-                                 time_t now,
-                                 nwipe_report_summary_t* out )
+void nwipe_report_build_summary( const nwipe_context_t* ctx, int user_abort, time_t now, nwipe_report_summary_t* out )
 {
     if( ctx == NULL || out == NULL )
     {
@@ -197,18 +194,15 @@ void nwipe_report_build_summary( const nwipe_context_t* ctx,
 
     out->total_duration_seconds = (u64) out->duration;
     nwipe_report_convert_seconds( out->total_duration_seconds, &out->hours, &out->minutes, &out->seconds );
-    snprintf( out->duration_str,
-              sizeof( out->duration_str ),
-              "%02i:%02i:%02i",
-              out->hours,
-              out->minutes,
-              out->seconds );
+    snprintf(
+        out->duration_str, sizeof( out->duration_str ), "%02i:%02i:%02i", out->hours, out->minutes, out->seconds );
 
     out->expected_size = nwipe_report_expected_size( ctx );
     if( out->expected_size > 0 )
     {
-        nwipe_report_format_percent(
-            out->percent_erased, sizeof( out->percent_erased ), ( (double) ctx->bytes_erased / out->expected_size ) * 100.0 );
+        nwipe_report_format_percent( out->percent_erased,
+                                     sizeof( out->percent_erased ),
+                                     ( (double) ctx->bytes_erased / out->expected_size ) * 100.0 );
     }
     else
     {
@@ -234,10 +228,7 @@ void nwipe_report_apply_summary( nwipe_context_t* ctx, const nwipe_report_summar
     }
 }
 
-void nwipe_report_build_pdf_filename( const nwipe_context_t* ctx,
-                                      const char* report_path,
-                                      char* out,
-                                      size_t out_size )
+void nwipe_report_build_pdf_filename( const nwipe_context_t* ctx, const char* report_path, char* out, size_t out_size )
 {
     char end_time_text[50] = "Unknown";
     char model[128] = "Unknown";

--- a/src/report.h
+++ b/src/report.h
@@ -23,14 +23,8 @@ typedef struct
     int seconds;
 } nwipe_report_summary_t;
 
-void nwipe_report_build_summary( const nwipe_context_t* ctx,
-                                 int user_abort,
-                                 time_t now,
-                                 nwipe_report_summary_t* out );
+void nwipe_report_build_summary( const nwipe_context_t* ctx, int user_abort, time_t now, nwipe_report_summary_t* out );
 void nwipe_report_apply_summary( nwipe_context_t* ctx, const nwipe_report_summary_t* summary );
-void nwipe_report_build_pdf_filename( const nwipe_context_t* ctx,
-                                      const char* report_path,
-                                      char* out,
-                                      size_t out_size );
+void nwipe_report_build_pdf_filename( const nwipe_context_t* ctx, const char* report_path, char* out, size_t out_size );
 
 #endif /* REPORT_H_ */

--- a/src/report.h
+++ b/src/report.h
@@ -1,0 +1,36 @@
+#ifndef REPORT_H_
+#define REPORT_H_
+
+#include <stddef.h>
+#include <time.h>
+
+#include "context.h"
+
+typedef struct
+{
+    char exclamation_flag[2];
+    char display_status[9];
+    char status_text[10];
+    char throughput_txt[13];
+    char duration_str[20];
+    char percent_erased[8];
+    u64 expected_size;
+    u64 total_duration_seconds;
+    double duration;
+    time_t effective_end_time;
+    int hours;
+    int minutes;
+    int seconds;
+} nwipe_report_summary_t;
+
+void nwipe_report_build_summary( const nwipe_context_t* ctx,
+                                 int user_abort,
+                                 time_t now,
+                                 nwipe_report_summary_t* out );
+void nwipe_report_apply_summary( nwipe_context_t* ctx, const nwipe_report_summary_t* summary );
+void nwipe_report_build_pdf_filename( const nwipe_context_t* ctx,
+                                      const char* report_path,
+                                      char* out,
+                                      size_t out_size );
+
+#endif /* REPORT_H_ */

--- a/tests/unit/test_report.c
+++ b/tests/unit/test_report.c
@@ -1,0 +1,120 @@
+#include <assert.h>
+#include <string.h>
+#include <time.h>
+
+#include "report.h"
+#include "hpa_dco.h"
+
+static void test_summary_uses_real_max_expected_size( void )
+{
+    nwipe_context_t ctx;
+    nwipe_report_summary_t summary;
+
+    memset( &ctx, 0, sizeof( ctx ) );
+    ctx.device_type = NWIPE_DEVICE_SCSI;
+    ctx.HPA_status = HPA_DISABLED;
+    ctx.device_size = 100;
+    ctx.Calculated_real_max_size_in_bytes = 125;
+    ctx.bytes_erased = 100;
+    ctx.throughput = 2000000;
+    ctx.start_time = 10;
+    ctx.end_time = 70;
+    ctx.wipe_status = 0;
+
+    nwipe_report_build_summary( &ctx, 0, 90, &summary );
+
+    assert( summary.expected_size == 125 );
+    assert( strcmp( summary.status_text, "ERASED" ) == 0 );
+    assert( strcmp( summary.percent_erased, "80.00" ) == 0 );
+    assert( strcmp( summary.duration_str, "00:01:00" ) == 0 );
+}
+
+static void test_summary_uses_device_size_for_nvme( void )
+{
+    nwipe_context_t ctx;
+    nwipe_report_summary_t summary;
+
+    memset( &ctx, 0, sizeof( ctx ) );
+    ctx.device_type = NWIPE_DEVICE_NVME;
+    ctx.HPA_status = HPA_ENABLED;
+    ctx.device_size = 200;
+    ctx.Calculated_real_max_size_in_bytes = 500;
+    ctx.bytes_erased = 100;
+    ctx.wipe_status = 0;
+
+    nwipe_report_build_summary( &ctx, 0, 0, &summary );
+
+    assert( summary.expected_size == 200 );
+    assert( strcmp( summary.percent_erased, "50.00" ) == 0 );
+}
+
+static void test_summary_marks_aborted_and_apply_updates_context( void )
+{
+    nwipe_context_t ctx;
+    nwipe_report_summary_t summary;
+
+    memset( &ctx, 0, sizeof( ctx ) );
+    ctx.start_time = 10;
+    ctx.end_time = 0;
+    ctx.wipe_status = 1;
+    ctx.throughput = 123456789;
+
+    nwipe_report_build_summary( &ctx, 1, 100, &summary );
+
+    assert( strcmp( summary.status_text, "ABORTED" ) == 0 );
+    assert( strcmp( summary.display_status, "UABORTED" ) == 0 );
+    assert( summary.effective_end_time == 100 );
+    assert( strcmp( summary.duration_str, "00:01:30" ) == 0 );
+
+    nwipe_report_apply_summary( &ctx, &summary );
+
+    assert( ctx.end_time == 100 );
+    assert( strcmp( ctx.wipe_status_txt, "ABORTED" ) == 0 );
+    assert( strcmp( ctx.duration_str, "00:01:30" ) == 0 );
+}
+
+static void test_summary_marks_failed_on_errors( void )
+{
+    nwipe_context_t ctx;
+    nwipe_report_summary_t summary;
+
+    memset( &ctx, 0, sizeof( ctx ) );
+    ctx.pass_errors = 1;
+    ctx.wipe_status = 0;
+
+    nwipe_report_build_summary( &ctx, 0, 0, &summary );
+
+    assert( strcmp( summary.exclamation_flag, "!" ) == 0 );
+    assert( strcmp( summary.display_status, "-FAILED-" ) == 0 );
+    assert( strcmp( summary.status_text, "FAILED" ) == 0 );
+}
+
+static void test_pdf_filename_sanitizes_without_mutating_context( void )
+{
+    nwipe_context_t ctx;
+    char model[] = "Loop Model/A";
+    char filename[FILENAME_MAX];
+
+    memset( &ctx, 0, sizeof( ctx ) );
+    ctx.device_model = model;
+    snprintf( ctx.device_serial_no, sizeof( ctx.device_serial_no ), "SER:01 02" );
+    snprintf( ctx.device_name_terse, sizeof( ctx.device_name_terse ), "loop0" );
+    ctx.end_time = 1704067200; /* 2024-01-01 00:00:00 UTC */
+
+    nwipe_report_build_pdf_filename( &ctx, "/tmp/reports", filename, sizeof( filename ) );
+
+    assert( strcmp( ctx.device_model, "Loop Model/A" ) == 0 );
+    assert( strcmp( ctx.device_serial_no, "SER:01 02" ) == 0 );
+    assert( strstr( filename, "/tmp/reports/nwipe_report_" ) == filename );
+    assert( strstr( filename, "_Model_Loop_Model_A_Serial_SER_01_02_device_loop0.pdf" ) != NULL );
+}
+
+int main( void )
+{
+    test_summary_uses_real_max_expected_size();
+    test_summary_uses_device_size_for_nvme();
+    test_summary_marks_aborted_and_apply_updates_context();
+    test_summary_marks_failed_on_errors();
+    test_pdf_filename_sanitizes_without_mutating_context();
+    return 0;
+}


### PR DESCRIPTION
This is a small internal refactor around the reporting path 
It does not change the wipe engine itself. My goal is to get some of the reporting loging out of logging.c` into a small helper module, so later changes like JSON or other report outputs dont have to duplicate the reporting logic again.

What i have changed:
- add `src/report.c` / `src/report.h`
- move summary/report helper logic there
- keep `logging.c` thinner by using the new helpers
- build PDF filenames from sanitized copies instead of altering fields in the device context
- add a small unit test for the new reporting helpers
- lower coupling in the reporting code
- make future reporting changes easier
- keep this first step low risk as we dicussed in https://github.com/martijnvanbrummelen/nwipe/issues/747


I tried to keep this pretty conservative, so behaviour should stay the same, its mostly moving derived/report-side logic into one place.
