### PR TITLE
feat: Allow external logo.jpg for PDFs

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -276,6 +276,8 @@ typedef struct
     char dmidecode_processor_manufacturer[DMIDECODE_RESULT_LENGTH];  // host info
     char dmidecode_processor_version[DMIDECODE_RESULT_LENGTH];  // host info
     char dmidecode_processor_frequency[DMIDECODE_RESULT_LENGTH];  // host info
+    unsigned char* logo_buffer;  // Pointer to an external logo for the PDFs, NULL if not
+    size_t logo_len;  // length of logo buffer/logo image file
 } nwipe_misc_thread_data_t;
 
 /*

--- a/src/create_pdf.c
+++ b/src/create_pdf.c
@@ -295,7 +295,16 @@ void pdf_header_footer_text( nwipe_misc_thread_data_t* d,
     pdf_add_line( pdf, NULL, 50, 50, 550, 50, 3, PDF_BLACK );  // Footer full width Line
     pdf_add_line( pdf, NULL, 50, 650, 550, 650, 3, PDF_BLACK );  // Header full width Line
     pdf_add_line( pdf, NULL, 175, 734, 425, 734, 3, PDF_BLACK );  // Header Page number, disk model divider line
-    pdf_add_image_data( pdf, NULL, 45, 665, 100, 100, bin2c_shred_db_jpg, 27063 );
+    if( d->logo_buffer != NULL )
+    {
+        // Custom logo found and loaded successfully
+        pdf_add_image_data( pdf, NULL, 45, 665, 100, 100, d->logo_buffer, d->logo_len );
+    }
+    else
+    {
+        // Fallback to standard nwipe logo
+        pdf_add_image_data( pdf, NULL, 45, 665, 100, 100, bin2c_shred_db_jpg, 27063 );
+    }
 
     if( nwipe_options.PDFtag || nwipe_options.PDF_toggle_host_info )
     {
@@ -998,4 +1007,66 @@ void pdf_add_footer_page_numbers( void* pp, size_t page_number, size_t total_pag
     pdf_set_font( pdf, "Courier-Bold" );
     snprintf( page_info, sizeof( page_info ), "Page %zu of %zu", page_number, total_pages );
     pdf_add_text( pdf, pp, page_info, 8, 485, 35, PDF_BLACK );
+}
+
+/**
+ * Checks for a custom nwipe logo in /etc/nwipe/ with various extensions.
+ * * @param out_len Pointer to a size_t where the file length will be stored.
+ * @return Pointer to the allocated image buffer on success, or NULL on failure.
+ * NOTE: The caller is responsible for calling free() on the returned pointer.
+ */
+unsigned char* check_and_load_logo( size_t* out_len )
+{
+    const char* extensions[] = { "jpg", "png", "ppm", "pgm", "bmp" };
+    const int ext_count = sizeof( extensions ) / sizeof( extensions[0] );
+
+    char filepath[256];
+    FILE* fp = NULL;
+    unsigned char* buffer = NULL;
+    long file_size = 0;
+
+    if( out_len == NULL )
+    {
+        return NULL;
+    }
+
+    for( int i = 0; i < ext_count; i++ )
+    {
+        snprintf( filepath, sizeof( filepath ), "/etc/nwipe/logo.%s", extensions[i] );
+
+        fp = fopen( filepath, "rb" );
+        if( fp != NULL )
+        {
+            if( fseek( fp, 0, SEEK_END ) == 0 )
+            {
+                file_size = ftell( fp );
+                if( file_size > 0 )
+                {
+                    rewind( fp );
+
+                    buffer = (unsigned char*) malloc( file_size );
+                    if( buffer != NULL )
+                    {
+                        size_t bytes_read = fread( buffer, 1, file_size, fp );
+
+                        // If read is successful, assign length and return the buffer immediately
+                        if( bytes_read == (size_t) file_size )
+                        {
+                            *out_len = (size_t) file_size;
+                            fclose( fp );
+                            return buffer;
+                        }
+
+                        // Clean up allocation if read failed
+                        free( buffer );
+                    }
+                }
+            }
+            fclose( fp );
+        }
+    }
+
+    // Explicitly set length to 0 if no file was found or read failed
+    *out_len = 0;
+    return NULL;
 }

--- a/src/create_pdf.h
+++ b/src/create_pdf.h
@@ -171,4 +171,12 @@ void pdf_add_blank_page( void*, size_t*, float, float, size_t, nwipe_context_t* 
  */
 void pdf_add_footer_page_numbers( void*, size_t, size_t );
 
+/**
+ * Checks for a custom nwipe logo in /etc/nwipe/ with various extensions.
+ * @param out_len Pointer to a size_t where the file length will be stored.
+ * @return Pointer to the allocated image buffer on success, or NULL on failure.
+ * NOTE: The caller is responsible for calling free() on the returned pointer.
+ */
+unsigned char* check_and_load_logo( size_t* out_len );
+
 #endif /* CREATE_PDF_H_ */

--- a/src/create_single_disc_pdf.c
+++ b/src/create_single_disc_pdf.c
@@ -106,6 +106,10 @@ int create_single_disc_pdf( nwipe_thread_data_ptr_t* ptrx, nwipe_context_t* ptr 
     /* ------------------ */
     /* Initialise Various */
 
+    /* Is there an external /etc/nwipe/logo.jpg [png/ppm/pgm/bmp] file? */
+    d->logo_buffer = 0;
+    d->logo_buffer = check_and_load_logo( &( d->logo_len ) );
+
     /* Used to display correct icon on page 2 */
     status_icon = 0;  // zero don't display icon, see header STATUS_ICON_..
 
@@ -530,5 +534,6 @@ int create_single_disc_pdf( nwipe_thread_data_ptr_t* ptrx, nwipe_context_t* ptr 
 
     pdf_save( pdf, c->PDF_filename );
     pdf_destroy( pdf );
+    free( d->logo_buffer );
     return 0;
 }

--- a/src/create_system_multi_disc_pdf.c
+++ b/src/create_system_multi_disc_pdf.c
@@ -126,6 +126,10 @@ int create_system_multi_disc_pdf( nwipe_thread_data_ptr_t* ptrx )
     /* ------------------ */
     /* Initialise Various */
 
+    /* Is there an external /etc/nwipe/logo.jpg [png/ppm/pgm/bmp] file? */
+    d->logo_buffer = 0;
+    d->logo_buffer = check_and_load_logo( &( d->logo_len ) );
+
     /* Used to display correct icon on page 2 */
     status_icon = 0;  // zero don't display icon, see header STATUS_ICON_..
 
@@ -539,5 +543,6 @@ int create_system_multi_disc_pdf( nwipe_thread_data_ptr_t* ptrx )
 cleanup:
     pdf_destroy( pdf );
     free( pdf_page_array );
+    free( d->logo_buffer );
     return 0;
 }


### PR DESCRIPTION
The user can now replace the nwipe logo that's located top left of both the disc and system PDF certificates.

Simply copy a file named logo.jpg into /etc/nwipe/

To keep the file size as small as possible, while allowing the logo to look sufficently sharp, it's recommended you scale your logo's to 256x256 300dpi using gimp or your preferred image editor, which should result in a jpg that's approximately 20-40KB in size.

If no logo.jpg is found in /etc/nwipe then nwipe will display it's standard embedded logo.

Example logo.jpg placed into /etc/nwipe/
<img width="256" height="256" alt="logo_SIGINT_256x256_300dpi" src="https://github.com/user-attachments/assets/0bc5e600-b331-415a-acf6-14c9bd3bbb84" />

Example of how it looks on the PDFs
<img width="1184" height="839" alt="Screenshot_20260607_232440" src="https://github.com/user-attachments/assets/afd48304-d781-41ed-9ad6-3f007237b85c" />

----------------------------------------------

<img width="1246" height="883" alt="Screenshot_20260608_000342" src="https://github.com/user-attachments/assets/02ced625-f0b1-49e9-92de-cab15178acdd" />
