### PR TITLE
feat(pdf): Integrate PDF and secure erase

### DIFF
--- a/src/create_pdf.c
+++ b/src/create_pdf.c
@@ -482,47 +482,63 @@ void pdf_add_text_bytes_erased( float xoff, float yoff, nwipe_context_t* c )
     char bytes_erased[50] = "";
     char bytes_percent_str[7] = "";
 
-    /* Bytes erased is not applicable when user only requested a verify */
-    if( nwipe_options.method == &nwipe_verify_one || nwipe_options.method == &nwipe_verify_zero )
+    if( c->secure_erase_orchestration == NWIPE_SECURE_ERASE_ORCHESTRATION_STANDALONE )
     {
-        snprintf( bytes_erased, sizeof( bytes_erased ), "Not applicable to method" );
-        pdf_add_text( pdf, NULL, bytes_erased, text_size_data, xoff, yoff, PDF_BLACK );
-    }
-    else
-    {
-        if( c->device_type == NWIPE_DEVICE_NVME || c->device_type == NWIPE_DEVICE_VIRT
-            || c->HPA_status == HPA_NOT_APPLICABLE )
+        if( c->secure_erase_status == NWIPE_SECURE_ERASE_SUCCESS )
         {
-            convert_double_to_string( bytes_percent_str,
-                                      (double) ( (double) c->bytes_erased / (double) c->device_size ) * 100 );
-
-            snprintf( bytes_erased, sizeof( bytes_erased ), "%lli, (%s%%)", c->bytes_erased, bytes_percent_str );
-
-            if( c->bytes_erased == c->device_size )
-            {
-                pdf_add_text( pdf, NULL, bytes_erased, text_size_data, xoff, yoff, PDF_DARK_GREEN );
-            }
-            else
-            {
-                pdf_add_text( pdf, NULL, bytes_erased, text_size_data, xoff, yoff, PDF_RED );
-            }
+            snprintf( bytes_erased, sizeof( bytes_erased ), "%lli, (%s%%)", c->device_size, "100" );
+            pdf_add_text( pdf, NULL, bytes_erased, text_size_data, xoff, yoff, PDF_DARK_GREEN );
         }
         else
         {
-
-            convert_double_to_string(
-                bytes_percent_str,
-                (double) ( (double) c->bytes_erased / (double) c->Calculated_real_max_size_in_bytes ) * 100 );
-
-            snprintf( bytes_erased, sizeof( bytes_erased ), "%lli, (%s%%)", c->bytes_erased, bytes_percent_str );
-
-            if( c->bytes_erased == c->Calculated_real_max_size_in_bytes )
+            snprintf( bytes_erased, sizeof( bytes_erased ), "%i, (%s%%)", 0, "0" );
+            pdf_add_text( pdf, NULL, bytes_erased, text_size_data, xoff, yoff, PDF_RED );
+        }
+    }
+    else
+    {
+        /* Bytes erased is not applicable when user only requested a verify */
+        if( nwipe_options.method == &nwipe_verify_one || nwipe_options.method == &nwipe_verify_zero )
+        {
+            snprintf( bytes_erased, sizeof( bytes_erased ), "Not applicable to method" );
+            pdf_add_text( pdf, NULL, bytes_erased, text_size_data, xoff, yoff, PDF_BLACK );
+        }
+        else
+        {
+            if( c->device_type == NWIPE_DEVICE_NVME || c->device_type == NWIPE_DEVICE_VIRT
+                || c->HPA_status == HPA_NOT_APPLICABLE )
             {
-                pdf_add_text( pdf, NULL, bytes_erased, text_size_data, xoff, yoff, PDF_DARK_GREEN );
+                convert_double_to_string( bytes_percent_str,
+                                          (double) ( (double) c->bytes_erased / (double) c->device_size ) * 100 );
+
+                snprintf( bytes_erased, sizeof( bytes_erased ), "%lli, (%s%%)", c->bytes_erased, bytes_percent_str );
+
+                if( c->bytes_erased == c->device_size )
+                {
+                    pdf_add_text( pdf, NULL, bytes_erased, text_size_data, xoff, yoff, PDF_DARK_GREEN );
+                }
+                else
+                {
+                    pdf_add_text( pdf, NULL, bytes_erased, text_size_data, xoff, yoff, PDF_RED );
+                }
             }
             else
             {
-                pdf_add_text( pdf, NULL, bytes_erased, text_size_data, xoff, yoff, PDF_RED );
+
+                convert_double_to_string(
+                    bytes_percent_str,
+                    (double) ( (double) c->bytes_erased / (double) c->Calculated_real_max_size_in_bytes ) * 100 );
+
+                snprintf( bytes_erased, sizeof( bytes_erased ), "%lli, (%s%%)", c->bytes_erased, bytes_percent_str );
+
+                if( c->bytes_erased == c->Calculated_real_max_size_in_bytes )
+                {
+                    pdf_add_text( pdf, NULL, bytes_erased, text_size_data, xoff, yoff, PDF_DARK_GREEN );
+                }
+                else
+                {
+                    pdf_add_text( pdf, NULL, bytes_erased, text_size_data, xoff, yoff, PDF_RED );
+                }
             }
         }
     }

--- a/src/create_single_disc_pdf.c
+++ b/src/create_single_disc_pdf.c
@@ -71,6 +71,8 @@ int create_single_disc_pdf( nwipe_thread_data_ptr_t* ptrx, nwipe_context_t* ptr 
     extern config_t nwipe_cfg;
     extern char nwipe_config_file[];
 
+    size_t idx;
+
     uint32_t text_color_size_apparent;  // local use of color
 
     //    char pdf_footer[MAX_PDF_FOOTER_TEXT_LENGTH];
@@ -81,6 +83,10 @@ int create_single_disc_pdf( nwipe_thread_data_ptr_t* ptrx, nwipe_context_t* ptr 
     char end_time_text[50] = "";
     char errors[50] = "";
     char throughput_txt[50] = "";
+    char secure_erase_method_txt[30] = "";
+
+    /* These methods should be ordered exactly as shown in nwipe_secure_erase_method_t in context.h */
+    const char* secure_erase_methods[] = { "Unknown", "Block", "Encrypt", "Overwrite" };
 
     size_t page_number = 1;
 
@@ -334,21 +340,29 @@ int create_single_disc_pdf( nwipe_thread_data_ptr_t* ptrx, nwipe_context_t* ptr 
     /********
      * Method
      */
-    char* p_nwipe_method_label_with_direction = 0;
-    p_nwipe_method_label_with_direction = nwipe_method_label_with_direction();
     pdf_add_text( pdf, NULL, "Method:", 12, 60, 270, PDF_GRAY );
     pdf_set_font( pdf, "Helvetica-Bold" );
+    idx = 0;
     if( c->secure_erase_orchestration == NWIPE_SECURE_ERASE_ORCHESTRATION_STANDALONE )
     {
-        pdf_add_text( pdf, NULL, "Secure Erase", text_size_data, 110, 270, PDF_BLACK );
+        /* Standalone Secure Erase Only */
+        snprintf( secure_erase_method_txt,
+                  sizeof( secure_erase_method_txt ),
+                  "Secure Erase (%s)",
+                  secure_erase_methods[c->secure_erase_method] );
+        pdf_add_text( pdf, NULL, secure_erase_method_txt, text_size_data, 110, 270, PDF_BLACK );
     }
     else
     {
+        /* Traditional methods */
+        char* p_nwipe_method_label_with_direction = 0;
+        p_nwipe_method_label_with_direction = nwipe_method_label_with_direction();
         pdf_add_text( pdf, NULL, p_nwipe_method_label_with_direction, text_size_data, 110, 270, PDF_BLACK );
+        free( p_nwipe_method_label_with_direction );  // free string
+        p_nwipe_method_label_with_direction = NULL;  // get rid of dangling pointer
     }
     pdf_set_font( pdf, "Helvetica" );
-    free( p_nwipe_method_label_with_direction );  // free string
-    p_nwipe_method_label_with_direction = NULL;  // get rid of dangling pointer
+
     /***********
      * prng type
      */


### PR DESCRIPTION
- added secure erase type, i.e block, encrypt, overwrite in method field, example: Method: Secure Erase (Block)

- Added bytes erased data.

Text is green if erasure succeeded or red if not.