### PR TITLE
fix(se): missing includes

### DIFF
--- a/src/se_ata.c
+++ b/src/se_ata.c
@@ -4,7 +4,9 @@
  * Based on: hdparm 9.65 - (c) 2007 Mark Lord (BSD-style license)
  */
 
-#define _POSIX_C_SOURCE 200809L
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -17,6 +19,8 @@
 #include <sys/types.h>
 #include <scsi/scsi.h>
 #include <scsi/sg.h>
+
+#include <linux/types.h>
 
 #include "nwipe.h"
 #include "context.h"

--- a/src/se_ata.h
+++ b/src/se_ata.h
@@ -8,7 +8,6 @@
 #define SE_ATA_H_
 
 #include <linux/types.h> /* __u8, __u16, __u32, __u64 */
-#include <stdbool.h>
 
 /*
  * While the device internal state machine has an "Idle" (SD0)

--- a/src/se_ata_gui.c
+++ b/src/se_ata_gui.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <ncurses.h>
 #include <panel.h>
 

--- a/src/se_nvme.c
+++ b/src/se_nvme.c
@@ -13,7 +13,18 @@
 #define _GNU_SOURCE 1 /* asprintf */
 #endif
 
-#define _POSIX_C_SOURCE 200809L
+#include <endian.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+#include <unistd.h>
+#include <libnvme.h>
+
+#include <linux/types.h>
 
 #include "nwipe.h"
 #include "context.h"

--- a/src/se_nvme_gui.c
+++ b/src/se_nvme_gui.c
@@ -15,7 +15,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <string.h>
+#include <time.h>
 #include <ncurses.h>
 #include <panel.h>
 #include <libnvme.h>


### PR DESCRIPTION
Makes explicit includes that were pulled in transitively (especially for NVMe), no functional changes.