### PR TITLE
create_pdf: use smartctl -x instead of -a

### DIFF
--- a/src/create_pdf.c
+++ b/src/create_pdf.c
@@ -73,10 +73,10 @@ int nwipe_get_smart_data( nwipe_misc_thread_data_t* d, size_t pdf_type, size_t* 
     char* pdata;
     char page_title[50];
 
-    char smartctl_command[] = "smartctl -a %s";
-    char smartctl_command2[] = "/sbin/smartctl -a %s";
-    char smartctl_command3[] = "/usr/bin/smartctl -a %s";
-    char smartctl_command4[] = "/usr/sbin/smartctl -a %s";
+    char smartctl_command[] = "smartctl -x %s";
+    char smartctl_command2[] = "/sbin/smartctl -x %s";
+    char smartctl_command3[] = "/usr/bin/smartctl -x %s";
+    char smartctl_command4[] = "/usr/sbin/smartctl -x %s";
     char final_cmd_smartctl[sizeof( smartctl_command3 ) + 256];
     char result[512];
     char buffer[512];


### PR DESCRIPTION
smartctl -x/--xall gives additional information compared to what smartctl -a/--all does, including attributes like Percentage Used Endurance Indicator for SSDs - which is very useful to have if re-selling a used drive with the nwipe report included.

The -x/--xall option was added to smartmontools in version 5.39, released 2009-12-09, so it should be safe to assume that it is supported on all modern distros by now.