### PR TITLE
feat(se): detect in-progress sanitizes on exit

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -76,6 +76,7 @@ typedef enum {
 
 typedef enum {
     NWIPE_SECURE_ERASE_STATUS_UNKNOWN = 0,
+    NWIPE_SECURE_ERASE_STATUS_IN_PROGRESS, /* Secure erase in progress */
     NWIPE_SECURE_ERASE_STATUS_SUCCESS, /* Secure erase was successful */
     NWIPE_SECURE_ERASE_STATUS_FAILURE /* Secure erase has failed */
 } nwipe_secure_erase_status_t;

--- a/src/logging.c
+++ b/src/logging.c
@@ -849,6 +849,122 @@ int nwipe_log_sysinfo( nwipe_misc_thread_data_t* ptrx )
     return 0;
 }
 
+/*
+ * Scans all enumerated devices for secure erase / sanitize operations that
+ * are still flagged as in progress and, if any are found, prints a warning
+ * table in the same layout as the drive status summary in nwipe_log_summary().
+ * Returns the amount of in-progress devices or -1 on invalid arguments provided.
+ */
+int nwipe_log_se_in_progress( nwipe_context_t** c, int nwipe_enumerated )
+{
+    int i;
+    int in_progress_count;
+    char device[18];
+    const char* type_str;
+    const char* method_str;
+
+    if( c == NULL || nwipe_enumerated <= 0 )
+    {
+        return -1;
+    }
+
+    /* First pass: is there anything to report at all ? */
+    in_progress_count = 0;
+
+    for( i = 0; i < nwipe_enumerated; i++ )
+    {
+        if( c[i] != NULL && c[i]->secure_erase_status == NWIPE_SECURE_ERASE_STATUS_IN_PROGRESS )
+        {
+            in_progress_count++;
+        }
+    }
+
+    if( in_progress_count == 0 )
+    {
+        return 0;
+    }
+
+    /* IMPORTANT: Keep maximum columns (line length) to 80 characters for use with 80x30 terminals, Shredos, ALT-F2 etc
+     * --------------------------------01234567890123456789012345678901234567890123456789012345678901234567890123456789-*/
+    nwipe_log( NWIPE_LOG_NOTIMESTAMP, "" );
+    nwipe_log( NWIPE_LOG_NOTIMESTAMP,
+               "*************************** Secure Erase In Progress ***************************" );
+    nwipe_log( NWIPE_LOG_NOTIMESTAMP, "!   Device | Type | Method" );
+    nwipe_log( NWIPE_LOG_NOTIMESTAMP,
+               "--------------------------------------------------------------------------------" );
+
+    for( i = 0; i < nwipe_enumerated; i++ )
+    {
+        if( c[i] == NULL || c[i]->secure_erase_status != NWIPE_SECURE_ERASE_STATUS_IN_PROGRESS )
+        {
+            continue;
+        }
+
+        /* Device name, strip any prefixed /dev/.. leaving up to 8 right justified characters */
+        device[0] = 0;
+        nwipe_strip_path( device, c[i]->device_name );
+
+        switch( c[i]->secure_erase_type )
+        {
+            case NWIPE_SECURE_ERASE_TYPE_ATA:
+                type_str = " ATA";
+                break;
+
+            case NWIPE_SECURE_ERASE_TYPE_NVME:
+                type_str = "NVMe";
+                break;
+
+            default:
+                type_str = "   ?";
+                break;
+        }
+
+        switch( c[i]->secure_erase_method )
+        {
+            case NWIPE_SECURE_ERASE_METHOD_BLOCK:
+                method_str = "Block";
+                break;
+
+            case NWIPE_SECURE_ERASE_METHOD_CRYPTO:
+                method_str = "Crypto";
+                break;
+
+            case NWIPE_SECURE_ERASE_METHOD_OVERWRITE:
+                method_str = "Overwrite";
+                break;
+
+            default:
+                method_str = "Unknown";
+                break;
+        }
+
+        nwipe_log( NWIPE_LOG_NOTIMESTAMP, "! %s | %s | %s", device, type_str, method_str );
+    }
+
+    nwipe_log( NWIPE_LOG_NOTIMESTAMP,
+               "--------------------------------------------------------------------------------" );
+    nwipe_log( NWIPE_LOG_NOTIMESTAMP, "! - DO NOT POWER OFF - DO NOT POWER OFF - DO NOT POWER OFF -" );
+    nwipe_log( NWIPE_LOG_NOTIMESTAMP, "!" );
+    nwipe_log(
+        NWIPE_LOG_NOTIMESTAMP, "! %i device(s) are still running a firmware-based secure erase.", in_progress_count );
+    nwipe_log( NWIPE_LOG_NOTIMESTAMP, "! These devices may be unresponsive or unusable until the firmware" );
+    nwipe_log( NWIPE_LOG_NOTIMESTAMP, "! completes it. Do not power off or disconnect them while it is running." );
+    nwipe_log( NWIPE_LOG_NOTIMESTAMP, "! The progress monitoring can be resumed by restarting nwipe and viewing" );
+    nwipe_log( NWIPE_LOG_NOTIMESTAMP, "! the device within the nwipe GUI (and then choosing keyboard hotkey 'e')." );
+    nwipe_log( NWIPE_LOG_NOTIMESTAMP, "!" );
+    nwipe_log( NWIPE_LOG_NOTIMESTAMP, "! - DO NOT POWER OFF - DO NOT POWER OFF - DO NOT POWER OFF -" );
+    nwipe_log( NWIPE_LOG_NOTIMESTAMP,
+               "********************************************************************************" );
+    nwipe_log( NWIPE_LOG_NOTIMESTAMP, "" );
+
+    /* Also emit a timestamped warning so it is visible in filtered/grepped logs. */
+    nwipe_log( NWIPE_LOG_WARNING,
+               "Firmware-based secure erase still in progress on %i device(s), do not power off before completion.",
+               in_progress_count );
+
+    return in_progress_count;
+}
+
 void nwipe_log_summary( nwipe_thread_data_ptr_t* ptrx, nwipe_context_t** ptr, int nwipe_selected )
 {
     /* Prints two summary tables, the first is the device pass and verification summary

--- a/src/logging.h
+++ b/src/logging.h
@@ -63,6 +63,7 @@ void nwipe_perror( int nwipe_errno, const char* f, const char* s );
 void nwipe_log_buildinfo();
 void nwipe_log_OSinfo();
 int nwipe_log_sysinfo( nwipe_misc_thread_data_t* );
+int nwipe_log_se_in_progress( nwipe_context_t** c, int nwipe_enumerated );
 void nwipe_log_summary( nwipe_thread_data_ptr_t*,
                         nwipe_context_t**,
                         int );  // This produces the wipe status table on exit

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -288,6 +288,7 @@ int main( int argc, char** argv )
     int nwipe_selected = 0;  // The number of contexts that have been selected.
     int any_threads_still_running;  // used in wipe thread cancellation wait loop
     int thread_timeout_counter;  // timeout thread cancellation after THREAD_CANCELLATION_TIMEOUT seconds
+    int remaining_secure_erases = -1;  // Remaining in-progress secure erases/sanitizes.
     pthread_t nwipe_gui_thread = 0;  // The thread ID of the GUI thread.
     pthread_t nwipe_temperature_thread = 0;  // The thread ID of the temperature update thread
     pthread_t nwipe_sigint_thread;  // The thread ID of the sigint handler.
@@ -816,7 +817,7 @@ int main( int argc, char** argv )
         }
     }
 
-    /* TODO: free c1 and c2 memory. */
+    /* TODO: c2 memory. */
     if( user_abort == 0 )
     {
         /* Log the wipe options that have been selected immediately prior to the start of the wipe */
@@ -1346,12 +1347,15 @@ int main( int argc, char** argv )
     /* Generate and send the drive status summary to the log */
     nwipe_log_summary( &nwipe_thread_data_ptr, c2, nwipe_selected );
 
+    /* Warn loud the user about remaining in-progress secure erases */
+    remaining_secure_erases = nwipe_log_se_in_progress( c1, nwipe_enumerated );
+
     /* Print a one line status message for the user */
     if( return_status == 0 || return_status == 1 )
     {
         if( user_abort == 1 )
         {
-            if( global_wipe_status == 1 )
+            if( global_wipe_status == 1 || remaining_secure_erases > 0 )
             {
                 nwipe_log( NWIPE_LOG_INFO,
                            "Nwipe was aborted by the user. Check the summary table for the drive status." );
@@ -1377,7 +1381,11 @@ int main( int argc, char** argv )
 
     cleanup();
 
-    check_for_autopoweroff();
+    /* Powering off with secure erases in progress may brick the devices */
+    if( remaining_secure_erases <= 0 )
+    {
+        check_for_autopoweroff();
+    }
 
     /* Exit. */
     return return_status;

--- a/src/se_ata_gui.c
+++ b/src/se_ata_gui.c
@@ -540,6 +540,11 @@ static void nwipe_gui_se_ata_monitor( nwipe_context_t* ctx, nwipe_se_ata_ctx* sa
 
     } while( terminate_signal != 1 );
 
+    if( terminate_signal == 1 )
+    {
+        user_aborted = 1;
+    }
+
     const char* ftr_results = ( !user_aborted && san->destructive_sanact )
         ? "Erase finished - press enter to create pdfs & return."
         : "Enter=Return";
@@ -911,8 +916,8 @@ void nwipe_gui_se_ata_sanitize( nwipe_context_t* ctx, nwipe_se_ata_ctx* san )
     {
         if( nwipe_gui_se_ata_prompt_in_progress( ctx, san ) )
         {
-            /* Reset the context status so a previous one does not leak */
-            ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_UNKNOWN;
+            /* Set the context status so a previous one does not leak */
+            ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_IN_PROGRESS;
 
             /* ATA does not provide which method is presently running */
             san->sanact = NWIPE_SE_ATA_SANACT_UNKNOWN;
@@ -972,8 +977,8 @@ void nwipe_gui_se_ata_sanitize( nwipe_context_t* ctx, nwipe_se_ata_ctx* san )
         return;
     }
 
-    /* Reset the context status so a previous one does not leak */
-    ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_UNKNOWN;
+    /* Set the context status so a previous one does not leak */
+    ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_IN_PROGRESS;
 
     /* Inform the device context of the chosen method */
     nwipe_gui_se_ata_set_context_method( ctx, san->planned_sanact );

--- a/src/se_nvme_gui.c
+++ b/src/se_nvme_gui.c
@@ -588,6 +588,11 @@ static void nwipe_gui_se_nvme_monitor( nwipe_context_t* ctx, nwipe_se_nvme_ctx* 
 
     } while( terminate_signal != 1 );
 
+    if( terminate_signal == 1 )
+    {
+        user_aborted = 1;
+    }
+
     const char* ftr_results = ( !user_aborted && san->destructive_sanact )
         ? "Erase finished - press enter to create pdfs & return."
         : "Enter=Return";
@@ -906,8 +911,8 @@ void nwipe_gui_se_nvme_sanitize( nwipe_context_t* ctx, nwipe_se_nvme_ctx* san )
     {
         if( nwipe_gui_se_nvme_prompt_in_progress( ctx, san ) )
         {
-            /* Reset the context status so a previous one does not leak */
-            ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_UNKNOWN;
+            /* Set the context status so a previous one does not leak */
+            ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_IN_PROGRESS;
 
             /* Inform the device context of the running method */
             nwipe_gui_se_nvme_set_context_method( ctx, san->sanact );
@@ -996,8 +1001,8 @@ void nwipe_gui_se_nvme_sanitize( nwipe_context_t* ctx, nwipe_se_nvme_ctx* san )
         return;
     }
 
-    /* Reset the context status so a previous one does not leak */
-    ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_UNKNOWN;
+    /* Set the context status so a previous one does not leak */
+    ctx->secure_erase_status = NWIPE_SECURE_ERASE_STATUS_IN_PROGRESS;
 
     /* Inform the device context of the chosen method */
     nwipe_gui_se_nvme_set_context_method( ctx, san->planned_sanact );


### PR DESCRIPTION
Detects if firmware-based secure erase is still running on CTRL+C and warns the user not to power off.
Also prevents automatic shutdown in such a case, not to brick devices which are still sanitizing.