### PR TITLE
feat: Show disc retries on single and system PDFs

### DIFF
--- a/src/create_pdf.c
+++ b/src/create_pdf.c
@@ -599,7 +599,7 @@ void pdf_add_text_status_of_erasure( float text_xoff,
     else
     {
         if( !strcmp( c->wipe_status_txt, "ERASED" )
-            && ( c->HPA_status == HPA_ENABLED || c->HPA_status == HPA_UNKNOWN ) )
+            && ( c->HPA_status == HPA_ENABLED || c->HPA_status == HPA_UNKNOWN || c->io_retries != 0 ) )
         {
             pdf_add_ellipse(
                 pdf, NULL, ellipse_xoff, ellipse_yoff, ellipse_xradius, ellipse_yradius, 2, PDF_RED, PDF_BLACK );

--- a/src/create_single_disc_pdf.c
+++ b/src/create_single_disc_pdf.c
@@ -402,16 +402,22 @@ int create_single_disc_pdf( nwipe_thread_data_ptr_t* ptrx, nwipe_context_t* ptr 
     /********
      * Errors
      */
-    pdf_add_text( pdf, NULL, "Errors(pass/sync/verify):", 12, 60, 190, PDF_GRAY );
+    pdf_add_text( pdf, NULL, "Errors(pass/sync/verify/retries):", 12, 60, 190, PDF_GRAY );
     pdf_set_font( pdf, "Helvetica-Bold" );
-    snprintf( errors, sizeof( errors ), "%llu/%llu/%llu", c->pass_errors, c->fsyncdata_errors, c->verify_errors );
-    if( c->pass_errors != 0 || c->fsyncdata_errors != 0 || c->verify_errors != 0 )
+    snprintf( errors,
+              sizeof( errors ),
+              "%llu/%llu/%llu/%llu",
+              c->pass_errors,
+              c->fsyncdata_errors,
+              c->verify_errors,
+              c->io_retries );
+    if( c->pass_errors != 0 || c->fsyncdata_errors != 0 || c->verify_errors != 0 || c->io_retries != 0 )
     {
-        pdf_add_text( pdf, NULL, errors, text_size_data, 195, 190, PDF_RED );
+        pdf_add_text( pdf, NULL, errors, text_size_data, 230, 190, PDF_RED );
     }
     else
     {
-        pdf_add_text( pdf, NULL, errors, text_size_data, 195, 190, PDF_DARK_GREEN );
+        pdf_add_text( pdf, NULL, errors, text_size_data, 230, 190, PDF_DARK_GREEN );
     }
     pdf_set_font( pdf, "Helvetica" );
 

--- a/src/create_system_multi_disc_pdf.c
+++ b/src/create_system_multi_disc_pdf.c
@@ -355,20 +355,21 @@ int create_system_multi_disc_pdf( nwipe_thread_data_ptr_t* ptrx )
         /********
          * Errors
          */
-        pdf_add_text( pdf, NULL, "Errors(pass/sync/verify):", TEXT_SIZE_DATA, 300, yoffset, PDF_GRAY );
+        pdf_add_text( pdf, NULL, "Errors(pass/sync/verify/retries):", TEXT_SIZE_DATA, 300, yoffset, PDF_GRAY );
         snprintf( errors,
                   sizeof( errors ),
-                  "%llu/%llu/%llu",
+                  "%llu/%llu/%llu/%llu",
                   c[i]->pass_errors,
                   c[i]->fsyncdata_errors,
-                  c[i]->verify_errors );
-        if( c[i]->pass_errors != 0 || c[i]->fsyncdata_errors != 0 || c[i]->verify_errors != 0 )
+                  c[i]->verify_errors,
+                  c[i]->io_retries );
+        if( c[i]->pass_errors != 0 || c[i]->fsyncdata_errors != 0 || c[i]->verify_errors != 0 || c[i]->io_retries != 0 )
         {
-            pdf_add_text( pdf, NULL, errors, TEXT_SIZE_DATA, 450, yoffset, PDF_RED );
+            pdf_add_text( pdf, NULL, errors, TEXT_SIZE_DATA, 500, yoffset, PDF_RED );
         }
         else
         {
-            pdf_add_text( pdf, NULL, errors, TEXT_SIZE_DATA, 450, yoffset, PDF_DARK_GREEN );
+            pdf_add_text( pdf, NULL, errors, TEXT_SIZE_DATA, 500, yoffset, PDF_DARK_GREEN );
         }
 
         /* ************


### PR DESCRIPTION
- Added retry counts to both single disc and system PDF disc info.
- Discs with non-zero retries are now marked with an "Erased with Warning" icon, even if erasure and verification   succeeded.
- This highlights potential drive degradation (e.g., performance issues, raw read errors, or reallocated sectors) that standard SMART data might miss in it's overall drive assessment of its health. Check the actual smart values, raw read errors, reallocated sectors. If non zero, your drive may not be in the best of shape.