### PR TITLE
Add duplex printing option to PDFs --pdfduplex

### DIFF
--- a/src/create_pdf.c
+++ b/src/create_pdf.c
@@ -960,3 +960,34 @@ void pdf_add_text_host_info_page( void* pdf,
         yoff -= 12;
     }
 }
+
+void pdf_add_blank_page( void* pdf,
+                         size_t* page_number,
+                         float xoff,
+                         float yoff,
+                         size_t pdf_type,
+                         nwipe_context_t* c,
+                         nwipe_misc_thread_data_t* d )
+{
+    char page_title[50];
+
+    /* Create a new page */
+    ( *page_number )++;
+    pdf_append_page_and_update_index( pdf, *page_number );
+
+    /* Create the header and footer for this host data page */
+    snprintf( page_title, sizeof( page_title ), "Page %zu - Intentionally Blank", *page_number );
+    pdf_header_footer_text( d, c, page_title, pdf_type, PDF_PAGE_ERASURE_DATA );
+    pdf_set_font( pdf, "Courier-Bold" );
+
+    pdf_add_text( pdf, NULL, "Page Intentionally Blank", INTENTIONALLY_BLANK_TEXT_SIZE, xoff, yoff, PDF_BLACK );
+
+    /* Display the appropriate status icon (green tick, red cross, tick with exclamation) for
+     * the single disk PDF. For multi disc PDFs the status icon is written upon completion
+     * of the entire PDF within the create_system_multidisc_pdf() function.
+     */
+    if( pdf_type == PDF_TYPE_SINGLE_DISC )
+    {
+        pdf_display_status_icon( PDF_TYPE_SINGLE_DISC, NULL );
+    }
+}

--- a/src/create_pdf.h
+++ b/src/create_pdf.h
@@ -40,6 +40,10 @@
 #define LEFT_MARGIN_TEXT 60
 #define LEFT_MARGIN_SMART_DATA 50
 
+#define INTENTIONALLY_BLANK_X 150
+#define INTENTIONALLY_BLANK_Y 400
+#define INTENTIONALLY_BLANK_TEXT_SIZE 18
+
 #define TOP_OF_TEXT_WINDOW_Y 630
 #define START_OF_SMART_DATA_TEXT_Y_MULTIDISC 608
 
@@ -146,5 +150,17 @@ void pdf_add_text_host_info_page( void*,
                                   size_t,
                                   nwipe_context_t* c,
                                   nwipe_misc_thread_data_t* d );
+/**
+ * Insert an intenionally blank page for duplex printing
+ * @param pointer to PDF document
+ * @param pointer to page number
+ * @param text xoffset
+ * @param text yoffset
+ * @param PDF type, PDF_TYPE_SINGLE_DISC or PDF_TYPE_MULTI_DISC
+ * @param pointer to drive context structure
+ * @param pointer to miscellaneous data structure
+ * @return
+ */
+void pdf_add_blank_page( void*, size_t*, float, float, size_t, nwipe_context_t* c, nwipe_misc_thread_data_t* d );
 
 #endif /* CREATE_PDF_H_ */

--- a/src/create_single_disc_pdf.c
+++ b/src/create_single_disc_pdf.c
@@ -486,6 +486,19 @@ int create_single_disc_pdf( nwipe_thread_data_ptr_t* ptrx, nwipe_context_t* ptr 
     }
     pdf_set_font( pdf, "Helvetica" );
 
+    /**********************************
+     * If the command line option --pdfduplex is active, insert a blank odd (recto) page
+     * before an even (verso) page.
+     */
+    if( nwipe_options.PDF_duplex == 1 )
+    {
+        if( !( ( page_number + 1 ) % 2 ) )
+        {
+            pdf_add_blank_page(
+                pdf, &page_number, INTENTIONALLY_BLANK_X, INTENTIONALLY_BLANK_Y, PDF_TYPE_SINGLE_DISC, c, d );
+        }
+    }
+
     /***************************************
      * Populate subsequent pages with smart data
      */

--- a/src/create_system_multi_disc_pdf.c
+++ b/src/create_system_multi_disc_pdf.c
@@ -452,6 +452,18 @@ int create_system_multi_disc_pdf( nwipe_thread_data_ptr_t* ptrx )
     /***************************************
      * Add SMBIOS/DMI host data page
      */
+
+    /* If the command line option --pdfduplex is active, insert a blank odd (recto) page before an even (verso) page. */
+    if( nwipe_options.PDF_duplex == 1 )
+    {
+        if( !( ( page_number + 1 ) % 2 ) )
+        {
+            pdf_add_blank_page(
+                pdf, &page_number, INTENTIONALLY_BLANK_X, INTENTIONALLY_BLANK_Y, PDF_TYPE_MULTI_DISC, NULL, d );
+        }
+    }
+
+    /* Write the SMBIOS/DMI info page to the PDF */
     pdf_add_text_host_info_page(
         pdf, &page_number, LEFT_MARGIN_TEXT, TOP_OF_TEXT_WINDOW_Y, PDF_TYPE_MULTI_DISC, NULL, d );
 
@@ -460,6 +472,18 @@ int create_system_multi_disc_pdf( nwipe_thread_data_ptr_t* ptrx )
      */
     for( i = 0; i < nwipe_misc_thread_data->nwipe_selected; i++ )
     {
+        /* If the command line option --pdfduplex is active, insert a blank odd (recto) page before an even (verso)
+         * page. */
+        if( nwipe_options.PDF_duplex == 1 )
+        {
+            if( !( ( page_number + 1 ) % 2 ) )
+            {
+                pdf_add_blank_page(
+                    pdf, &page_number, INTENTIONALLY_BLANK_X, INTENTIONALLY_BLANK_Y, PDF_TYPE_MULTI_DISC, NULL, d );
+            }
+        }
+
+        /* Write the smart data for a selected drive */
         result = nwipe_get_smart_data( d, PDF_TYPE_MULTI_DISC, &page_number, c[i] );
         if( result != 0 )
         {

--- a/src/options.c
+++ b/src/options.c
@@ -150,6 +150,9 @@ int nwipe_options_parse( int argc, char** argv )
         /* Enables a field on the PDF that holds a tag that identifies the host computer */
         { "pdftag", no_argument, 0, 0 },
 
+        /* Enables PDF duplex mode where each new section starts on a odd (recto) page */
+        { "pdfduplex", no_argument, 0, 0 },
+
         /* Display program version. */
         { "verbose", no_argument, 0, 0 },
 
@@ -204,6 +207,7 @@ int nwipe_options_parse( int argc, char** argv )
     nwipe_options.noabort_block_errors = 0;
     nwipe_options.PDF_toggle_host_info = 0; /* Default: host visibility on PDF disabled */
     nwipe_options.PDFtag = 0;
+    nwipe_options.PDF_duplex = 0;  // 0 = duplex switched off, 1 = on.
     memset( nwipe_options.logfile, '\0', sizeof( nwipe_options.logfile ) );
     memset( nwipe_options.PDFreportpath, '\0', sizeof( nwipe_options.PDFreportpath ) );
     strncpy( nwipe_options.PDFreportpath, ".", 2 );
@@ -656,6 +660,12 @@ int nwipe_options_parse( int argc, char** argv )
                 if( strcmp( nwipe_options_long[i].name, "pdftag" ) == 0 )
                 {
                     nwipe_options.PDFtag = 1;
+                    break;
+                }
+
+                if( strcmp( nwipe_options_long[i].name, "pdfduplex" ) == 0 )
+                {
+                    nwipe_options.PDF_duplex = 1;
                     break;
                 }
 

--- a/src/options.h
+++ b/src/options.h
@@ -76,6 +76,7 @@ typedef struct
     int PDF_preview_details;  // 0=Disable preview Org/Cust/date/time before drive selection, 1=Enable Preview
     int PDF_toggle_host_info;  // 0=Disable visibility of host Info on PDF. UUID & S/N
     int PDFtag;  // Enable display of hostID, such as UUID or serial no. on PDF report.
+    int PDF_duplex;  // Enables duplex mode, each section starts on a odd page, intentionally blank pages are inserted.
     nwipe_verify_t verify;  // A flag to indicate whether writes should be verified.
     nwipe_io_mode_t io_mode;  // Global runtime I/O mode selection (auto/direct/cached), note in auto mode each
                               // drive may use a different I/O mode if directIO isn't supported on a given drive.


### PR DESCRIPTION
To provide visual clarity the --pdfduplex option inserts a blank left-hand page which signals a shift in topic, preventing differing information from running together.

The user can now enable duplex printing with the --pdfduplex command line option.

This causes each section of the PDF to start on a new sheet with a page marked as `intentionally blank` to make sure a new section starts on a odd (recto) page.

Enabling this option turns on duplex printing for both nwipe's single-disc and system focused reports.

Closes https://github.com/PartialVolume/shredos.x86_64/issues/486