### PR TITLE
fix(se): rae false and progress calc

### DIFF
--- a/src/se_ata.c
+++ b/src/se_ata.c
@@ -841,14 +841,12 @@ int nwipe_se_ata_poll( nwipe_se_ata_ctx* san )
     {
         san->state = NWIPE_SE_ATA_STATE_IN_PROGRESS;
         san->progress_raw = ( r.lob.lbam << 8 ) | r.lob.lbal;
-        san->progress_pct = ( (int) san->progress_raw * 100 ) / UINT16_MAX;
-        if( san->progress_pct > 100 )
-            san->progress_pct = 100;
+        san->progress_pct = ( (int) san->progress_raw * 100 ) / 65536;
     }
     else if( san->state_raw & SANITIZE_FLAG_OPERATION_SUCCEEDED )
     {
         san->state = NWIPE_SE_ATA_STATE_SUCCESS;
-        san->progress_raw = UINT16_MAX;
+        san->progress_raw = 0xFFFF;
         san->progress_pct = 100;
     }
     else

--- a/src/se_ata_gui.c
+++ b/src/se_ata_gui.c
@@ -167,7 +167,7 @@ static void nwipe_gui_se_ata_print_device( nwipe_context_t* ctx,
 
 static void nwipe_gui_se_ata_progress_bar( WINDOW* win, int y, int x, int width, int pct )
 {
-    int filled = ( pct * width ) / 100;
+    int filled;
     char bar[64];
 
     if( width > (int) sizeof( bar ) - 1 )
@@ -175,6 +175,8 @@ static void nwipe_gui_se_ata_progress_bar( WINDOW* win, int y, int x, int width,
 
     if( width < 0 )
         width = 0;
+
+    filled = ( pct * width ) / 100;
 
     if( filled < 0 )
         filled = 0;

--- a/src/se_nvme.c
+++ b/src/se_nvme.c
@@ -333,7 +333,7 @@ int nwipe_se_nvme_poll( nwipe_se_nvme_ctx* san )
         return -1;
     }
 
-    int err = nvme_get_log_sanitize( san->fd, true, log );
+    int err = nvme_get_log_sanitize( san->fd, false, log );
     if( err != 0 )
     {
         if( err < 0 )
@@ -374,30 +374,35 @@ int nwipe_se_nvme_poll( nwipe_se_nvme_ctx* san )
         /* Don't fix the typo, it's in the library */
         case NVME_SANITIZE_SSTAT_STATUS_IN_PROGESS:
             san->state = NWIPE_SE_NVME_STATE_IN_PROGRESS;
+            san->progress_raw = le16toh( log->sprog );
+            san->progress_pct = ( (int) san->progress_raw * 100 ) / 65536;
             break;
 
         case NVME_SANITIZE_SSTAT_STATUS_COMPLETE_SUCCESS:
         case NVME_SANITIZE_SSTAT_STATUS_ND_COMPLETE_SUCCESS:
             san->state = NWIPE_SE_NVME_STATE_SUCCESS;
+            san->progress_raw = 0xFFFF;
+            san->progress_pct = 100;
             break;
 
         case NVME_SANITIZE_SSTAT_STATUS_COMPLETED_FAILED:
             san->state = NWIPE_SE_NVME_STATE_FAILURE;
+            san->progress_raw = 0;
+            san->progress_pct = 0;
             break;
 
         case NVME_SANITIZE_SSTAT_STATUS_NEVER_SANITIZED:
             san->state = NWIPE_SE_NVME_STATE_NEVER_SANITIZED;
+            san->progress_raw = 0;
+            san->progress_pct = 0;
             break;
 
         default:
             san->state = NWIPE_SE_NVME_STATE_UNKNOWN;
+            san->progress_raw = 0;
+            san->progress_pct = 0;
             break;
     }
-
-    san->progress_raw = le16toh( log->sprog );
-    san->progress_pct = ( (int) san->progress_raw * 100 ) / UINT16_MAX;
-    if( san->progress_pct > 100 )
-        san->progress_pct = 100;
 
     __u32 eto = le32toh( log->eto );
     __u32 etbe = le32toh( log->etbe );

--- a/src/se_nvme_gui.c
+++ b/src/se_nvme_gui.c
@@ -190,7 +190,7 @@ static void nwipe_gui_se_nvme_print_device( nwipe_context_t* ctx,
 
 static void nwipe_gui_se_nvme_progress_bar( WINDOW* win, int y, int x, int width, int pct )
 {
-    int filled = ( pct * width ) / 100;
+    int filled;
     char bar[64];
 
     if( width > (int) sizeof( bar ) - 1 )
@@ -198,6 +198,8 @@ static void nwipe_gui_se_nvme_progress_bar( WINDOW* win, int y, int x, int width
 
     if( width < 0 )
         width = 0;
+
+    filled = ( pct * width ) / 100;
 
     if( filled < 0 )
         filled = 0;


### PR DESCRIPTION
Resolves two more issues discovered during AIO development:
- Off-by-one in percentage calculation & guard ordering in GUI.
- NVMe `rae` bool should be false for `nvme_get_log_sanitize` (= clear event).