### PR TITLE
Secure erase improvements

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -81,6 +81,14 @@ typedef enum {
     NWIPE_SECURE_ERASE_FAILURE /* Secure erase has failed */
 } nwipe_secure_erase_status_t;
 
+/* Keep this list applicable for both ATA and NVMe */
+typedef enum {
+    NWIPE_SECURE_ERASE_METHOD_UNKNOWN = 0,
+    NWIPE_SECURE_ERASE_METHOD_BLOCK, /* Block Erase */
+    NWIPE_SECURE_ERASE_METHOD_CRYPTO, /* Crypto Erase */
+    NWIPE_SECURE_ERASE_METHOD_OVERWRITE /* Pattern Overwrite */
+} nwipe_secure_erase_method_t;
+
 /* I/O direction for data path. */
 typedef enum {
     NWIPE_IO_DIRECTION_FORWARD = 0, /* Start -> End */
@@ -257,6 +265,7 @@ typedef struct nwipe_context_t_
                                  //  1: Confirmed to be supported by device
     nwipe_secure_erase_type_t secure_erase_type; /* Secure Erase: ATA or NVMe */
     nwipe_secure_erase_status_t secure_erase_status; /* Secure Erase: Status */
+    nwipe_secure_erase_method_t secure_erase_method; /* Secure Erase: Method */
     void* secure_erase_context; /* Secure Erase: Pointer to context */
 
     /*

--- a/src/display_help.c
+++ b/src/display_help.c
@@ -1,6 +1,7 @@
 #include "stdio.h"
 #include "ANSI-color-codes.h"
 
+/* clang-format off */
 void display_help()
 {
     /************************************************
@@ -210,3 +211,4 @@ void display_help()
     "        --exclude=/dev/disk/by-id/ata-XXXXXXXX\n" \
     "        --exclude=/dev/disk/by-path/pci-0000:00:17.0-ata-1\n\n");
 }
+/* clang-format on */

--- a/src/se_ata_gui.c
+++ b/src/se_ata_gui.c
@@ -446,7 +446,7 @@ static int nwipe_gui_se_ata_overwrite_opts( nwipe_context_t* ctx, nwipe_se_ata_c
 
 static void nwipe_gui_se_ata_monitor( nwipe_context_t* ctx, nwipe_se_ata_ctx* san )
 {
-    const char* ftr_progress = "ESC=Stop Monitoring";
+    const char* ftr_progress = "No keyboard actions are available";
     int user_aborted = 0;
 
     werase( footer_window );
@@ -507,13 +507,14 @@ static void nwipe_gui_se_ata_monitor( nwipe_context_t* ctx, nwipe_se_ata_ctx* sa
         if( !poll_err && san->state != NWIPE_SE_ATA_STATE_IN_PROGRESS )
             break;
 
-        /* Wait ~5s, check for ESC */
+        /* Wait ~5s, monitoring is intentionally not interruptible */
         for( int tick = 0; tick < 20 && terminate_signal != 1; tick++ )
         {
             timeout( 250 );
             keystroke = getch();
             timeout( -1 );
 
+#if 0 /* TODO: re-enable if monitoring should be interruptible */
             switch( keystroke )
             {
                 case KEY_BACKSPACE:
@@ -522,6 +523,7 @@ static void nwipe_gui_se_ata_monitor( nwipe_context_t* ctx, nwipe_se_ata_ctx* sa
                     user_aborted = 1;
                     break;
             }
+#endif
             if( user_aborted )
                 break;
         }

--- a/src/se_ata_gui.c
+++ b/src/se_ata_gui.c
@@ -114,6 +114,34 @@ static const char* nwipe_gui_se_ata_action_str( nwipe_se_ata_sanact_e act )
     return "Unknown";
 } /* nwipe_gui_se_ata_action_str */
 
+/*
+ * Sets the device context erase method from a ATA sanitize action.
+ * Returns 1 when a known secure erase method was set.
+ * Returns 0 when NWIPE_SECURE_ERASE_METHOD_UNKNOWN was set.
+ */
+static int nwipe_gui_se_ata_set_context_method( nwipe_context_t* ctx, nwipe_se_ata_sanact_e act )
+{
+    switch( act )
+    {
+        case NWIPE_SE_ATA_SANACT_BLOCK_ERASE:
+            ctx->secure_erase_method = NWIPE_SECURE_ERASE_METHOD_BLOCK;
+            return 1;
+
+        case NWIPE_SE_ATA_SANACT_CRYPTO_SCRAMBLE:
+            ctx->secure_erase_method = NWIPE_SECURE_ERASE_METHOD_CRYPTO;
+            return 1;
+
+        case NWIPE_SE_ATA_SANACT_OVERWRITE:
+            ctx->secure_erase_method = NWIPE_SECURE_ERASE_METHOD_OVERWRITE;
+            return 1;
+
+        default:
+            /* Keep this to prevent a stale method from a previous run */
+            ctx->secure_erase_method = NWIPE_SECURE_ERASE_METHOD_UNKNOWN;
+            return 0;
+    }
+} /* nwipe_gui_se_ata_set_context_method */
+
 static void nwipe_gui_se_ata_print_device( nwipe_context_t* ctx,
                                            nwipe_se_ata_ctx* san,
                                            WINDOW* win,
@@ -920,6 +948,9 @@ void nwipe_gui_se_ata_sanitize( nwipe_context_t* ctx, nwipe_se_ata_ctx* san )
         nwipe_se_ata_close( san );
         return;
     }
+
+    /* Inform the device context of the chosen method */
+    nwipe_gui_se_ata_set_context_method( ctx, san->planned_sanact );
 
     /* Issue the sanitize command */
     if( nwipe_se_ata_sanitize( san ) != 0 )

--- a/src/se_nvme_gui.c
+++ b/src/se_nvme_gui.c
@@ -479,7 +479,7 @@ static int nwipe_gui_se_nvme_overwrite_opts( nwipe_context_t* ctx, nwipe_se_nvme
 
 static void nwipe_gui_se_nvme_monitor( nwipe_context_t* ctx, nwipe_se_nvme_ctx* san )
 {
-    const char* ftr_progress = "ESC=Stop Monitoring";
+    const char* ftr_progress = "No keyboard actions are available";
     int user_aborted = 0;
     int method_set = 0;
 
@@ -555,13 +555,14 @@ static void nwipe_gui_se_nvme_monitor( nwipe_context_t* ctx, nwipe_se_nvme_ctx* 
         if( !poll_err && san->state != NWIPE_SE_NVME_STATE_IN_PROGRESS )
             break;
 
-        /* Wait ~5s, check for ESC */
+        /* Wait ~5s, monitoring is intentionally not interruptible */
         for( int tick = 0; tick < 20 && terminate_signal != 1; tick++ )
         {
             timeout( 250 );
             keystroke = getch();
             timeout( -1 );
 
+#if 0 /* TODO: re-enable if monitoring should be interruptible */
             switch( keystroke )
             {
                 case KEY_BACKSPACE:
@@ -570,6 +571,7 @@ static void nwipe_gui_se_nvme_monitor( nwipe_context_t* ctx, nwipe_se_nvme_ctx* 
                     user_aborted = 1;
                     break;
             }
+#endif
             if( user_aborted )
                 break;
         }

--- a/src/se_nvme_gui.c
+++ b/src/se_nvme_gui.c
@@ -137,6 +137,34 @@ static const char* nwipe_gui_se_nvme_action_str( enum nvme_sanitize_sanact act )
     return "Unknown";
 } /* nwipe_gui_se_nvme_action_str */
 
+/*
+ * Sets the device context erase method from a NVMe sanitize action.
+ * Returns 1 when a known secure erase method was set.
+ * Returns 0 when NWIPE_SECURE_ERASE_METHOD_UNKNOWN was set.
+ */
+static int nwipe_gui_se_nvme_set_context_method( nwipe_context_t* ctx, enum nvme_sanitize_sanact act )
+{
+    switch( act )
+    {
+        case NVME_SANITIZE_SANACT_START_BLOCK_ERASE:
+            ctx->secure_erase_method = NWIPE_SECURE_ERASE_METHOD_BLOCK;
+            return 1;
+
+        case NVME_SANITIZE_SANACT_START_CRYPTO_ERASE:
+            ctx->secure_erase_method = NWIPE_SECURE_ERASE_METHOD_CRYPTO;
+            return 1;
+
+        case NVME_SANITIZE_SANACT_START_OVERWRITE:
+            ctx->secure_erase_method = NWIPE_SECURE_ERASE_METHOD_OVERWRITE;
+            return 1;
+
+        default:
+            /* Keep this to prevent a stale method from a previous run */
+            ctx->secure_erase_method = NWIPE_SECURE_ERASE_METHOD_UNKNOWN;
+            return 0;
+    }
+} /* nwipe_gui_se_nvme_set_context_method */
+
 static void nwipe_gui_se_nvme_print_device( nwipe_context_t* ctx,
                                             nwipe_se_nvme_ctx* san,
                                             WINDOW* win,
@@ -453,6 +481,7 @@ static void nwipe_gui_se_nvme_monitor( nwipe_context_t* ctx, nwipe_se_nvme_ctx* 
 {
     const char* ftr_progress = "ESC=Stop Monitoring";
     int user_aborted = 0;
+    int method_set = 0;
 
     werase( footer_window );
     nwipe_gui_amend_footer_window( ftr_progress, "" );
@@ -469,6 +498,12 @@ static void nwipe_gui_se_nvme_monitor( nwipe_context_t* ctx, nwipe_se_nvme_ctx* 
         nwipe_gui_create_all_windows_on_terminal_resize( 0, ftr_progress, "" );
 
         poll_err = nwipe_se_nvme_poll( san );
+
+        /* In case monitoring was resumed, set again the device context's method */
+        if( !method_set && !poll_err && san->sanact > 0 )
+        {
+            method_set = nwipe_gui_se_nvme_set_context_method( ctx, san->sanact );
+        }
 
         nwipe_gui_se_nvme_print_device( ctx, san, main_window, &yy, tab1, &san->sanact );
         yy++;
@@ -938,6 +973,9 @@ void nwipe_gui_se_nvme_sanitize( nwipe_context_t* ctx, nwipe_se_nvme_ctx* san )
         nwipe_se_nvme_close( san );
         return;
     }
+
+    /* Inform the device context of the chosen method */
+    nwipe_gui_se_nvme_set_context_method( ctx, san->planned_sanact );
 
     /* Sanitize the device now */
     if( nwipe_se_nvme_sanitize( san ) != 0 )


### PR DESCRIPTION
- Adds chosen/resumed secure erase method to device context.
- Disables being able to exit monitoring (with option to quickly revert this in the future).
- Excludes `display_help.c` from being messed up by `clang-format` (e.g. when run from CLI).