### PR TITLE
fix(se): one-off error in overwrite passes

### DIFF
--- a/src/se_ata.c
+++ b/src/se_ata.c
@@ -917,7 +917,8 @@ int nwipe_se_ata_sanitize( nwipe_se_ata_ctx* san )
         case NWIPE_SE_ATA_SANACT_OVERWRITE:
             feature = SANITIZE_OVERWRITE_EXT;
             lba = ( (__u64) SANITIZE_OVERWRITE_KEY << 32 ) | san->ovrpat;
-            nsect = ( san->owpass & 0x0F ) | ( 1 << 4 ); /* Passes + Allow Failure Exit */
+            /* owpass is 0-based: 0=1 pass .. 15=16 passes; +1 to wire format where 0=16 passes */
+            nsect = ( ( san->owpass + 1 ) & 0x0F ) | ( 1 << 4 ); /* Passes + Allow Failure Exit */
             break;
 
         case NWIPE_SE_ATA_SANACT_FREEZE_LOCK:

--- a/src/se_ata.h
+++ b/src/se_ata.h
@@ -62,7 +62,7 @@ typedef struct
     /* Options (set before nwipe_se_ata_sanitize) */
     nwipe_se_ata_sanact_e planned_sanact;
     int destructive_sanact; /* 0 = No, 1 = Yes */
-    __u8 owpass; /* 0-15 overwrite pass count */
+    __u8 owpass; /* 0-based overwrite passes (0=1..15=16) */
     __u32 ovrpat; /* 32-bit overwrite pattern */
 } nwipe_se_ata_ctx;
 

--- a/src/se_ata_gui.c
+++ b/src/se_ata_gui.c
@@ -350,7 +350,7 @@ static int nwipe_gui_se_ata_overwrite_opts( nwipe_context_t* ctx, nwipe_se_ata_c
     const char* ftr = "J=Down K=Up +/-=Change Enter=Confirm ESC=Cancel";
 
     san->owpass = 0;
-    san->ovrpat = 0xDEADBEEF;
+    san->ovrpat = 0x00000000;
 
     werase( footer_window );
     nwipe_gui_amend_footer_window( ftr, "" );

--- a/src/se_nvme.c
+++ b/src/se_nvme.c
@@ -514,7 +514,8 @@ int nwipe_se_nvme_sanitize( nwipe_se_nvme_ctx* san )
     args.sanact = san->planned_sanact;
     args.ovrpat = san->ovrpat;
     args.ause = san->ause;
-    args.owpass = san->owpass;
+    /* owpass is 0-based: 0=1 pass .. 15=16 passes; +1 to wire format where 0=16 passes */
+    args.owpass = ( san->planned_sanact == NVME_SANITIZE_SANACT_START_OVERWRITE ) ? ( ( san->owpass + 1 ) & 0x0F ) : 0;
     args.oipbp = san->oipbp;
     args.nodas = san->nodas;
 #ifdef HAVE_NVME_SANITIZE_SANACT_EXIT_MEDIA_VERIF

--- a/src/se_nvme.h
+++ b/src/se_nvme.h
@@ -70,7 +70,7 @@ typedef struct
     /* Options (set before nwipe_se_nvme_sanitize) */
     enum nvme_sanitize_sanact planned_sanact;
     int destructive_sanact; /* 0 = No, 1 = Yes */
-    __u8 owpass; /* 0-15 (0-based, sent directly) */
+    __u8 owpass; /* 0-based overwrite passes (0=1..15=16) */
     bool oipbp; /* invert pattern between passes */
     __u32 ovrpat; /* 32-bit overwrite pattern */
     bool nodas; /* no deallocate after sanitize */

--- a/src/se_nvme_gui.c
+++ b/src/se_nvme_gui.c
@@ -374,7 +374,7 @@ static int nwipe_gui_se_nvme_overwrite_opts( nwipe_context_t* ctx, nwipe_se_nvme
 
     san->owpass = 0;
     san->oipbp = false;
-    san->ovrpat = 0xDEADBEEF;
+    san->ovrpat = 0x00000000;
 
     werase( footer_window );
     nwipe_gui_amend_footer_window( ftr, "" );


### PR DESCRIPTION
Resolves a off-by-one bug with the calculation of overwrite passes.