### PR TITLE
miscellaneous: guard popen result before pclose in write_system_datetime

### DIFF
--- a/src/miscellaneous.c
+++ b/src/miscellaneous.c
@@ -612,15 +612,21 @@ int write_system_datetime( char* year, char* month, char* day, char* hours, char
      */
 
     fp = popen( cmd, "w" );
-    r = pclose( fp );
-
-    if( fp == NULL || r != 0 )
+    if( fp == NULL )
     {
         nwipe_log( NWIPE_LOG_ERROR, "Failed to write system date/time using command = %s", cmd );
     }
     else
     {
-        nwipe_log( NWIPE_LOG_INFO, "Date/time succesfully writen to system using command = %s", cmd );
+        r = pclose( fp );
+        if( r != 0 )
+        {
+            nwipe_log( NWIPE_LOG_ERROR, "Failed to write system date/time using command = %s", cmd );
+        }
+        else
+        {
+            nwipe_log( NWIPE_LOG_INFO, "Date/time succesfully writen to system using command = %s", cmd );
+        }
     }
 
     return 0;


### PR DESCRIPTION
## What

In `write_system_datetime()` (`src/miscellaneous.c`) the final `popen()` result is used before it is checked for NULL: `pclose(fp)` runs unconditionally, and only afterwards does `if( fp == NULL || r != 0 )` test the handle. If `popen()` fails and returns NULL (for example a fork failure under memory pressure, which is realistic on the live-USB environments nwipe targets), `pclose(NULL)` dereferences the NULL `FILE*` and crashes.

## Why

The guard cannot protect anything because it runs after `pclose()` has already touched the possibly-NULL handle. Every other `popen()` block in this same function already uses the correct order (`if( fp == NULL ) { log } else { ... pclose(fp) }`); this last block was the only one that did not.

## Change

Only call `pclose()` inside the non-NULL branch, mirroring the pattern used by the other `popen()` blocks in the function. The NULL case logs the existing error message; behaviour is otherwise unchanged.

## How tested

`clang-format` (repo `.clang-format`) reports no changes. A full build could not be produced on the machine used here (no `libparted`), but the change is a minimal reordering that matches the sibling blocks already present in the same function.
