### PR TITLE
Add speed profile page creation

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -75,8 +75,8 @@ typedef enum {
     NWIPE_IO_DIRECTION_SCATTER /* Random Order */
 } nwipe_io_direction_t;
 
-#define NWIPE_KNOB_SPEEDRING_SIZE 30
-#define NWIPE_KNOB_SPEEDRING_GRANULARITY 10
+#define NWIPE_KNOB_SPEEDRING_SIZE 300
+#define NWIPE_KNOB_SPEEDRING_GRANULARITY 1
 
 typedef struct nwipe_speedring_t_
 {
@@ -200,11 +200,19 @@ typedef struct nwipe_context_t_
     int wipe_status;  // Wipe finished = 0, wipe in progress = 1, wipe yet to start = -1.
     char wipe_status_txt[10];  // ERASED, FAILED, ABORTED, INSANITY
     int spinner_idx;  // Index into the spinner character array
-    char spinner_character[1];  // The current spinner character
-    double duration;  // Duration of the wipe in seconds
-    char duration_str[20];  // The duration string in hh:mm:ss
+    char spinner_character[1];  // The current spinner character// Keep for legacy date/time stamps
+    //
+    // Keep for legacy date/time stamps
     time_t start_time;  // Start time of wipe
     time_t end_time;  // End time of wipe
+    double duration;  // Duration of the wipe in seconds
+    char duration_str[20];  // The duration string in hh:mm:ss
+    //
+    // NEW: High-resolution timing fields for very fast small devices such as loop devices, for speed profiling
+    struct timespec start_clock;
+    struct timespec end_clock;
+    //
+    double exact_duration;  // Duration in seconds with decimal precision (e.g., 0.000250)
     u64 fsyncdata_errors;  // The number of fsyncdata errors across all passes.
     u64 io_retries;  // The number of I/O retries across all passes.
     char PDF_filename[FILENAME_MAX];  // The filename of the PDF certificate/report.
@@ -236,6 +244,8 @@ typedef struct nwipe_context_t_
      * c[i]->serial_no) and not c[i]->identity.serial_no);
      */
     struct hd_driveid identity;
+    float min_throughput[400];  // buckets for storing minimum speed of drive
+    float max_throughput[400];  // buckets for storing maximum speed of drive
 } nwipe_context_t;
 
 /*

--- a/src/create_pdf.h
+++ b/src/create_pdf.h
@@ -69,6 +69,15 @@ int create_single_disc_pdf( nwipe_thread_data_ptr_t*, nwipe_context_t* ptr );
 
 int nwipe_get_smart_data( nwipe_misc_thread_data_t*, size_t, size_t*, nwipe_context_t* );
 
+/**
+ * Create the disk speed profile page for both single disc and multi disk system PDF certificates
+ * @param pointer nwipe_misc_thread_data_t
+ * @param size_t PDF type PDF_TYPE_SINGLE_DISC PDF_TYPE_MULTI_DISC
+ * @param size_t* pointer to page number
+ * @param pointer drive context
+ */
+size_t create_pdf_speed_profile_page( nwipe_misc_thread_data_t*, size_t, size_t*, nwipe_context_t* c );
+
 void pdf_header_footer_text( nwipe_misc_thread_data_t*, nwipe_context_t*, char*, size_t, size_t );
 
 /**
@@ -178,5 +187,27 @@ void pdf_add_footer_page_numbers( void*, size_t, size_t );
  * NOTE: The caller is responsible for calling free() on the returned pointer.
  */
 unsigned char* check_and_load_logo( size_t* out_len );
+
+/**
+ * Generates a stylized dual-line graph on an existing PDF document page with peak annotations,
+ * an overall duration average line, and an expanded left margin padding for clean axis label layout.
+ * @param pointer to the PDF document
+ * @param pointer to the PDF page
+ * @param float array of minimum speed values
+ * @param float array of maximum speed values
+ * @param int the number of elements in each array (400 for portrait)
+ * @param char* title text label
+ * @param char* x_label text label
+ * @param char* y_axis text label
+ * @param float x_scale_max
+ */
+int generate_graph_pdf( float plot_y_start,
+                        const float* min_values,
+                        const float* max_values,
+                        int data_count,
+                        const char* title,
+                        const char* x_label,
+                        const char* y_label,
+                        float x_scale_max );
 
 #endif /* CREATE_PDF_H_ */

--- a/src/create_pdf_graph.c
+++ b/src/create_pdf_graph.c
@@ -21,6 +21,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "context.h"
+#include "create_pdf.h"
 #include "PDFGen/pdfgen.h"
 
 // --- Global Page Geometry Setup (A4 Portrait Layout) ---
@@ -29,13 +31,293 @@ const float PAGE_HEIGHT = 841.89f;  // A4 height in points
 
 #define DATA_POINTS 400  // Fixed sizing requirement for dataset array length
 
+extern struct pdf_doc* pdf;
+extern struct pdf_object* page;
+
+size_t
+create_pdf_speed_profile_page( nwipe_misc_thread_data_t* d, size_t pdf_type, size_t* page_number, nwipe_context_t* c )
+{
+    extern struct pdf_object** pdf_page_array;
+
+    // --- Global Page Geometry Setup (A4 Portrait Layout) ---
+    const float PAGE_WIDTH = 595.27f;  // A4 width in points
+    const float PAGE_HEIGHT = 841.89f;  // A4 height in point
+    char speed_profile_page_title[100];
+    char buffer[512];
+    int x, y;
+#if 0
+    float min_disk_speed[DATA_POINTS];
+    float max_disk_speed[DATA_POINTS];
+
+    // TEST CASE #1: Next-Gen NVMe Drive (GB/s range)
+    //    float start_speed_bytes = 2100000000.0f; // 2.1 GB/s
+    //    float end_speed_bytes   = 1700000000.0f; // 1.7 GB/s
+    //    float anomaly_drop      = 800000000.0f;  // 800 MB/s (0.8 GB/s)
+
+    // TEST CASE #2: Standard High-Speed Drive (MB/s range)
+    float start_speed_bytes = 68000000.0f;  // 68 MB/s
+    float end_speed_bytes = 55000000.0f;  // 55 MB/s
+    float anomaly_drop = 25000000.0f;  // 25 MB/s
+
+    // Populate data loops
+    for( int i = 0; i < DATA_POINTS; i++ )
+    {
+        int cycle_index = i % 100;
+        float linear_drop_ratio = (float) cycle_index / 99.0f;
+
+        float current_speed_bytes = start_speed_bytes - ( linear_drop_ratio * ( start_speed_bytes - end_speed_bytes ) );
+
+        min_disk_speed[i] = current_speed_bytes;
+        max_disk_speed[i] = current_speed_bytes;
+
+        if( i == 140 || i == 340 )
+        {
+            min_disk_speed[i] = anomaly_drop;
+        }
+    }
+#endif
+
+    // Add a new page for the graph
+    page = pdf_append_page_and_update_index( pdf, ++( *page_number ) );
+
+    // Fill Page Background
+    const uint32_t COLOR_BG = 0xFFFFFF;
+    pdf_add_filled_rectangle( pdf, NULL, 0, 0, PAGE_WIDTH, PAGE_HEIGHT, 0, COLOR_BG, COLOR_BG );
+
+    /* Create the header and footer for the speed profile page */
+    snprintf( speed_profile_page_title, sizeof( speed_profile_page_title ), "Page %zu - Speed Profile", *page_number );
+    pdf_header_footer_text( d, c, speed_profile_page_title, pdf_type, PDF_PAGE_SMART_DATA );
+
+    /* Display the appropriate status icon (green tick, red cross, tick with exclamation) for
+     * the single disk PDF. For multi disc PDFs the status icon is written upon completion
+     * of the entire PDF within the create_system_multidisc_pdf() function.
+     */
+    if( pdf_type == PDF_TYPE_SINGLE_DISC )
+    {
+        pdf_display_status_icon( PDF_TYPE_SINGLE_DISC, NULL );
+    }
+
+    x = LEFT_MARGIN_SMART_DATA;  // left side of page
+
+    /* For multidisc the smart data starts slighlty lower to accomodate
+     * the erasure status ellipse & text
+     */
+    if( pdf_type == PDF_TYPE_SINGLE_DISC )
+    {
+        y = TOP_OF_TEXT_WINDOW_Y;  // top row of page
+    }
+    else
+    {
+        y = START_OF_SMART_DATA_TEXT_Y_MULTIDISC;  // start of smart data
+    }
+
+    if( pdf_type == PDF_TYPE_MULTI_DISC && y == START_OF_SMART_DATA_TEXT_Y_MULTIDISC )
+    {
+        /* Write the erasure status of this drive at the top of each smart data page
+         * for system multi disc pdf only
+         */
+        pdf_set_font( pdf, "Helvetica-Bold" );
+        snprintf( buffer, sizeof( buffer ), "Erasure Status of this disk: S/N %s", c->device_serial_no );
+        pdf_add_text( pdf, NULL, buffer, 10, 160, TOP_OF_TEXT_WINDOW_Y - 3, PDF_BLACK );
+        pdf_add_text_status_of_erasure( LEFT_MARGIN_SMART_DATA + 25,
+                                        TOP_OF_TEXT_WINDOW_Y - 4,
+                                        LEFT_MARGIN_SMART_DATA + 50,
+                                        TOP_OF_TEXT_WINDOW_Y + 1,
+                                        45,
+                                        10,
+                                        0,
+                                        c );
+        pdf_set_font( pdf, "Courier" );
+    }
+
+    // Place the graph above the help text
+    float graph_y_start = 340.0f;
+
+    // Convert erasure duartion in seconds to minutes for x axis scale
+    // float x_scale_max = (float)c->duration / 60.0f;
+
+    // Safeguard: Clamp to a minimum of 1 minute for ultra-fast runs
+    // if( x_scale_max < 1.0f )
+    //{
+    //  x_scale_max = 1.0f;
+    //}
+#if 0
+    /* ======================================================================
+     * GRAPH DATA POLISHING: Forward-Fill Trailing Buckets
+     * Extends the final valid throughput values to the 100% edge for
+     * fast-completing drives that terminate between timer ticks.
+     * ====================================================================== */
+    double last_valid_max = 0.0;
+    double last_valid_min = 0.0;
+
+    for( int b = 0; b < 400; b++ )
+    {
+        // Track the last non-zero maximum speed seen
+        if( c->max_throughput[b] > 0.0 )
+        {
+            last_valid_max = c->max_throughput[b];
+        }
+        else if( last_valid_max > 0.0 )
+        {
+            // Carry the last known speed forward into the uninitialized bucket
+            c->max_throughput[b] = last_valid_max;
+        }
+
+        // Track the last non-zero minimum speed seen
+        if( c->min_throughput[b] > 0.0 )
+        {
+            last_valid_min = c->min_throughput[b];
+        }
+        else if( last_valid_min > 0.0 )
+        {
+            // Carry the last known speed forward into the uninitialized bucket
+            c->min_throughput[b] = last_valid_min;
+        }
+    }
+
+    /* ======================================================================
+     * GRAPH DATA POLISHING: Forward-Fill & Zero-Data Fallback
+     *
+     * ====================================================================== */
+    double last_valid_max = 0.0;
+    double last_valid_min = 0.0;
+
+    for( int b = 0; b < 400; b++ )
+    {
+        if( c->max_throughput[b] > 0.0 )  last_valid_max = c->max_throughput[b];
+        else if( last_valid_max > 0.0 )       c->max_throughput[b] = last_valid_max;
+
+        if( c->min_throughput[b] > 0.0 )  last_valid_min = c->min_throughput[b];
+        else if( last_valid_min > 0.0 )       c->min_throughput[b] = last_valid_min;
+    }
+
+    // Fallback for sub-millisecond wipes that bypassed the timer loop entirely
+    if( last_valid_max == 0.0 && c->bytes_erased > 0 )
+    {
+        double final_speed = c->throughput;
+
+        if( final_speed <= 0.0 && c->duration > 0 )
+        {
+            final_speed = (double)c->bytes_erased / (double)c->duration;
+        }
+
+        for( int b = 0; b < 400; b++ )
+        {
+            c->max_throughput[b] = final_speed;
+            c->min_throughput[b] = final_speed;
+        }
+    }
+    /* ====================================================================== */
+#endif
+
+    /* ======================================================================
+     * GRAPH DATA POLISHING: Forward-Fill & Zero-Data Fallback
+     * ====================================================================== */
+    double last_valid_max = 0.0;
+    double last_valid_min = 0.0;
+
+    for( int b = 0; b < 400; b++ )
+    {
+        if( c->max_throughput[b] > 0.0 )
+            last_valid_max = c->max_throughput[b];
+        else if( last_valid_max > 0.0 )
+            c->max_throughput[b] = last_valid_max;
+
+        if( c->min_throughput[b] > 0.0 )
+            last_valid_min = c->min_throughput[b];
+        else if( last_valid_min > 0.0 )
+            c->min_throughput[b] = last_valid_min;
+    }
+
+    // Fallback for sub-millisecond wipes that bypassed the timer loop entirely
+    if( last_valid_max == 0.0 && c->bytes_erased > 0 )
+    {
+        // Use the global throughput calculated by nwipe if available
+        double final_speed = c->throughput;
+
+        if( final_speed <= 0.0 )
+        {
+            if( c->duration > 0 )
+            {
+                final_speed = (double) c->bytes_erased / (double) c->duration;
+            }
+            else
+            {
+                // Safeguard against division by zero for sub-second execution.
+                // Treats the burst as having occurred over 1 second.
+                final_speed = (double) c->bytes_erased;
+            }
+        }
+
+        // Broadcast the fallback speed across all buckets
+        for( int b = 0; b < 400; b++ )
+        {
+            c->max_throughput[b] = final_speed;
+            c->min_throughput[b] = final_speed;
+        }
+    }
+    /* ====================================================================== */
+
+    // Generate Graph Vector Elements
+    generate_graph_pdf( graph_y_start,
+                        c->min_throughput,
+                        c->max_throughput,
+                        DATA_POINTS,
+                        "",
+                        "Erasure Completion - %",
+                        "Speed",
+                        100.0f );
+
+    // --- Interpretation Help & Disclaimer Text Block ---
+    const float PLOT_X = LEFT_MARGIN_TEXT + 20;
+
+    // 1. Interpretation Content Lines
+    const char* help_title = "Interpretation Guide:";
+    const char* help_body1 = "Monitor the speed vectors closely for unusual anomalies or performance bottlenecks.";
+    const char* help_body2 = "Look for sharp, sudden downward spikes where operational speed differs substantially";
+    const char* help_body3 = "from typical baseline values. These spikes can indicate a drive slowing down over";
+    const char* help_body4 = "specificphysical sectors, signaling potential disk failure. Such degradation may not";
+    const char* help_body5 = "trigger standard drive or I/O errors, meaning it won't always be obvious in SMART data.";
+    const char* help_body6 = "The SMART health status may even report the drive as 'Good' when,in fact, this graph ";
+    const char* help_body7 = "highlights a localized failure on the platter surface.";
+
+    // 2. Disclaimer Content Lines
+    const char* disc_title = "Disclaimer:";
+    const char* disc_body1 = "If your system is suffering from controller bottlenecks or CPU constraints due to too";
+    const char* disc_body2 = "many discs being simultaneously erased due to a non-optimal setup, the disk profile may";
+    const char* disc_body3 = "not represent the true speed profile. If in doubt, test using ShredOS with only the";
+    const char* disc_body4 = "single disk you suspect is behaving oddly in regards to its speed profile.";
+
+    // Render Interpretation Text Vector Elements (Y positions spaced down progressively)
+    size_t PLOT_Y = 240;
+    size_t PLOT_Y_DIFF = 11;
+    pdf_set_font( pdf, "Courier" );
+    pdf_add_text( pdf, NULL, help_title, 10.0f, PLOT_X, PLOT_Y, PDF_BLACK );
+    pdf_add_text( pdf, NULL, help_body1, 8.0f, PLOT_X, ( PLOT_Y -= PLOT_Y_DIFF ), PDF_BLACK );
+    pdf_add_text( pdf, NULL, help_body2, 8.0f, PLOT_X, ( PLOT_Y -= PLOT_Y_DIFF ), PDF_BLACK );
+    pdf_add_text( pdf, NULL, help_body3, 8.0f, PLOT_X, ( PLOT_Y -= PLOT_Y_DIFF ), PDF_BLACK );
+    pdf_add_text( pdf, NULL, help_body4, 8.0f, PLOT_X, ( PLOT_Y -= PLOT_Y_DIFF ), PDF_BLACK );
+    pdf_add_text( pdf, NULL, help_body5, 8.0f, PLOT_X, ( PLOT_Y -= PLOT_Y_DIFF ), PDF_BLACK );
+    pdf_add_text( pdf, NULL, help_body6, 8.0f, PLOT_X, ( PLOT_Y -= PLOT_Y_DIFF ), PDF_BLACK );
+    pdf_add_text( pdf, NULL, help_body7, 8.0f, PLOT_X, ( PLOT_Y -= PLOT_Y_DIFF ), PDF_BLACK );
+
+    // Render Disclaimer Text Vector Elements
+    PLOT_Y -= 20;
+    pdf_add_text( pdf, NULL, disc_title, 10.0f, PLOT_X, PLOT_Y -= PLOT_Y_DIFF, PDF_BLACK );
+    pdf_add_text( pdf, NULL, disc_body1, 8.0f, PLOT_X, PLOT_Y -= PLOT_Y_DIFF, PDF_BLACK );
+    pdf_add_text( pdf, NULL, disc_body2, 8.0f, PLOT_X, PLOT_Y -= PLOT_Y_DIFF, PDF_BLACK );
+    pdf_add_text( pdf, NULL, disc_body3, 8.0f, PLOT_X, PLOT_Y -= PLOT_Y_DIFF, PDF_BLACK );
+    pdf_add_text( pdf, NULL, disc_body4, 8.0f, PLOT_X, PLOT_Y -= PLOT_Y_DIFF, PDF_BLACK );
+
+    return 0;
+}
+
 /**
  * Generates a stylized dual-line graph on an existing PDF document page with peak annotations,
  * an overall duration average line, and an expanded left margin padding for clean axis label layout.
  */
-int generate_graph_pdf( struct pdf_doc* pdf,
-                        struct pdf_object* page,
-                        float plot_y_start,
+
+int generate_graph_pdf( float plot_y_start,
                         const float* min_values,
                         const float* max_values,
                         int data_count,
@@ -44,7 +326,8 @@ int generate_graph_pdf( struct pdf_doc* pdf,
                         const char* y_label,
                         float x_scale_max )
 {
-    if( !pdf || !page || !min_values || !max_values || data_count < 2 )
+    // page excluded from NULL check as NULL is a valid value
+    if( !pdf || !min_values || !max_values || data_count < 2 )
     {
         return -1;
     }
@@ -61,7 +344,7 @@ int generate_graph_pdf( struct pdf_doc* pdf,
     // --- Graph Geometry Setup ---
     const float PLOT_W = 400.0f;
     const float PLOT_X = 115.0f;  // Opened up extra space on the left margin
-    const float PLOT_H = 400.0f;
+    const float PLOT_H = 200.0f;
     const float PLOT_Y = plot_y_start;
 
     // 1. Scan dataset to find absolute min, max, and sum
@@ -174,6 +457,10 @@ int generate_graph_pdf( struct pdf_doc* pdf,
 
     // 2. Draw Vertical Grid Lines & X-Axis Labels (Fixed at 5 horizontal blocks)
     const int X_GRID_DIVISIONS = 5;
+
+    // Dynamically choose precision: use 1 decimal place if the max time window is small, i.e for small loop devices
+    // const char* x_fmt = (x_scale_max <= 5.0f) ? "%.1f" : "%.0f";
+
     for( int i = 0; i <= X_GRID_DIVISIONS; i++ )
     {
         float ratio = (float) i / X_GRID_DIVISIONS;
@@ -196,7 +483,7 @@ int generate_graph_pdf( struct pdf_doc* pdf,
         }
 
         char label_buf[32];
-        snprintf( label_buf, sizeof( label_buf ), "%.0f", val_x );
+        snprintf( label_buf, sizeof( label_buf ), "%.0f%%", val_x );
         float text_width = 0;
         pdf_get_font_text_width( pdf, "Helvetica", label_buf, 9.0f, &text_width );
         pdf_add_text( pdf, page, label_buf, 9.0f, curr_x - ( text_width / 2.0f ), PLOT_Y - 15.0f, COLOR_TEXT_MUTED );

--- a/src/create_single_disc_pdf.c
+++ b/src/create_single_disc_pdf.c
@@ -514,6 +514,11 @@ int create_single_disc_pdf( nwipe_thread_data_ptr_t* ptrx, nwipe_context_t* ptr 
      */
     nwipe_get_smart_data( d, PDF_TYPE_SINGLE_DISC, &page_number, c );
 
+    /***************************************
+     * Add speed profile graph
+     */
+    create_pdf_speed_profile_page( d, PDF_TYPE_SINGLE_DISC, &page_number, c );
+
     /*****************************
      * Create the reports filename
      *

--- a/src/create_system_multi_disc_pdf.c
+++ b/src/create_system_multi_disc_pdf.c
@@ -496,6 +496,26 @@ int create_system_multi_disc_pdf( nwipe_thread_data_ptr_t* ptrx )
             nwipe_log( NWIPE_LOG_ERROR, "Function nwipe_get_smart_data() returned an error %u", result );
             goto cleanup;
         }
+
+        /* If the command line option --pdfduplex is active, insert a blank odd (recto) page before an even (verso)
+         * page. */
+        if( nwipe_options.PDF_duplex == 1 )
+        {
+            if( !( ( page_number + 1 ) % 2 ) )
+            {
+                pdf_add_blank_page(
+                    pdf, &page_number, INTENTIONALLY_BLANK_X, INTENTIONALLY_BLANK_Y, PDF_TYPE_MULTI_DISC, NULL, d );
+            }
+        }
+
+        /* Write the page containing the speed profile graph for a given drive */
+        result = create_pdf_speed_profile_page( d, PDF_TYPE_MULTI_DISC, &page_number, c[i] );
+        if( result != 0 )
+        {
+            // fatal error, don't bother trying to save the file'
+            nwipe_log( NWIPE_LOG_ERROR, "Function create_pdf_speed_profile_page() returned an error %u", result );
+            goto cleanup;
+        }
     }
 
     /************************************************************************************

--- a/src/gui.c
+++ b/src/gui.c
@@ -8191,6 +8191,140 @@ int compute_stats( void* ptr )
                 }
             }
 
+            /* ======================================================================
+             * GRAPH MIN/MAX TRACKING ENGINE (Adaptive Sub-Window Slice)
+             * Fills the 400 bucket min/max arrays, used to construct speed profile
+             * graph.
+             * ====================================================================== */
+            u64 bytes_10 = 0;
+            u64 times_10 = 0;
+            int idx = c[i]->speedring.position;
+            int sub_window_seconds = 10;  // Tracks localized shifts tightly
+
+            for( int j = 0; j < sub_window_seconds; j++ )
+            {
+                /* Safely step backward through the 300-slot ring buffer */
+                idx = ( idx - 1 + 300 ) % 300;
+
+                if( c[i]->speedring.times[idx] == 0 )
+                {
+                    break;  // Stop early if the drive thread hasn't run for 10 seconds yet
+                }
+
+                bytes_10 += c[i]->speedring.bytes[idx];
+                times_10 += c[i]->speedring.times[idx];
+            }
+
+            /* FIX 1: Change constraint from '>= sub_window_seconds' to '> 0'
+             * This allows ultra-fast wipes to log their throughput immediately,
+             * while also improving normal drives by drawing lines from second 1. */
+            if( times_10 > 0 && c[i]->round_size > 0 )
+            {
+                double throughput_10 = (double) bytes_10 / (double) times_10;
+
+                /* Map current byte progress cleanly to one of the 400 array buckets */
+                int bucket = (int) ( (double) c[i]->round_done / (double) c[i]->round_size * 400.0 );
+
+                /* Guard against an out-of-bounds array index at exactly 100% completion */
+                if( bucket >= 400 )
+                {
+                    bucket = 399;
+                }
+
+                /* Record maximum throughput for this chunk */
+                if( throughput_10 > c[i]->max_throughput[bucket] )
+                {
+                    c[i]->max_throughput[bucket] = throughput_10;
+                }
+
+                /* Record minimum throughput for this chunk */
+                if( c[i]->min_throughput[bucket] == 0 || throughput_10 < c[i]->min_throughput[bucket] )
+                {
+                    c[i]->min_throughput[bucket] = throughput_10;
+                }
+
+                /* FIX 2:Backfill previous uninitialized buckets.
+                 * Because fast wipes blitz across multiple progress buckets between 1-second ticks,
+                 * this bridges the gaps backward to form a continuous, readable line on the PDF. */
+                for( int b = bucket - 1; b >= 0; b-- )
+                {
+                    int backfill_performed = 0;
+
+                    if( c[i]->max_throughput[b] == 0.0f )
+                    {
+                        c[i]->max_throughput[b] = throughput_10;
+                        backfill_performed = 1;
+                    }
+                    if( c[i]->min_throughput[b] == 0.0f )
+                    {
+                        c[i]->min_throughput[b] = throughput_10;
+                        backfill_performed = 1;
+                    }
+
+                    /* If we hit a bucket that already contains real historical data from a
+                     * previous sampling period, stop backfilling to preserve accurate history. */
+                    if( !backfill_performed )
+                    {
+                        break;
+                    }
+                }
+            }
+            /* ====================================================================== */
+#if 0
+            /* ======================================================================
+             * GRAPH MIN/MAX TRACKING ENGINE (10-Second Sub-Window Slice)
+             * Fills the 400 bucket min/max arrays, used to construct speed profile
+             * graph.
+             * ====================================================================== */
+            u64 bytes_10 = 0;
+            u64 times_10 = 0;
+            int idx = c[i]->speedring.position;
+            int sub_window_seconds = 10;  // Tracks localized shifts tightly
+
+            for( int j = 0; j < sub_window_seconds; j++ )
+            {
+                /* Safely step backward through the 300-slot ring buffer */
+                idx = ( idx - 1 + 300 ) % 300;
+
+                if( c[i]->speedring.times[idx] == 0 )
+                {
+                    break;  // Stop early if the drive thread hasn't run for 10 seconds yet
+                }
+
+                bytes_10 += c[i]->speedring.bytes[idx];
+                times_10 += c[i]->speedring.times[idx];
+            }
+
+            /* Only log data once we have gathered a valid time-slice */
+            if( times_10 >= (u64) sub_window_seconds && c[i]->round_size > 0 )
+            {
+                double throughput_10 = (double) bytes_10 / (double) times_10;
+
+                /* Map current byte progress cleanly to one of the 400 array buckets */
+                int bucket = (int) ( (double) c[i]->round_done / (double) c[i]->round_size * 400.0 );
+
+                /* Guard against an out-of-bounds array index at exactly 100% completion */
+                if( bucket >= 400 )
+                {
+                    bucket = 399;
+                }
+
+                /* Record maximum throughput for this chunk */
+                if( throughput_10 > c[i]->max_throughput[bucket] )
+                {
+                    c[i]->max_throughput[bucket] = throughput_10;
+                }
+
+                /* Record minimum throughput for this chunk
+                 * (Checks if uninitialized '0' or if a new definitive minimum is found) */
+                if( c[i]->min_throughput[bucket] == 0 || throughput_10 < c[i]->min_throughput[bucket] )
+                {
+                    c[i]->min_throughput[bucket] = throughput_10;
+                }
+            }
+#endif
+            /* ====================================================================== */
+
             /* Calculate the average throughput */
             c[i]->throughput = (double) c[i]->round_done / (double) difftime( nwipe_time_now, c[i]->start_time );
         }

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -793,6 +793,10 @@ int main( int argc, char** argv )
 
         /* Initialise the variable that tracks how much of the drive has been erased */
         c1[i]->bytes_erased = 0;
+
+        /* Zero buckets that will contain the max and min disk speeds */
+        memset( c1[i]->min_throughput, 0, sizeof( c1[i]->min_throughput ) );
+        memset( c1[i]->max_throughput, 0, sizeof( c1[i]->max_throughput ) );
     }
 
     /* Pass the number selected to the struct for other threads */


### PR DESCRIPTION
The purpose of this speed profile page that is present in both the single disc and multi disc system certificates, is to provide the user with a quick visual indication of a disc that might have a issues. See example images below.

Added the speed profile page creation to the single disc and system multi disc PDF creation functions. The x axis granularity of the graph is exactly 400 points, therefore a 400 bucket minimum speed and a 400 bucket maximum speed data sets are generated. The Total number of bytes to be erased (number of passes x rounds) is divided by 400. So if a single pass of a 1TB drive, each bucket would represent 2.5GB. The max/min values are recorded for that bucket. Tested with 160GB drives with both drives that a functioning properly and drives that are failing. Speeds are sampled at 10 second intervals via additional code added to the speedring buffer. The speedring buffer was increased in size from 30 to 300 elements with standard sample granularity changed from 10 to 1. This effectively will make ETA a little more responsive to speed changes. The graph will show min, max and overall average speed values.

One further commit will resolve the display of sub 1 second wipes by using nano or milli second recording of start end end times.

### Example 1 - Single pass, showing typical reduction in speed as heads move to inner cyclinders. Drive has no faults, no reallocated sectors, no significant errors recorded in smart data. This is what is expected for a drive that has no faults.
<img width="886" height="477" alt="Screenshot_20260712_213429" src="https://github.com/user-attachments/assets/a96d49fe-5004-4651-aa9e-778880d9ef98" />

### Example 2 - PRNG pass + PRNG verification pass + Blanking (zero) pass + zeros verification pass, expected saw tooth graph as heads retract back to outer cylinders for each new pass. Ignore x axis label in minutes. X axis will always be percentage completion and not minutes. This is what is expected for a drive that has no faults.
<img width="886" height="512" alt="Screenshot_20260712_213849" src="https://github.com/user-attachments/assets/0b6f20fa-75a6-4a6d-a01c-22f815a07911" />

### Example 3 - This graph used the same method as example 2 PRNG + blanking + all pass verification. Interestingly the drive reported 0 errors and 0 retries. The drive had no reallocated sectors, however if the smart data was examined closely there was a value that seemed high, read_soft_error_rate = 77762928 and hardware_ecc_recovered 77762928. The first pass speed was normal, the average speed throughput is lower than expected. However the user could have missed the fact that this drive has a serious read problem that isn't reporting I/O errors.
<img width="886" height="512" alt="Screenshot_20260712_214545" src="https://github.com/user-attachments/assets/e32a00d2-d120-43bc-858e-44d86d0c39d2" />

### Example 4 - This last graph shows a failing drive that ultimately ended the wipe with I/O errors hitting the 3 retries limit. Notice the eratic speed prior to the drive ultimately failing.
<img width="867" height="506" alt="Screenshot_20260712_215607" src="https://github.com/user-attachments/assets/8ea24825-6e0e-47eb-99c0-655c6c5ad431" />

### Example 5 - This represents a ones method + verification on a cheap unbranded USB stick 'General UDISK' with a sustained write of about 8MB/s and read of ~23MB/s, no faults. 
<img width="863" height="485" alt="Screenshot_20260713_213435" src="https://github.com/user-attachments/assets/c04fdaa6-4d28-4308-ae78-3b9b87f0ec1e" />

