### PR TITLE
Post-secure-erase PDF generation & enum misnomer

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -75,9 +75,9 @@ typedef enum {
 } nwipe_secure_erase_type_t;
 
 typedef enum {
-    NWIPE_SECURE_ERASE_UNKNOWN = 0,
-    NWIPE_SECURE_ERASE_SUCCESS, /* Secure erase was successful */
-    NWIPE_SECURE_ERASE_FAILURE /* Secure erase has failed */
+    NWIPE_SECURE_ERASE_STATUS_UNKNOWN = 0,
+    NWIPE_SECURE_ERASE_STATUS_SUCCESS, /* Secure erase was successful */
+    NWIPE_SECURE_ERASE_STATUS_FAILURE /* Secure erase has failed */
 } nwipe_secure_erase_status_t;
 
 typedef enum {

--- a/src/context.h
+++ b/src/context.h
@@ -269,7 +269,8 @@ typedef struct nwipe_context_t_
                                  // -1: Device did not understand probe
                                  //  0: Confirmed not supported by device
                                  //  1: Confirmed to be supported by device
-    int secure_erase_orchestration;  // Flag, used by the PDF report logic to determine
+    nwipe_secure_erase_orchestration_t
+        secure_erase_orchestration;  // Flag, used by the PDF report logic to determine
                                      // whether to show secure erase only on report (STANDALONE)
                                      // or whether the report includes traditional
                                      // pre or post wipes, verification and blanking (PRE_CHAINED/POST_CHAINED)

--- a/src/create_pdf.c
+++ b/src/create_pdf.c
@@ -484,7 +484,7 @@ void pdf_add_text_bytes_erased( float xoff, float yoff, nwipe_context_t* c )
 
     if( c->secure_erase_orchestration == NWIPE_SECURE_ERASE_ORCHESTRATION_STANDALONE )
     {
-        if( c->secure_erase_status == NWIPE_SECURE_ERASE_SUCCESS )
+        if( c->secure_erase_status == NWIPE_SECURE_ERASE_STATUS_SUCCESS )
         {
             snprintf( bytes_erased, sizeof( bytes_erased ), "%lli, (%s%%)", c->device_size, "100" );
             pdf_add_text( pdf, NULL, bytes_erased, text_size_data, xoff, yoff, PDF_DARK_GREEN );
@@ -609,7 +609,7 @@ void pdf_add_text_status_of_erasure( float text_xoff,
     /* Is this a standalone secure erase?, i.e not part of a method */
     if( c->secure_erase_orchestration == NWIPE_SECURE_ERASE_ORCHESTRATION_STANDALONE )
     {
-        if( c->secure_erase_status == NWIPE_SECURE_ERASE_SUCCESS )
+        if( c->secure_erase_status == NWIPE_SECURE_ERASE_STATUS_SUCCESS )
         {
             text = "ERASED";
             text_color = stroke_color = PDF_DARK_GREEN;
@@ -804,7 +804,7 @@ void pdf_add_text_rounds( float text_size, float xoff, float yoff, nwipe_context
 
     if( c->secure_erase_orchestration == NWIPE_SECURE_ERASE_ORCHESTRATION_STANDALONE )
     {
-        if( c->secure_erase_status == NWIPE_SECURE_ERASE_SUCCESS )
+        if( c->secure_erase_status == NWIPE_SECURE_ERASE_STATUS_SUCCESS )
         {
             pdf_add_text( pdf, NULL, "1/1", text_size, xoff, yoff, PDF_DARK_GREEN );
         }

--- a/src/gui.c
+++ b/src/gui.c
@@ -1539,14 +1539,14 @@ void nwipe_gui_select( int count, nwipe_context_t** c )
                     nwipe_gui_draw_acs_prefix( main_window, yy, 4 );
                     switch( c[i + offset]->secure_erase_status )
                     {
-                        case NWIPE_SECURE_ERASE_SUCCESS:
+                        case NWIPE_SECURE_ERASE_STATUS_SUCCESS:
                             mvwprintw( main_window,
                                        yy,
                                        7,
                                        " Secure Erase: Device sanitized, recommended to do a regular wipe now." );
                             break;
 
-                        case NWIPE_SECURE_ERASE_FAILURE:
+                        case NWIPE_SECURE_ERASE_STATUS_FAILURE:
                             mvwprintw( main_window,
                                        yy,
                                        7,

--- a/src/se_ata_gui.c
+++ b/src/se_ata_gui.c
@@ -650,6 +650,7 @@ static void nwipe_gui_se_ata_monitor( nwipe_context_t* ctx, nwipe_se_ata_ctx* sa
                 {
                     ctx->secure_erase_orchestration = NWIPE_SECURE_ERASE_ORCHESTRATION_STANDALONE;
                     create_single_disc_pdf( global_nwipe_thread_data_ptr, ctx );
+                    ctx->secure_erase_orchestration = NWIPE_SECURE_ERASE_ORCHESTRATION_UNKNOWN; /* Reset */
                 }
                 return;
         }

--- a/src/se_ata_gui.c
+++ b/src/se_ata_gui.c
@@ -576,7 +576,7 @@ static void nwipe_gui_se_ata_monitor( nwipe_context_t* ctx, nwipe_se_ata_ctx* sa
             mvwprintw( main_window, yy++, tab1, "Action completed with success." );
             mvwprintw( main_window, yy++, tab1, "Device status: %s", result_status_str );
 
-            ctx->secure_erase_status = NWIPE_SECURE_ERASE_SUCCESS;
+            ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_SUCCESS;
 
             if( !logged )
             {
@@ -594,7 +594,7 @@ static void nwipe_gui_se_ata_monitor( nwipe_context_t* ctx, nwipe_se_ata_ctx* sa
             yy++;
             mvwprintw( main_window, yy++, tab1, "Use 'Exit Failure Mode' to clear a failure state." );
 
-            ctx->secure_erase_status = NWIPE_SECURE_ERASE_FAILURE;
+            ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_FAILURE;
 
             if( !logged )
             {
@@ -611,7 +611,7 @@ static void nwipe_gui_se_ata_monitor( nwipe_context_t* ctx, nwipe_se_ata_ctx* sa
             mvwprintw( main_window, yy++, tab1, "The device did not return a success or failure." );
             mvwprintw( main_window, yy++, tab1, "Device status: %s", result_status_str );
 
-            ctx->secure_erase_status = NWIPE_SECURE_ERASE_SUCCESS;
+            ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_SUCCESS;
 
             if( !logged )
             {
@@ -912,7 +912,7 @@ void nwipe_gui_se_ata_sanitize( nwipe_context_t* ctx, nwipe_se_ata_ctx* san )
         if( nwipe_gui_se_ata_prompt_in_progress( ctx, san ) )
         {
             /* Reset the context status so a previous one does not leak */
-            ctx->secure_erase_status = NWIPE_SECURE_ERASE_UNKNOWN;
+            ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_UNKNOWN;
 
             /* ATA does not provide which method is presently running */
             ctx->secure_erase_method = NWIPE_SECURE_ERASE_METHOD_UNKNOWN;
@@ -972,7 +972,7 @@ void nwipe_gui_se_ata_sanitize( nwipe_context_t* ctx, nwipe_se_ata_ctx* san )
     }
 
     /* Reset the context status so a previous one does not leak */
-    ctx->secure_erase_status = NWIPE_SECURE_ERASE_UNKNOWN;
+    ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_UNKNOWN;
 
     /* Inform the device context of the chosen method */
     nwipe_gui_se_ata_set_context_method( ctx, san->planned_sanact );

--- a/src/se_nvme_gui.c
+++ b/src/se_nvme_gui.c
@@ -698,6 +698,7 @@ static void nwipe_gui_se_nvme_monitor( nwipe_context_t* ctx, nwipe_se_nvme_ctx* 
                 {
                     ctx->secure_erase_orchestration = NWIPE_SECURE_ERASE_ORCHESTRATION_STANDALONE;
                     create_single_disc_pdf( global_nwipe_thread_data_ptr, ctx );
+                    ctx->secure_erase_orchestration = NWIPE_SECURE_ERASE_ORCHESTRATION_UNKNOWN; /* Reset */
                 }
                 return;
         }

--- a/src/se_nvme_gui.c
+++ b/src/se_nvme_gui.c
@@ -624,7 +624,7 @@ static void nwipe_gui_se_nvme_monitor( nwipe_context_t* ctx, nwipe_se_nvme_ctx* 
             mvwprintw( main_window, yy++, tab1, "Action completed with success." );
             mvwprintw( main_window, yy++, tab1, "Device status: %s", result_status_str );
 
-            ctx->secure_erase_status = NWIPE_SECURE_ERASE_SUCCESS;
+            ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_SUCCESS;
 
             if( !logged )
             {
@@ -642,7 +642,7 @@ static void nwipe_gui_se_nvme_monitor( nwipe_context_t* ctx, nwipe_se_nvme_ctx* 
             yy++;
             mvwprintw( main_window, yy++, tab1, "Use 'Exit Failure Mode' to clear a failure state." );
 
-            ctx->secure_erase_status = NWIPE_SECURE_ERASE_FAILURE;
+            ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_FAILURE;
 
             if( !logged )
             {
@@ -659,7 +659,7 @@ static void nwipe_gui_se_nvme_monitor( nwipe_context_t* ctx, nwipe_se_nvme_ctx* 
             mvwprintw( main_window, yy++, tab1, "The device did not return a success or failure." );
             mvwprintw( main_window, yy++, tab1, "Device status: %s", result_status_str );
 
-            ctx->secure_erase_status = NWIPE_SECURE_ERASE_SUCCESS;
+            ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_SUCCESS;
 
             if( !logged )
             {
@@ -907,7 +907,7 @@ void nwipe_gui_se_nvme_sanitize( nwipe_context_t* ctx, nwipe_se_nvme_ctx* san )
         if( nwipe_gui_se_nvme_prompt_in_progress( ctx, san ) )
         {
             /* Reset the context status so a previous one does not leak */
-            ctx->secure_erase_status = NWIPE_SECURE_ERASE_UNKNOWN;
+            ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_UNKNOWN;
 
             /* Inform the device context of the running method */
             nwipe_gui_se_nvme_set_context_method( ctx, san->sanact );
@@ -997,7 +997,7 @@ void nwipe_gui_se_nvme_sanitize( nwipe_context_t* ctx, nwipe_se_nvme_ctx* san )
     }
 
     /* Reset the context status so a previous one does not leak */
-    ctx->secure_erase_status = NWIPE_SECURE_ERASE_UNKNOWN;
+    ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_UNKNOWN;
 
     /* Inform the device context of the chosen method */
     nwipe_gui_se_nvme_set_context_method( ctx, san->planned_sanact );


### PR DESCRIPTION
Unexpectedly had some more time, so my last pull request for today fixes these issues:
- PDF generation for regular wipe reporting success despite failure after successful secure erase.
- Misnomer in `nwipe_secure_erase_status_t` and type for context's `secure_erase_orchestration`.

Tested & working as expected.