### PR TITLE
Footer for blocking sanitizes, ATA fixes & low-level refactor

### DIFF
--- a/src/se_ata.c
+++ b/src/se_ata.c
@@ -357,7 +357,13 @@ sg16( int fd, int rw, int dma, struct ata_tf* tf, void* data, unsigned int data_
     if( ioctl( fd, SG_IO, &io_hdr ) == -1 )
     {
         int eno = errno;
+
         nwipe_log( NWIPE_LOG_ERROR, "%s: ioctl() failed: %s (%d)", __FUNCTION__, strerror( eno ), eno );
+
+        /* No device response, do not leave the outgoing registers in place */
+        memset( &tf->lob, 0, sizeof( tf->lob ) );
+        memset( &tf->hob, 0, sizeof( tf->hob ) );
+
         errno = eno; /* errno from ioctl */
         return -1;
     }
@@ -397,6 +403,15 @@ sg16( int fd, int rw, int dma, struct ata_tf* tf, void* data, unsigned int data_
 
     if( io_hdr.driver_status == 0 && io_hdr.status == 0 )
     {
+        if( data == NULL )
+        {
+            /* CK_COND was requested (not an IDENTIFY command), but no registers were returned */
+            nwipe_log(
+                NWIPE_LOG_ERROR, "%s: missing sense data (behind RAID controller or USB bridge?)", __FUNCTION__ );
+            errno = EBADE;
+            return -1;
+        }
+
         tf->status = 0;
         tf->error = 0;
         return 0;
@@ -406,7 +421,7 @@ sg16( int fd, int rw, int dma, struct ata_tf* tf, void* data, unsigned int data_
 
     if( sb[0] != 0x72 || sb[7] < 14 || desc[0] != 0x09 || desc[1] < 0x0c )
     {
-        nwipe_log( NWIPE_LOG_ERROR, "%s: bad or missing sense data (behind RAID controller?)", __FUNCTION__ );
+        nwipe_log( NWIPE_LOG_ERROR, "%s: bad sense data (behind RAID controller or USB bridge?)", __FUNCTION__ );
         errno = EBADE;
         return -1;
     }
@@ -649,8 +664,10 @@ static int ata_sanitize_taskfile( int fd, __u16 feature, __u64 lba, __u8 nsect, 
 
     if( do_taskfile_cmd( fd, &r, 10 ) )
     {
+        int eno = errno;
         if( r_out )
             memcpy( r_out, &r, sizeof( r ) );
+        errno = eno;
         return -1;
     }
 
@@ -801,8 +818,9 @@ int nwipe_se_ata_poll( nwipe_se_ata_ctx* san )
     if( ata_sanitize_taskfile( san->fd, SANITIZE_STATUS_EXT, 0, 0, &r ) != 0 )
     {
         int eno = errno;
+        __u8 lbal = ( eno == EIO ) ? r.lob.lbal : 0;
 
-        if( r.lob.lbal == 1 )
+        if( lbal == 1 )
         {
             /* Device is in Sanitize Operation Failed state */
             san->state = NWIPE_SE_ATA_STATE_FAILURE;
@@ -816,7 +834,7 @@ int nwipe_se_ata_poll( nwipe_se_ata_ctx* san )
                   "%s (errno=%d, device reason: %s)",
                   strerror( eno ),
                   eno,
-                  lbal_to_error_str( r.lob.lbal ) );
+                  lbal_to_error_str( lbal ) );
 
         nwipe_log( NWIPE_LOG_ERROR,
                    "%s: %s: SANITIZE_STATUS_EXT failed: %s (errno=%d, device reason: %s)",
@@ -824,7 +842,7 @@ int nwipe_se_ata_poll( nwipe_se_ata_ctx* san )
                    san->device_path,
                    strerror( eno ),
                    eno,
-                   lbal_to_error_str( r.lob.lbal ) );
+                   lbal_to_error_str( lbal ) );
 
         return -1;
     }
@@ -980,13 +998,14 @@ int nwipe_se_ata_sanitize( nwipe_se_ata_ctx* san )
     if( ata_sanitize_taskfile( san->fd, feature, lba, nsect, &r ) != 0 )
     {
         int eno = errno;
+        __u8 lbal = ( eno == EIO ) ? r.lob.lbal : 0;
 
         snprintf( san->error_msg,
                   sizeof( san->error_msg ),
                   "%s (errno=%d, device reason: %s)",
                   strerror( eno ),
                   eno,
-                  lbal_to_error_str( r.lob.lbal ) );
+                  lbal_to_error_str( lbal ) );
 
         nwipe_log( NWIPE_LOG_ERROR,
                    "%s: %s: SANITIZE failed: %s (errno=%d, device reason: %s)",
@@ -994,7 +1013,7 @@ int nwipe_se_ata_sanitize( nwipe_se_ata_ctx* san )
                    san->device_path,
                    strerror( eno ),
                    eno,
-                   lbal_to_error_str( r.lob.lbal ) );
+                   lbal_to_error_str( lbal ) );
 
         return -1;
     }

--- a/src/se_ata.c
+++ b/src/se_ata.c
@@ -898,20 +898,7 @@ int nwipe_se_ata_sanitize( nwipe_se_ata_ctx* san )
         return -1;
     }
 
-    if( san->planned_sanact != NWIPE_SE_ATA_SANACT_OVERWRITE )
-    {
-        if( san->owpass || san->ovrpat )
-        {
-            snprintf( san->error_msg, sizeof( san->error_msg ), "Overwrite fields not allowed with sanact" );
-            nwipe_log( NWIPE_LOG_ERROR,
-                       "%s: %s: Overwrite fields set but sanact=%d is not overwrite",
-                       __FUNCTION__,
-                       san->device_path,
-                       san->planned_sanact );
-            return -1;
-        }
-    }
-    else
+    if( san->planned_sanact == NWIPE_SE_ATA_SANACT_OVERWRITE )
     {
         if( san->owpass > 15 )
         {
@@ -923,6 +910,12 @@ int nwipe_se_ata_sanitize( nwipe_se_ata_ctx* san )
                        san->owpass );
             return -1;
         }
+    }
+    else
+    {
+        /* No effect, must be in zero state */
+        san->owpass = 0;
+        san->ovrpat = 0;
     }
 
     switch( san->planned_sanact )

--- a/src/se_ata.c
+++ b/src/se_ata.c
@@ -194,6 +194,8 @@ struct scsi_sg_io_hdr
 }; /* scsi_sg_io_hdr */
 
 static const unsigned int default_timeout_secs = 15;
+static const unsigned int sanitize_poll_timeout_secs = 10;
+static const unsigned int sanitize_action_timeout_secs = 60;
 
 static void dump_bytes( const char* f, const char* prefix, unsigned char* p, int len )
 {
@@ -628,7 +630,9 @@ static __u16* ata_identify( int fd )
 
 static int ata_sanitize_taskfile( int fd, __u16 feature, __u64 lba, __u8 nsect, struct hdio_taskfile* r_out )
 {
+    unsigned int timeout_secs = sanitize_action_timeout_secs;
     struct hdio_taskfile r;
+
     memset( &r, 0, sizeof( r ) );
 
     r.cmd_req = TASKFILE_CMD_REQ_NODATA;
@@ -662,7 +666,12 @@ static int ata_sanitize_taskfile( int fd, __u16 feature, __u64 lba, __u8 nsect, 
         r.lob.nsect = nsect;
     }
 
-    if( do_taskfile_cmd( fd, &r, 10 ) )
+    if( !nsect && feature == SANITIZE_STATUS_EXT ) /* Poll */
+    {
+        timeout_secs = sanitize_poll_timeout_secs;
+    }
+
+    if( do_taskfile_cmd( fd, &r, timeout_secs ) )
     {
         int eno = errno;
         if( r_out )

--- a/src/se_ata.c
+++ b/src/se_ata.c
@@ -968,7 +968,7 @@ int nwipe_se_ata_sanitize( nwipe_se_ata_ctx* san )
     san->destructive_sanact = nwipe_se_ata_sanact_is_destructive( san->planned_sanact );
 
     nwipe_log( NWIPE_LOG_INFO,
-               "%s: issuing SANITIZE feat=0x%04x lba=0x%012llx nsect=%u",
+               "%s: issuing SANITIZE feat=0x%04x lba=0x%012llx nsect=0x%02x",
                san->device_path,
                (unsigned) feature,
                (unsigned long long) lba,

--- a/src/se_ata_gui.c
+++ b/src/se_ata_gui.c
@@ -956,12 +956,6 @@ void nwipe_gui_se_ata_sanitize( nwipe_context_t* ctx, nwipe_se_ata_ctx* san )
             return;
         }
     }
-    /* Otherwise clear overwrite-specific fields */
-    else
-    {
-        san->owpass = 0;
-        san->ovrpat = 0;
-    }
 
     /* Final confirmation screen before sanitize operation */
     if( !nwipe_gui_se_ata_confirm( ctx, san ) )

--- a/src/se_ata_gui.c
+++ b/src/se_ata_gui.c
@@ -874,6 +874,11 @@ static int nwipe_gui_se_ata_confirm( nwipe_context_t* ctx, nwipe_se_ata_ctx* san
         {
             case 'e':
             case 'E':
+                wattron( footer_window, COLOR_PAIR( 9 ) );
+                nwipe_gui_amend_footer_window( "Executing... some devices may block here until completion.",
+                                               "Do not interrupt or power off, beware it can be a long wait..." );
+                wattroff( footer_window, COLOR_PAIR( 9 ) );
+                doupdate();
                 return 1;
 
             case 27:

--- a/src/se_nvme.c
+++ b/src/se_nvme.c
@@ -441,6 +441,12 @@ int nwipe_se_nvme_sanact_is_destructive( enum nvme_sanitize_sanact act )
  */
 int nwipe_se_nvme_sanitize( nwipe_se_nvme_ctx* san )
 {
+    bool nodas; /* No-Deallocate After Sanitize */
+    bool ause; /* Allow Unrestricted Sanitize Exit */
+#ifdef HAVE_NVME_SANITIZE_SANACT_EXIT_MEDIA_VERIF
+    bool emvs; /* Enter Media Verification State */
+#endif
+
     memset( san->error_msg, 0, sizeof( san->error_msg ) ); /* Used in GUI */
 
     if( san->fd < 0 )
@@ -450,48 +456,7 @@ int nwipe_se_nvme_sanitize( nwipe_se_nvme_ctx* san )
         return -1;
     }
 
-    if( san->planned_sanact == NVME_SANITIZE_SANACT_EXIT_FAILURE
-#ifdef HAVE_NVME_SANITIZE_SANACT_EXIT_MEDIA_VERIF
-        || san->planned_sanact == NVME_SANITIZE_SANACT_EXIT_MEDIA_VERIF
-#endif
-    )
-    {
-        if( san->ause )
-        {
-            snprintf( san->error_msg, sizeof( san->error_msg ), "AUSE not allowed with sanact" );
-            nwipe_log( NWIPE_LOG_ERROR,
-                       "%s: %s: AUSE not allowed with sanact=%d",
-                       __FUNCTION__,
-                       san->ctrl_path,
-                       san->planned_sanact );
-            return -1;
-        }
-        if( san->nodas )
-        {
-            snprintf( san->error_msg, sizeof( san->error_msg ), "NODAS not allowed with sanact" );
-            nwipe_log( NWIPE_LOG_ERROR,
-                       "%s: %s: NODAS not allowed with sanact=%d",
-                       __FUNCTION__,
-                       san->ctrl_path,
-                       san->planned_sanact );
-            return -1;
-        }
-    }
-
-    if( san->planned_sanact != NVME_SANITIZE_SANACT_START_OVERWRITE )
-    {
-        if( san->owpass || san->oipbp || san->ovrpat )
-        {
-            snprintf( san->error_msg, sizeof( san->error_msg ), "Overwrite fields not allowed with sanact" );
-            nwipe_log( NWIPE_LOG_ERROR,
-                       "%s: %s: Overwrite fields set but sanact=%d is not overwrite",
-                       __FUNCTION__,
-                       san->ctrl_path,
-                       san->planned_sanact );
-            return -1;
-        }
-    }
-    else
+    if( san->planned_sanact == NVME_SANITIZE_SANACT_START_OVERWRITE )
     {
         if( san->owpass > 15 )
         {
@@ -503,6 +468,35 @@ int nwipe_se_nvme_sanitize( nwipe_se_nvme_ctx* san )
                        san->owpass );
             return -1;
         }
+    }
+    else
+    {
+        /* No effect, must be in zero state */
+        san->owpass = 0;
+        san->oipbp = false;
+        san->ovrpat = 0;
+    }
+
+    if( san->planned_sanact == NVME_SANITIZE_SANACT_EXIT_FAILURE
+#ifdef HAVE_NVME_SANITIZE_SANACT_EXIT_MEDIA_VERIF
+        || san->planned_sanact == NVME_SANITIZE_SANACT_EXIT_MEDIA_VERIF
+#endif
+    )
+    {
+        /* No effect, must be in zero state */
+        nodas = false;
+        ause = false;
+#ifdef HAVE_NVME_SANITIZE_SANACT_EXIT_MEDIA_VERIF
+        emvs = false;
+#endif
+    }
+    else
+    {
+        nodas = false; /* Enabling this is dangerous, keep it disabled */
+        ause = true; /* Disabling this is dangerous, keep it enabled */
+#ifdef HAVE_NVME_SANITIZE_SANACT_EXIT_MEDIA_VERIF
+        emvs = false; /* Enabling this is dangerous, keep it disabled */
+#endif
     }
 
     /* Keep in sync, in case the caller did not set it themselves */
@@ -518,13 +512,13 @@ int nwipe_se_nvme_sanitize( nwipe_se_nvme_ctx* san )
     args.timeout = NVME_DEFAULT_IOCTL_TIMEOUT;
     args.sanact = san->planned_sanact;
     args.ovrpat = san->ovrpat;
-    args.ause = san->ause;
+    args.ause = ause;
     /* owpass is 0-based: 0=1 pass .. 15=16 passes; +1 to wire format where 0=16 passes */
     args.owpass = ( san->planned_sanact == NVME_SANITIZE_SANACT_START_OVERWRITE ) ? ( ( san->owpass + 1 ) & 0x0F ) : 0;
     args.oipbp = san->oipbp;
-    args.nodas = san->nodas;
+    args.nodas = nodas;
 #ifdef HAVE_NVME_SANITIZE_SANACT_EXIT_MEDIA_VERIF
-    args.emvs = san->emvs;
+    args.emvs = emvs;
 #endif
     args.result = NULL;
 

--- a/src/se_nvme.h
+++ b/src/se_nvme.h
@@ -73,11 +73,6 @@ typedef struct
     __u8 owpass; /* 0-based overwrite passes (0=1..15=16) */
     bool oipbp; /* invert pattern between passes */
     __u32 ovrpat; /* 32-bit overwrite pattern */
-    bool nodas; /* no deallocate after sanitize */
-    bool ause; /* allow unrestricted sanitize exit */
-#ifdef HAVE_NVME_SANITIZE_SANACT_EXIT_MEDIA_VERIF
-    bool emvs; /* enter media verification state */
-#endif
 } nwipe_se_nvme_ctx;
 
 int nwipe_se_nvme_topo_init( nwipe_se_nvme_topo* topo );

--- a/src/se_nvme_gui.c
+++ b/src/se_nvme_gui.c
@@ -877,6 +877,11 @@ static int nwipe_gui_se_nvme_confirm( nwipe_context_t* ctx, nwipe_se_nvme_ctx* s
         {
             case 'e':
             case 'E':
+                wattron( footer_window, COLOR_PAIR( 9 ) );
+                nwipe_gui_amend_footer_window( "Executing... some devices may block here until completion.",
+                                               "Do not interrupt or power off, beware it can be a long wait..." );
+                wattroff( footer_window, COLOR_PAIR( 9 ) );
+                doupdate();
                 return 1;
 
             case 27:

--- a/src/se_nvme_gui.c
+++ b/src/se_nvme_gui.c
@@ -949,42 +949,6 @@ void nwipe_gui_se_nvme_sanitize( nwipe_context_t* ctx, nwipe_se_nvme_ctx* san )
             nwipe_se_nvme_close( san );
             return;
         }
-
-        san->nodas = false; /* This is dangerous, keep it disabled */
-        san->ause = true; /* This is dangerous, keep it enabled */
-#ifdef HAVE_NVME_SANITIZE_SANACT_EXIT_MEDIA_VERIF
-        san->emvs = false; /* This is dangerous, keep it disabled */
-#endif
-    }
-    /* Otherwise there are no options to configure for the user */
-    else if( san->planned_sanact == NVME_SANITIZE_SANACT_EXIT_FAILURE
-#ifdef HAVE_NVME_SANITIZE_SANACT_EXIT_MEDIA_VERIF
-             || san->planned_sanact == NVME_SANITIZE_SANACT_EXIT_MEDIA_VERIF
-#endif
-    )
-    {
-        /* These are all unused and must be kept in their zero state here */
-        san->owpass = 0;
-        san->oipbp = false;
-        san->ovrpat = 0;
-
-        san->nodas = false; /* No effect, must be in zero state also */
-        san->ause = false; /* No effect, must be in zero state also */
-#ifdef HAVE_NVME_SANITIZE_SANACT_EXIT_MEDIA_VERIF
-        san->emvs = false; /* No effect, must be in zero state also */
-#endif
-    }
-    else
-    {
-        san->owpass = 0;
-        san->oipbp = false;
-        san->ovrpat = 0;
-
-        san->nodas = false; /* This is dangerous, keep it disabled */
-        san->ause = true; /* This is dangerous, keep it enabled */
-#ifdef HAVE_NVME_SANITIZE_SANACT_EXIT_MEDIA_VERIF
-        san->emvs = false; /* This is dangerous, keep it disabled */
-#endif
     }
 
     /* Final confirmation screen before sanitize operation */


### PR DESCRIPTION
This PR includes:

- Red footer for sanitizes which block before reaching the monitoring (progress) screen.
- Refactor moving lower-level logic away from GUI ("dangerous" flags) -> no functional changes.
- More error safeguards and fixes for non-compliant ATA communication.